### PR TITLE
rename ReVIEWEPUBMaker -> ReVIEW::EPUBMaker

### DIFF
--- a/bin/review-epubmaker-ng
+++ b/bin/review-epubmaker-ng
@@ -11,9 +11,9 @@
 require 'pathname'
 bindir = Pathname.new(__FILE__).realpath.dirname
 $LOAD_PATH.unshift((bindir + '../lib').realpath)
-require 'reviewepubmaker'
+require 'review/epubmaker'
 
-rv = ReVIEWEPUBMaker.new
+rv = ReVIEW::EPUBMaker.new
 if ARGV.size < 1 || !File.exist?(ARGV[0])
   STDERR.puts "Usage: #{$0} YAML_filename [export_filename]"
   exit 0

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -12,8 +12,9 @@ require 'rexml/document'
 require 'rexml/streamlistener'
 require 'epubmaker'
 
-class ReVIEWEPUBMaker
-  include EPUBMaker
+module ReVIEW
+  class EPUBMaker
+  include ::EPUBMaker
   include REXML
 
   def initialize
@@ -423,4 +424,5 @@ EOT
       end
     end
   end
+end
 end


### PR DESCRIPTION
ReVIEWEPUBMakerはReVIEW専用になるかと思うので、ReVIEWモジュールの下に置く形で変更してみました。

EPUBMaker側は別の名前空間になり、ReVIEW側には一切依存しない（はずな）ので、特に手当てする必要はないはずです。
一方、ReVIEW内で元のEPUBMakerを呼ぶ時は、::EPUBMakerとしてトップクラスを明示すれば大丈夫です。
