### PR TITLE
"®" が "速" に変換されてしまう

### DIFF
--- a/lib/review/textutils.rb
+++ b/lib/review/textutils.rb
@@ -43,6 +43,8 @@ module ReVIEW
         NKF.nkf("-S -w -m0x", str)
       when /^JIS$/i
         NKF.nkf("-J -w -m0x", str)
+      when /^UTF-8$/i
+        NKF.nkf("-W -w -m0x", str)
       else
         NKF.nkf("-w -m0 -m0x", str)
       end


### PR DESCRIPTION
英語のドキュメント中に「®」があると、「速」に変換されてしまいました。
NKF の文字コード自動判定の問題だと思われるので -W を明示しました。
