### PR TITLE
review-pdfmakerでEPSファイルをコピーする

### DIFF
--- a/bin/review-pdfmaker
+++ b/bin/review-pdfmaker
@@ -195,7 +195,7 @@ def copyImagesToDir(dirname, copybase)
       if FileTest.directory?("#{dirname}/#{fname}")
         copyImagesToDir("#{dirname}/#{fname}", "#{copybase}/#{fname}")
       else
-        if fname =~ /\.(png|gif|jpg|jpeg|svg|pdf)$/i
+        if fname =~ /\.(png|gif|jpg|jpeg|svg|pdf|eps)$/i
           Dir.mkdir(copybase) unless File.exist?(copybase)
           FileUtils.cp "#{dirname}/#{fname}", copybase
         end
@@ -221,5 +221,6 @@ def copyStyToDir(dirname, copybase, extname = "sty")
   }
 end
 
-
-main
+if __FILE__ == $0
+  main
+end

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -1,0 +1,37 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'tmpdir'
+require 'fileutils'
+
+load File.expand_path('../bin/review-pdfmaker', File.dirname(__FILE__))
+
+class PDFMakerTest < Test::Unit::TestCase
+  def setup
+    @tmpdir1 = Dir.mktmpdir
+    @tmpdir2 = Dir.mktmpdir
+  end
+
+  def teardown
+    FileUtils.rm_rf @tmpdir1
+    FileUtils.rm_rf @tmpdir2
+  end
+
+  def test_copyImagesToDir
+    types = %w{png gif jpg jpeg svg pdf eps PNG GIF JPG JPEG SVG PDF EPS}
+    types.each do |type|
+      touch_file("#{@tmpdir1}/foo.#{type}")
+    end
+    copyImagesToDir(@tmpdir1, @tmpdir2)
+
+    types.each do |type|
+      assert File.exists?("#{@tmpdir2}/foo.#{type}"), "Copying #{type} file failed"
+    end
+  end
+
+  private
+  def touch_file(path)
+    File.open(path, "w").close
+    path
+  end
+end


### PR DESCRIPTION
review-pdfmaker の copyImagesToDir では、epsファイルがコピーされないようになっていたため、epsファイルもコピーされるようにしました。
