### PR TITLE
stop generating epub file if file names duplicate.

### DIFF
--- a/bin/review-epubmaker
+++ b/bin/review-epubmaker
@@ -23,7 +23,7 @@ $LOAD_PATH.unshift((bindir + '../lib').realpath)
 require 'uuid'
 require 'review'
 
-$essential_files = ['top', 'toc']
+$essential_files = ['top', 'toc', 'colophon']
 def main
   if ARGV.size != 1
     puts "Usage: #{$0} configfile"


### PR DESCRIPTION
https://github.com/kmuto/review/blob/master/doc/quickstart.rdoc
に従って使い方を勉強していたのですが、どうもsample.reとbooknameからsample.htmlが生成されていて、後者が前者のを上書きしているためうまくいきませんでした。top, tocの場合も同じことが起こることを確認しました。生成されるファイル名に重複があるときは停止するようにしました。
