### PR TITLE
IDGXMLBuilder: auto-renumbering in orderedlist

### DIFF
--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -287,14 +287,23 @@ module ReVIEW
 
     def ol_begin
       puts '<ol>'
+      if !@ol_num
+        @ol_num = 1
+      end
     end
 
     def ol_item(lines, num)
-      puts %Q(<li aid:pstyle="ol-item" num="#{num}">#{lines.join.chomp}</li>)
+      puts %Q(<li aid:pstyle="ol-item" num="#{@ol_num}">#{lines.join.chomp}</li>)
+      @ol_num += 1
     end
 
     def ol_end
       puts '</ol>'
+      @ol_num = nil
+    end
+
+    def olnum(num)
+      @ol_num = num.to_i
     end
 
     def dl_begin

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -519,6 +519,19 @@ EOS
     ul_helper(src, expect.chomp)
   end
 
+  def test_ol
+    src =<<-EOS
+  3. AAA
+  3. BBB
+EOS
+
+    expect =<<-EOS
+<?xml version="1.0" encoding="UTF-8"?>
+<doc xmlns:aid="http://ns.adobe.com/AdobeInDesign/4.0/"><ol><li aid:pstyle="ol-item" num="1">AAA</li><li aid:pstyle="ol-item" num="2">BBB</li></ol>
+EOS
+    ol_helper(src, expect.chomp)
+  end
+
   def test_inline_raw0
     assert_equal "normal", @builder.inline_raw("normal")
   end


### PR DESCRIPTION
IDGXMLBuilderの番号付き箇条書きについて、HTMLBuilder（とLATEXBuilder）と挙動を揃えたいのですが、こういう感じにするのではいかがなもんでしょうか(InDesign使ってないのでtestで挙動を確認しているだけです)。
