### PR TITLE
fix review-epubmaker-ng: forcing date into String in colophon

### DIFF
--- a/lib/epubmaker/epubv2.rb
+++ b/lib/epubmaker/epubv2.rb
@@ -388,7 +388,7 @@ EOT
     end
 
     def date_to_s(date)
-      ymd = date.split('-')
+      ymd = date.to_s.split('-')
       "#{ymd[0]}年#{ymd[1].sub(/\A0/, '')}月#{ymd[2].sub(/\A0/, '')}日" # FIXME:i18n
     end
 


### PR DESCRIPTION
date_to_sにDate型が渡るようなのでto_sで強制的に文字列にしてみました。
