### PR TITLE
LATEXBuilder and HTMLBuilder: add new command //olnum[]

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -165,6 +165,7 @@ module ReVIEW
     defsingle :raw, 1
     defsingle :tsize, 1
     defsingle :include, 1
+    defsingle :olnum, 1
 
     definline :chapref
     definline :chap

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -51,6 +51,7 @@ module ReVIEW
       @subsubsection = 0
       @subsubsubsection = 0
       @noindent = nil
+      @ol_num = nil
     end
     private :builder_init
 
@@ -381,7 +382,12 @@ EOT
     end
 
     def ol_begin
-      puts '<ol>'
+      if @ol_num
+        puts "<ol start=\"#{@ol_num}\">"  ## it's OK in HTML5, but not OK in XHTML1.1
+        @ol_num = nil
+      else
+        puts '<ol>'
+      end
     end
 
     def ol_item(lines, num)
@@ -1057,6 +1063,10 @@ QUOTE
 
     def image_ext
       "png"
+    end
+
+    def olnum(num)
+      @ol_num = num.to_i
     end
   end
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -38,6 +38,7 @@ module ReVIEW
       @latex_tsize = nil
       @tsize = nil
       @table_caption = nil
+      @ol_num = nil
     end
     private :builder_init_file
 
@@ -159,6 +160,10 @@ module ReVIEW
     def ol_begin
       blank
       puts '\begin{enumerate}'
+      if @ol_num
+        puts "\\setcounter{enumi}{#{@ol_num - 1}}"
+        @ol_num = nil
+      end
     end
 
     def ol_item(lines, num)
@@ -745,6 +750,10 @@ module ReVIEW
 
     def image_ext
       "svg"
+    end
+
+    def olnum(num)
+      @ol_num = num.to_i
     end
 
   end


### PR DESCRIPTION
箇条書きの中で図表とかblock要素的なものが入る場合、連番が崩れてしまうのを回避するため、//olnum[]というコマンドを作ってみました。

<pre>
 1. 項目（１）
 1. 項目（２）
 1. 項目（３）

（図表とか文言とかいろいろ）

//olnum[4]
 1. 項目（ここが４になる）
 1. 項目（５）
 1. 項目（６）
</pre>


という風に使えます。

既知の問題としては、XHTML1.1でol要素のstart属性が廃止されているのですが、HTML5では復活しているのと、FirefoxのEPUBReaderでもMurasakiでもCSSで上手く指定できなかったのでこちらを使っています（逆にstart属性はEPUBReader/Murasaki/iPhoneのiBooksでもちゃんと見れてます）。
