### PR TITLE
support @<del> in LATEXBuilder (but no decoration in default)

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -676,7 +676,7 @@ module ReVIEW
     end
 
     def inline_del(str)
-      escape(str)               # TODO: use strike ?
+      macro('reviewstrike', escape(str))
     end
 
     def inline_tti(str)

--- a/lib/review/review.tex.erb
+++ b/lib/review/review.tex.erb
@@ -134,6 +134,15 @@
 \newcommand{\reviewstrong}[1]{%
   \textbf{#1}}
 
+%% @<del> is ignored in LaTeX with default style
+\newcommand{\reviewstrike}[1]{#1}
+
+%%%% for ulem.sty:
+%%\renewcommand{\reviewstrike}[1]{\sout{#1}}
+%%
+%%%% for jumoline.sty:
+%%\renewcommand{\reviewstrike}[1]{\Middleline{#1}}
+
 \newcommand{\reviewth}[1]{%
   \textgt{#1}}
 


### PR DESCRIPTION
cf. #178

LATEXBuilderでも `@<del>` による打ち消し線を使えるようにするpull requestです。
`\reviewstrike`というコマンドを使うようにしてますが、デフォルトでは`\reviewstrike{foo}`はただの`foo`になります。
ulem.styを使うなら`\renewcommand{\reviewstrike}[1]{\sout{#1}}`、jumoline.styを使うなら`\renewcommand{\reviewstrike}[1]{\sout{#1}}`等を各スタイルファイルに記入して使う形になります。
