### PR TITLE
HTMLBuilder等でReVIEWの文法エラーがRubyのNameError例外になる

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -475,7 +475,7 @@ module ReVIEW
         syntax.check_args args
       rescue CompileError => err
         error err.message
-        args = ['(NoArgument)'] * SYNTAX[name].min_argc
+        args = ['(NoArgument)'] * syntax.min_argc
       end
       if syntax.block_allowed?
         compile_block syntax, args, lines


### PR DESCRIPTION
HTMLBuilder等で、ReVIEWテキストに文法エラーがあったときに、RubyのNameError例外になります。Compiler#compile_commandメソッド中のCompileError処理で、使われていない変数`name'を参照しているためです。

なお、LATEXBuilderのようにerrorメソッドを再定義していないBuilerでは、該当箇所を通らないため発生しません。
