### PR TITLE
Fix compiling HTML or LaTeX failed on emlistnum directive.

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -549,8 +549,9 @@ EOT
       puts '</div>'
     end
 
-    def emlistnum(lines)
+    def emlistnum(lines, caption = nil)
       puts %Q[<div class="emlistnum-code">]
+      puts %Q(<p class="caption">#{caption}</p>) unless caption.nil?
       print %Q[<pre class="emlist">]
       lines.each_with_index do |line, i|
         puts detab((i+1).to_s.rjust(2) + ": " + line)


### PR DESCRIPTION
emlistnmを記述したファイルをHTMLに変換する際、"ArgumentError"が発生する不具合を修正した。
