### PR TITLE
latexbuilderで quote の挙動を htmlbuilder に合わせました。

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -390,7 +390,7 @@ module ReVIEW
     end
 
     def quote(lines)
-      latex_block 'quotation', lines
+      latex_block 'quote', lines.join('\\\\')
     end
 
     def center(lines)


### PR DESCRIPTION
- 段落の字下げをしない（quotation → quote）
- 入力された改行は改行として扱う（join('\\')）
