### PR TITLE
リンクを記述する際に、アンカー文字列が書かれていないとエラーが出る

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -242,7 +242,7 @@ module ReVIEW
     def inline_href(arg)
       url, label = *arg.scan(/(?:(?:(?:\\\\)*\\,)|[^,\\]+)+/).map(&:lstrip)
       url = url.gsub(/\\,/, ",").strip
-      label = label.gsub(/\\,/, ",").strip
+      label = label.gsub(/\\,/, ",").strip if label
       compile_href(url, label)
     end
 


### PR DESCRIPTION
```
@<href>{http://developer.apple.com/jp/}
```

のようにリンクを記述すると

```
error: undefined method `gsub' for nil:NilClass
```

とエラーが表示されます。
