### PR TITLE
add class info and remove unnecessary LF from bibpaper.

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -884,7 +884,7 @@ QUOTE
     end
 
     def bibpaper(lines, id, caption)
-      puts "<div>"
+      puts %Q[<div class="bibpaper">]
       bibpaper_header id, caption
       unless lines.empty?
         bibpaper_bibpaper id, caption, lines
@@ -893,13 +893,13 @@ QUOTE
     end
 
     def bibpaper_header(id, caption)
-      puts %Q(<a id="bib-#{id}">)
-      puts "[#{@chapter.bibpaper(id).number}] #{compile_inline(caption)}"
+      print %Q(<a id="bib-#{id}">)
+      print "[#{@chapter.bibpaper(id).number}] #{compile_inline(caption)}"
       puts %Q(</a>)
     end
 
     def bibpaper_bibpaper(id, caption, lines)
-      puts %Q(<p>)
+      print %Q(<p>)
       lines.each do |line|
         puts detab(line)
       end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -316,7 +316,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     end
 
     @builder.bibpaper(["a", "b"], "samplebib", "sample bib @<b>{bold}")
-    assert_equal %Q|<div>\n<a id=\"bib-samplebib\">\n[1] sample bib <b>bold</b>\n</a>\n<p>\na\nb\n</p>\n</div>\n|, @builder.raw_result
+    assert_equal %Q|<div class=\"bibpaper\">\n<a id=\"bib-samplebib\">[1] sample bib <b>bold</b></a>\n<p>a\nb\n</p>\n</div>\n|, @builder.raw_result
   end
 
   def column_helper(review)


### PR DESCRIPTION
bibpaperのhtmlbuilder実装のタグがちと扱いづらいので、class付けたりprintにしたりしたいです。手元環境ではこれまでbibpaper使っていなかったので副作用はないのですが、高橋さんのところに影響出ますか？

ちなみにbibpaperで単純に<p> puts lines </p>しちゃっているけど、本当は//noteなどと同様に空行チェックしてeachで分割しないと整合性が取れない感じ？
