### PR TITLE
locale が en でも chapref が "第n章" を生成してしまう

### DIFF
--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -79,11 +79,11 @@ module ReVIEW
       def number(id)
         chapter = @index.fetch(id)
         if chapter.on_CHAPS?
-          "第#{chapter.number}章"
+          "#{I18n.t("chapter", chapter.number)}#{I18n.t("chapter_postfix")}"
         elsif chapter.on_PREDEF?
           "#{chapter.number}"
         elsif chapter.on_POSTDEF?
-          "付録#{chapter.number}"
+          "#{I18n.t("appendix", chapter.number)}#{I18n.t("chapter_postfix")}"
         end
       end
 

--- a/lib/review/i18n.yaml
+++ b/lib/review/i18n.yaml
@@ -5,6 +5,7 @@ ja:
   part: 第%d部
   chapter: 第%d章
   chapter_postfix: "　"
+  appendix: 付録%s
   numberless_image: "図:"
   format_number: "%s.%d"
   format_number_header: "%s.%d:"
@@ -21,6 +22,7 @@ en:
   list: "List "
   chapter: Chapter %d
   chapter_postfix: ". "
+  appendix: Appendix %s
   numberless_image: "Figure:"
   format_number: "%s.%d"
   format_number_header: "%s.%d:"


### PR DESCRIPTION
locale が en の時でも chapref が日本語を生成してしまうので I18n を使うように修正しました。「付録」にも対応しました。
