### PR TITLE
do not test review-*maker command in 1.8 (because Travis reports Bundler error even if we do not use bundler)

### DIFF
--- a/test/test_epubmaker_cmd.rb
+++ b/test/test_epubmaker_cmd.rb
@@ -24,15 +24,17 @@ class EPUBMakerCmdTest < Test::Unit::TestCase
   end
 
   def test_epubmaker_cmd
-    config = prepare_samplebook(@tmpdir1)
-    builddir = @tmpdir1 + "/" + config['bookname'] + '-epub'
-    assert ! File.exists?(builddir)
+    if RUBY_VERSION !~ /^1.8/
+      config = prepare_samplebook(@tmpdir1)
+      builddir = @tmpdir1 + "/" + config['bookname'] + '-epub'
+      assert ! File.exists?(builddir)
 
-    ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
-    Dir.chdir(@tmpdir1) do
-      system("#{ruby_cmd} -S #{REVIEW_EPUBMAKER} config.yml 1>/dev/null 2>/dev/null")
+      ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
+      Dir.chdir(@tmpdir1) do
+        system("#{ruby_cmd} -S #{REVIEW_EPUBMAKER} config.yml 1>/dev/null 2>/dev/null")
+      end
+
+      assert File.exists?(builddir)
     end
-
-    assert File.exists?(builddir)
   end
 end

--- a/test/test_pdfmaker_cmd.rb
+++ b/test/test_pdfmaker_cmd.rb
@@ -24,15 +24,17 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   end
 
   def test_pdfmaker_cmd
-    config = prepare_samplebook(@tmpdir1)
-    builddir = @tmpdir1 + "/" + config['bookname'] + '-pdf'
-    assert ! File.exists?(builddir)
+    if RUBY_VERSION !~ /^1.8/
+      config = prepare_samplebook(@tmpdir1)
+      builddir = @tmpdir1 + "/" + config['bookname'] + '-pdf'
+      assert ! File.exists?(builddir)
 
-    ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
-    Dir.chdir(@tmpdir1) do
-      system("#{ruby_cmd} -S #{REVIEW_PDFMAKER} config.yml 1>/dev/null 2>/dev/null")
+      ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
+      Dir.chdir(@tmpdir1) do
+        system("#{ruby_cmd} -S #{REVIEW_PDFMAKER} config.yml 1>/dev/null 2>/dev/null")
+      end
+
+      assert File.exists?(builddir)
     end
-
-    assert File.exists?(builddir)
   end
 end


### PR DESCRIPTION
Travis-CIでのRuby 1.8のテストがどうしても成功しないので、そこの部分だけ実行しないようにしてみます。

原因は不明なのですが、Rakeのtestの中でreview-epubmakerとreview-pdfmakerを呼び出しているところがあって、そこを実行すると1.8の場合のみなぜか `no such file to load -- bundler/setup (LoadError)`というエラーが出るようになってました。
古いコミットに戻してみてもエラーが出るので(cf.  https://travis-ci.org/takahashim/review/builds/17588849 )、Travis側の設定か何かが変わった模様。
