### PR TITLE
[inaobuilder] listnum対応追加

### DIFF
--- a/lib/review/inaobuilder.rb
+++ b/lib/review/inaobuilder.rb
@@ -202,7 +202,7 @@ module ReVIEW
 
     def listnum_body(lines)
       lines.each_with_index do |line, i|
-        puts detab((i+1).to_s.rjust(2, "0") + " " +line)
+        puts detab((i+1).to_s.rjust(2) + " " +line)
       end
       puts "◆/list◆"
     end

--- a/test/test_inaobuilder.rb
+++ b/test/test_inaobuilder.rb
@@ -235,10 +235,10 @@ EOS
 　リスト1.1
 ◆list/◆
 ●リスト1.1　キャプション（コードのタイトル）
-01 function hoge() {
-02     alert(foo);
-03     alert(bar);
-04 }
+ 1 function hoge() {
+ 2     alert(foo);
+ 3     alert(bar);
+ 4 }
 ◆/list◆
 EOS
       assert_equal expected, compiler.compile(chapter)


### PR DESCRIPTION
inaobuilderにlistnumの実装がなかったため追加しました。
行番号は2桁0埋めになっています。
