### PR TITLE
use compile_inline method for a caption

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -896,7 +896,7 @@ QUOTE
     end
 
     def inline_hd_chap(chap, id)
-      "「#{chap.headline_index.number(id)} #{chap.headline(id).caption}」"
+      "「#{chap.headline_index.number(id)} #{compile_inline(chap.headline(id).caption)}」"
     end
 
     def inline_list(id)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -634,7 +634,7 @@ module ReVIEW
     end
 
     def inline_hd_chap(chap, id)
-      "「#{chap.headline_index.number(id)} #{chap.headline(id).caption}」"
+      "「#{chap.headline_index.number(id)} #{compile_inline(chap.headline(id).caption)}」"
     end
 
     def inline_raw(str)

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -131,6 +131,16 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|test <tt><b>inline test</b></tt> test2|, ret
   end
 
+  def test_inline_hd_chap
+    def @chapter.headline_index
+      items = [Book::HeadlineIndex::Item.new("chap1|test", [1, 1], "te_st")]
+      Book::HeadlineIndex.new(items, self)
+    end
+
+    ret = @builder.compile_inline("test @<hd>{chap1|test} test2")
+    assert_equal %Q|test 「1.1.1 te_st」 test2|, ret
+  end
+
   def test_inline_uchar
     ret = @builder.compile_inline("test @<uchar>{2460} test2")
     assert_equal %Q|test &#x2460; test2|, ret

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'test_helper'
 require 'review/compiler'
 require 'review/book'
@@ -178,6 +179,16 @@ class LATEXBuidlerTest < Test::Unit::TestCase
   def test_inline_ttb
     ret = @builder.compile_inline("test @<ttb>{inline test} test2")
     assert_equal %Q|test \\texttt{\\textbf{inline test}} test2|, ret
+  end
+
+  def test_inline_hd_chap
+    def @chapter.headline_index
+      items = [Book::HeadlineIndex::Item.new("chap1|test", [1, 1], "te_st")]
+      Book::HeadlineIndex.new(items, self)
+    end
+
+    ret = @builder.compile_inline("test @<hd>{chap1|test} test2")
+    assert_equal %Q|test 「1.1.1 te\\textunderscore{}st」 test2|, ret
   end
 
   def test_inline_uchar


### PR DESCRIPTION
以下をlatexbuilderで変換してlatexでコンパイルするとエラーになるようです。

```
= test
== foo_bar
@<hd>{foo_bar}
```

アンダーバーがそのまま出てしまうのがまずいようです。

インラインの@<hd>{xxx}で出力されるcaptionに対してもcompile_inlineを使うように修正してみました。
