### PR TITLE
FIX: `<a id="xxx" />' is invalid. it should be `<a id="xxx"></a>'.

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -226,7 +226,7 @@ EOT
       puts '' if level > 1
       a_id = ""
       unless anchor.nil?
-        a_id = %Q[<a id="h#{anchor}" />]
+        a_id = %Q[<a id="h#{anchor}"></a>]
       end
       if caption.empty?
         puts a_id unless label.nil?
@@ -746,7 +746,7 @@ QUOTE
     end
 
     def label(id)
-      puts %Q(<a id="#{id}" />)
+      puts %Q(<a id="#{id}"></a>)
     end
 
     def linebreak

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -26,39 +26,39 @@ class HTMLBuidlerTest < Test::Unit::TestCase
 
   def test_headline_level1
     @builder.headline(1,"test","this is test.")
-    assert_equal %Q|<h1 id="test"><a id="h1" />第1章　this is test.</h1>\n|, @builder.raw_result
+    assert_equal %Q|<h1 id="test"><a id="h1"></a>第1章　this is test.</h1>\n|, @builder.raw_result
   end
 
   def test_headline_level1_without_secno
     @param["secnolevel"] = 0
     @builder.headline(1,"test","this is test.")
-    assert_equal %Q|<h1 id="test"><a id="h1" />this is test.</h1>\n|, @builder.raw_result
+    assert_equal %Q|<h1 id="test"><a id="h1"></a>this is test.</h1>\n|, @builder.raw_result
   end
 
   def test_headline_level1_with_inlinetag
     @builder.headline(1,"test","this @<b>{is} test.<&\">")
-    assert_equal %Q|<h1 id="test"><a id="h1" />第1章　this <b>is</b> test.&lt;&amp;&quot;&gt;</h1>\n|, @builder.raw_result
+    assert_equal %Q|<h1 id="test"><a id="h1"></a>第1章　this <b>is</b> test.&lt;&amp;&quot;&gt;</h1>\n|, @builder.raw_result
   end
 
   def test_headline_level2
     @builder.headline(2,"test","this is test.")
-    assert_equal %Q|\n<h2 id="test"><a id="h1-1" />1.1　this is test.</h2>\n|, @builder.raw_result
+    assert_equal %Q|\n<h2 id="test"><a id="h1-1"></a>1.1　this is test.</h2>\n|, @builder.raw_result
   end
 
   def test_headline_level3
     @builder.headline(3,"test","this is test.")
-    assert_equal %Q|\n<h3 id="test"><a id="h1-0-1" />this is test.</h3>\n|, @builder.raw_result
+    assert_equal %Q|\n<h3 id="test"><a id="h1-0-1"></a>this is test.</h3>\n|, @builder.raw_result
   end
 
   def test_headline_level3_with_secno
     @param["secnolevel"] = 3
     @builder.headline(3,"test","this is test.")
-    assert_equal %Q|\n<h3 id="test"><a id="h1-0-1" />1.0.1　this is test.</h3>\n|, @builder.raw_result
+    assert_equal %Q|\n<h3 id="test"><a id="h1-0-1"></a>1.0.1　this is test.</h3>\n|, @builder.raw_result
   end
 
   def test_label
     @builder.label("label_test")
-    assert_equal %Q|<a id="label_test" />\n|, @builder.raw_result
+    assert_equal %Q|<a id="label_test"></a>\n|, @builder.raw_result
   end
 
   def test_href
@@ -340,12 +340,12 @@ EOS
     expect =<<-EOS
 <div class="column">
 
-<h3><a id="h1-0-1" />prev column</h3>
+<h3><a id="h1-0-1"></a>prev column</h3>
 <p>inside prev column</p>
 </div>
 <div class="column">
 
-<h3><a id="h1-0-2" />test</h3>
+<h3><a id="h1-0-2"></a>test</h3>
 <p>inside column</p>
 </div>
 EOS
@@ -363,11 +363,11 @@ EOS
     expect =<<-EOS
 <div class="column">
 
-<h3><a id="h1-0-1" />test</h3>
+<h3><a id="h1-0-1"></a>test</h3>
 <p>inside column</p>
 </div>
 
-<h3><a id="h1-0-2" />next level</h3>
+<h3><a id="h1-0-2"></a>next level</h3>
 EOS
 
     assert_equal expect, column_helper(review)

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -39,7 +39,7 @@ class I18nTest < Test::Unit::TestCase
   def test_htmlbuilder
     _setup_htmlbuilder
     @builder.headline(1,"test","this is test.")
-    assert_equal %Q|<h1 id="test"><a id="h1" />Chapter 1. this is test.</h1>\n|, @builder.raw_result
+    assert_equal %Q|<h1 id="test"><a id="h1"></a>Chapter 1. this is test.</h1>\n|, @builder.raw_result
   end
 
   def _setup_htmlbuilder


### PR DESCRIPTION
HTML形式で、アンカーのための A タグが `<a id="xxx" />` のように出力されますが、 `<a id="xxx"></a>` としないと、IE や Firefox が正しくパースできないようです。
