### PR TITLE
奥付での書名が「example」になる (review-epubmaker-ng)

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -5,7 +5,7 @@ module ReVIEW
       { # These parameters can be overridden by YAML file.
         "bookname"=> "example", # it defines epub file name also
         "booktitle" => "ReVIEW EPUBサンプル",
-        "title" => "example",
+        "title" => nil,
         "aut" => nil, # author
         "prt" => nil, # printer(publisher)
         "asn" => nil, # associated name


### PR DESCRIPTION
booktitleではなくtitleを見ていて、titleはあらかじめtitleの値を設定されていなければbooktitleになるはずのところを、ReVIEW::Configureで「example」に設定しているためそのまま値が使われていたのが原因です。

「example」にしておかないと困る、ということはさすがにないと思うので、ReVIEW::Configureのデフォルト値をnilに修正してみました。
