### PR TITLE
use compile_inline() to caption on //bibpaper

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -791,7 +791,7 @@ QUOTE
 
     def bibpaper_header(id, caption)
       puts %Q(<a name="bib-#{id}">)
-      puts "[#{@chapter.bibpaper(id).number}] #{caption}"
+      puts "[#{@chapter.bibpaper(id).number}] #{compile_inline(caption)}"
       puts %Q(</a>)
     end
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -596,7 +596,7 @@ module ReVIEW
     end
 
     def bibpaper_header(id, caption)
-      puts "[#{@chapter.bibpaper(id).number}] #{caption}"
+      puts "[#{@chapter.bibpaper(id).number}] #{compile_inline(caption)}"
     end
 
     def bibpaper_bibpaper(id, caption, lines)

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -238,8 +238,8 @@ class HTMLBuidlerTest < Test::Unit::TestCase
       BibpaperIndex::Item.new("samplebib",1,"sample bib")
     end
 
-    @builder.bibpaper(["a", "b"], "samplebib", "sample bib")
-    assert_equal %Q|<div>\n<a name=\"bib-samplebib\">\n[1] sample bib\n</a>\n<p>\na\nb\n</p>\n</div>\n|, @builder.raw_result
+    @builder.bibpaper(["a", "b"], "samplebib", "sample bib @<b>{bold}")
+    assert_equal %Q|<div>\n<a name=\"bib-samplebib\">\n[1] sample bib <b>bold</b>\n</a>\n<p>\na\nb\n</p>\n</div>\n|, @builder.raw_result
   end
 
   def column_helper(review)

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -295,8 +295,8 @@ class LATEXBuidlerTest < Test::Unit::TestCase
       BibpaperIndex::Item.new("samplebib",1,"sample bib")
     end
 
-    @builder.bibpaper(["a", "b"], "samplebib", "sample bib")
-    assert_equal %Q|[1] sample bib\n\na\nb\n\n|, @builder.raw_result
+    @builder.bibpaper(["a", "b"], "samplebib", "sample bib @<b>{bold}")
+    assert_equal %Q|[1] sample bib \\textbf{bold}\n\na\nb\n\n|, @builder.raw_result
   end
 
   def test_bibpaper_without_body


### PR DESCRIPTION
//bibpaperのcaptionにcompile_inline()を使うのを忘れていましたので追記しました。
idgxmlbuilder.rb の方はすでについていたのでそのままにしています。
