### PR TITLE
htmlbuilder: table_header に章番号追加

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -592,7 +592,7 @@ QUOTE
     end
 
     def table_header(id, caption)
-      puts %Q[<p class="caption">表#{@chapter.table(id).number}: #{escape_html(caption)}</p>]
+      puts %Q[<p class="caption">表#{getChap}#{@chapter.table(id).number}: #{escape_html(caption)}</p>]
     end
 
     def table_begin(ncols)


### PR DESCRIPTION
「表1」だったのを、参照元に合わせて「表1.1」になるように章番号を追加しました。
