### PR TITLE
add a space into between word and number.

### DIFF
--- a/lib/review/i18n.yaml
+++ b/lib/review/i18n.yaml
@@ -6,8 +6,8 @@ ja:
   chapter_postfix: "　"
 
 en:
-  image: Figure
-  table: Table
-  list: List
+  image: "Figure "
+  table: "Table "
+  list: "List "
   chapter: Chapter %d
   chapter_postfix: ". "

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -23,8 +23,8 @@ class I18nTest < Test::Unit::TestCase
 
   def test_en
     I18n.i18n "en"
-    assert_equal I18n.t("image"), "Figure"
-    assert_equal I18n.t("table"), "Table"
+    assert_equal I18n.t("image"), "Figure "
+    assert_equal I18n.t("table"), "Table "
     assert_equal I18n.t("chapter", 1), "Chapter 1"
     assert_equal I18n.t("etc"), "etc"
   end


### PR DESCRIPTION
"locale: en" の際に、"Figure4.2" と出力されるので、"Figure 4.2" となるようにスペースを挿入しました。
