### PR TITLE
use split_paragraph for //bibpaper block; fix #141

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+Sat Jun 29 01:34:14 2013  Masayoshi Takahashi  <takahashimm@gmail.com>
+
+	* lib/review/htmlbuilder.rb, lib/review/latexbuilder.rb: 
+
+	  use split_paragraph for //bibpaper block.
+
 Sat Mar 30 03:15:43 2013  Masayoshi Takahashi  <takahashimm@gmail.com>
 
 	* lib/review/latexbuilder.rb, lib/review/review.tex.erb,

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -928,11 +928,7 @@ QUOTE
     end
 
     def bibpaper_bibpaper(id, caption, lines)
-      print %Q(<p>)
-      lines.each do |line|
-        puts detab(line)
-      end
-      puts %Q(</p>)
+      print split_paragraph(lines).join("")
     end
 
     def inline_bib(id)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -746,9 +746,7 @@ module ReVIEW
     end
 
     def bibpaper_bibpaper(id, caption, lines)
-      lines.each do |line|
-        puts detab(line)
-      end
+      print split_paragraph(lines).join("")
     end
 
     def index(str)

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -321,7 +321,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     end
 
     @builder.bibpaper(["a", "b"], "samplebib", "sample bib @<b>{bold}")
-    assert_equal %Q|<div class=\"bibpaper\">\n<a id=\"bib-samplebib\">[1]</a> sample bib <b>bold</b>\n<p>a\nb\n</p>\n</div>\n|, @builder.raw_result
+    assert_equal %Q|<div class=\"bibpaper\">\n<a id=\"bib-samplebib\">[1]</a> sample bib <b>bold</b>\n<p>ab</p></div>\n|, @builder.raw_result
   end
 
   def test_bibpaper_with_anchor
@@ -330,7 +330,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     end
 
     @builder.bibpaper(["a", "b"], "samplebib", "sample bib @<href>{http://example.jp}")
-    assert_equal %Q|<div class=\"bibpaper\">\n<a id=\"bib-samplebib\">[1]</a> sample bib <a href=\"http://example.jp\" class=\"link\">http://example.jp</a>\n<p>a\nb\n</p>\n</div>\n|, @builder.raw_result
+    assert_equal %Q|<div class=\"bibpaper\">\n<a id=\"bib-samplebib\">[1]</a> sample bib <a href=\"http://example.jp\" class=\"link\">http://example.jp</a>\n<p>ab</p></div>\n|, @builder.raw_result
   end
 
   def column_helper(review)

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -386,7 +386,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     @builder.bibpaper(["a", "b"], "samplebib", "sample bib @<b>{bold}")
-    assert_equal %Q|[1] sample bib \\textbf{bold}\n\\label{bib:samplebib}\n\na\nb\n\n|, @builder.raw_result
+    assert_equal %Q|[1] sample bib \\textbf{bold}\n\\label{bib:samplebib}\n\nab\n|, @builder.raw_result
   end
 
   def test_bibpaper_without_body


### PR DESCRIPTION
#141 の件について、idgxmlbuilderに合わせてhtmlbuilderとlatexbuilderも空行区切り・改行無視にするように修正してみました。
