### PR TITLE
fix broken gemspec

### DIFF
--- a/review.gemspec
+++ b/review.gemspec
@@ -106,7 +106,6 @@ Gem::Specification.new do |s|
      "test/test_htmlbuilder.rb",
      "test/test_htmlutils.rb",
      "test/test_idgxmlbuilder.rb",
-     "test/test_index.rb",
      "test/test_latexbuilder.rb",
      "test/test_lineinput.rb",
      "test/test_textutils.rb",


### PR DESCRIPTION
review をインストールしようとしたときにするときに以下のようなエラーが発生しました。

```
  ERROR:  While executing gem ... (Gem::InvalidSpecificationException)
      ["test/test_index.rb"] are not files
```

test/test_index.rb を gemspec から削除して、テストが通ることとインストールできることを確認しました。
test/test_index.rb は存在していて、push されていないだけだった場合は push をお願いします。
