### PR TITLE
fix #189

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -224,7 +224,9 @@ module ReVIEW
     end
 
     def inline_ruby(arg)
-      base, ruby = *arg.split(',', 2)
+      base, *ruby = *arg.scan(/(?:(?:(?:\\\\)*\\,)|[^,\\]+)+/)
+      base = base.gsub(/\\,/, ",") if base
+      ruby = ruby.join(",").gsub(/\\,/, ",") if ruby
       compile_ruby(base, ruby)
     end
 

--- a/test/test_builder.rb
+++ b/test/test_builder.rb
@@ -112,6 +112,16 @@ class BuidlerTest < Test::Unit::TestCase
     assert_equal [:text, text], @b.compile_inline(text)
   end
 
+  def test_inline_ruby
+    def @b.compile_ruby(base,ruby)
+      [base,ruby]
+    end
+    str = @b.inline_ruby("foo,bar")
+    assert_equal str, ["foo","bar"]
+    str = @b.inline_ruby("foo\\,\\,,\\,bar,buz")
+    assert_equal str, ["foo,,",",bar,buz"]
+  end
+
   def test_compile_inline_backslash
     text = "abc\\d\\#a"
     assert_equal [:text, text], @b.compile_inline(text)

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -157,6 +157,11 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     assert_equal "<ruby><rb>粗雑</rb><rp>（</rp><rt>クルード</rt><rp>）</rp></ruby>と思われているなら<ruby><rb>繊細</rb><rp>（</rp><rt>テクニカル</rt><rp>）</rp></ruby>にやり、繊細と思われているなら粗雑にやる。", ret
   end
 
+  def test_inline_ruby_comma
+    ret = @builder.compile_inline("@<ruby>{foo\\, bar\\, buz,フー・バー・バズ}")
+    assert_equal "<ruby><rb>foo, bar, buz</rb><rp>（</rp><rt>フー・バー・バズ</rt><rp>）</rp></ruby>", ret
+  end
+
   def test_inline_ref
     ret = @builder.compile_inline("@<ref>{外部参照<>&}")
     assert_equal %Q|<a target='外部参照&lt;&gt;&amp;'>「●●　外部参照&lt;&gt;&amp;」</a>|, ret


### PR DESCRIPTION
comma after escape (like '\,') are not used as argument separator.
