### PR TITLE
fixes : add items into toc even if secnolevel < toclevel

### DIFF
--- a/bin/review-compile
+++ b/bin/review-compile
@@ -71,6 +71,7 @@ def _main
   parser.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC, JIS, and SJIS)') {|enc| param["outencoding"] = enc }
   parser.on('-c', '--check', 'Check manuscript') { check_only = true }
   parser.on('--level=LVL', 'Section level to append number.') {|lvl| param["secnolevel"] = lvl.to_i }
+  parser.on('--toclevel=LVL', 'Section level to append number.') {|lvl| param["toclevel"] = lvl.to_i }
   parser.on('--nolfinxml', 'Do not insert LF in XML. (idgxml)') { param["nolf"] = true }
   parser.on('--table=WIDTH', 'Default table width. (idgxml)') {|tbl| param["tableopt"] = tbl }
   parser.on('--listinfo', 'Append listinfo tag to lists to indicate begin/end. (idgxml)') { param["listinfo"] = true }

--- a/bin/review-pdfmaker
+++ b/bin/review-pdfmaker
@@ -109,7 +109,7 @@ def output_chaps(chapsfile, values)
       fork {
         STDOUT.reopen("#{@path}/#{filename}")
         $stderr.puts "compiling #{l}"
-        exec("review-compile --target=latex --level=#{values["secnolevel"]} #{values["params"]} #{l}")
+        exec("review-compile --target=latex --level=#{values["secnolevel"]} --toclevel=#{values["toclevel"]} #{values["params"]} #{l}")
       }
       Process.waitall
       @chaps_filenames[chapsfile] << %Q|\\input{#{filename}}\n|

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -78,6 +78,9 @@ module ReVIEW
       end
       blank unless @output.pos == 0
       puts macro(HEADLINE[level]+prefix, compile_inline(caption))
+      if prefix == "*" && level <= ReVIEW.book.param["toclevel"]
+        puts "\\addcontentsline{toc}{#{HEADLINE[level]}}{#{compile_inline(caption)}}"
+      end
       if level == 1
         puts macro('label', chapter_label)
       end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -10,6 +10,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     @builder = LATEXBuilder.new()
     @param = {
       "secnolevel" => 2,    # for IDGXMLBuilder, EPUBBuilder
+      "toclevel" => 2,
       "inencoding" => "UTF-8",
       "outencoding" => "UTF-8",
       "subdirmode" => nil,
@@ -30,7 +31,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
   def test_headline_level1_without_secno
     @param["secnolevel"] = 0
     @builder.headline(1,"test","this is test.")
-    assert_equal %Q|\\chapter*{this is test.}\n\\label{chap:chap1}\n|, @builder.result
+    assert_equal %Q|\\chapter*{this is test.}\n\\addcontentsline{toc}{chapter}{this is test.}\n\\label{chap:chap1}\n|, @builder.result
   end
 
   def test_headline_level1_with_inlinetag


### PR DESCRIPTION
secnolevelがtoclevelよりも小さかった場合（要するに節などに番号が振られないけれど目次には含まれるような場合）、LATEXBuilderでは目次からも消えてしまっていたので、それを修正するパッチです。
