### PR TITLE
Syntax highlight LaTeX and PDF outputs

### DIFF
--- a/bin/review-compile
+++ b/bin/review-compile
@@ -142,7 +142,9 @@ def _main
 
   begin
     ReVIEW.book.param = param
-    compiler = ReVIEW::Compiler.new(load_strategy_class(target, check_only, param['syntax-highlight']))
+    builder = load_strategy_class(target, check_only)
+    builder.highlighter_opts = ReVIEW::Highlighter::highlighter_opts(:pygments, param['syntax-highlight'])
+    compiler = ReVIEW::Compiler.new(builder)
     case mode
     when :files
       if ARGV.empty?
@@ -203,10 +205,9 @@ def error(msg)
   $stderr.puts "#{File.basename($0, '.*')}: error: #{msg}"
 end
 
-def load_strategy_class(target, strict, highlight)
+def load_strategy_class(target, strict)
   require "review/#{target}builder"
   builder = ReVIEW.const_get("#{target.upcase}Builder").new(strict)
-  builder.highlighter_opts = ReVIEW::Highlighter::highlighter_opts(:pygments, highlight)
   return builder
 end
 

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -209,9 +209,9 @@ def load_strategy_class(target, strict, highlight)
   when nil, 'none'
     # do nothing
   when 'monochrome'
-    builder.highlighter_opts = {pygments_opts:{style:'bw'}}
+    builder.highlighter_opts = {:pygments_opts => {style:'bw'}}
   when 'color'
-    builder.highlighter_opts = {pygments_opts:{style:'default'}}
+    builder.highlighter_opts = {:pygments_opts => {style:'default'}}
   else
     $stderr.puts "syntax-highlight must be none, monochrome, or color"
     exit 1

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -143,7 +143,8 @@ def _main
   begin
     ReVIEW.book.param = param
     builder = load_strategy_class(target, check_only)
-    builder.highlighter_opts = ReVIEW::Highlighter::highlighter_opts(:pygments, param['syntax-highlight'])
+    highlighter = ReVIEW::Highlighter.new(:pygments, param['syntax-highlight'])
+    builder.highlighter = highlighter
     compiler = ReVIEW::Compiler.new(builder)
     case mode
     when :files

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -61,6 +61,7 @@ def _main
     "footnotetext" => false,
     "htmlext" => "html",
     "htmlversion" => 4,
+		"syntax-highlight" => "none",
   }
 
   parser = OptionParser.new
@@ -116,6 +117,9 @@ def _main
     output_filename = filename
   end
   parser.on('--tabwidth=WIDTH', 'tab width') {|width| param["tabwidth"] = width.to_i }
+  parser.on('--syntax-highlight=NONE', 'Apply monochrome/color highlight or [none]') do |highlight|
+    param['syntax-highlight'] = highlight
+  end
   parser.on('--help', 'Prints this message and quit.') do
     puts parser.help
     exit 0
@@ -137,7 +141,7 @@ def _main
 
   begin
     ReVIEW.book.param = param
-    compiler = ReVIEW::Compiler.new(load_strategy_class(target, check_only))
+    compiler = ReVIEW::Compiler.new(load_strategy_class(target, check_only, param['syntax-highlight']))
     case mode
     when :files
       if ARGV.empty?
@@ -198,9 +202,20 @@ def error(msg)
   $stderr.puts "#{File.basename($0, '.*')}: error: #{msg}"
 end
 
-def load_strategy_class(target, strict)
+def load_strategy_class(target, strict, highlight)
   require "review/#{target}builder"
-  ReVIEW.const_get("#{target.upcase}Builder").new(strict)
+  case highlight
+  when nil, 'none'
+    pygments_opts = nil
+  when 'monochrome'
+    pygments_opts = {style:'bw'}
+  when 'color'
+    pygments_opts = {style:'default'}
+  else
+    $stderr.puts "syntax-highlight must be none, monochrome, or color"
+    exit 1
+  end
+  ReVIEW.const_get("#{target.upcase}Builder").new(strict, pygments_opts)
 end
 
 def write(path, str)

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -61,7 +61,7 @@ def _main
     "footnotetext" => false,
     "htmlext" => "html",
     "htmlversion" => 4,
-		"syntax-highlight" => "none",
+    "syntax-highlight" => "none",
   }
 
   parser = OptionParser.new

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -204,18 +204,19 @@ end
 
 def load_strategy_class(target, strict, highlight)
   require "review/#{target}builder"
+  builder = ReVIEW.const_get("#{target.upcase}Builder").new(strict)
   case highlight
   when nil, 'none'
-    pygments_opts = nil
+    # do nothing
   when 'monochrome'
-    pygments_opts = {style:'bw'}
+    builder.highlighter_opts = {pygments_opts:{style:'bw'}}
   when 'color'
-    pygments_opts = {style:'default'}
+    builder.highlighter_opts = {pygments_opts:{style:'default'}}
   else
     $stderr.puts "syntax-highlight must be none, monochrome, or color"
     exit 1
   end
-  ReVIEW.const_get("#{target.upcase}Builder").new(strict, pygments_opts)
+  return builder
 end
 
 def write(path, str)

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -18,6 +18,7 @@ $LOAD_PATH.unshift((bindir + '../lib').realpath)
 require 'review'
 require 'review/compiler'
 require 'review/book'
+require 'review/highlighter'
 require 'fileutils'
 require 'optparse'
 
@@ -205,17 +206,7 @@ end
 def load_strategy_class(target, strict, highlight)
   require "review/#{target}builder"
   builder = ReVIEW.const_get("#{target.upcase}Builder").new(strict)
-  case highlight
-  when nil, 'none'
-    # do nothing
-  when 'monochrome'
-    builder.highlighter_opts = {:pygments_opts => {style:'bw'}}
-  when 'color'
-    builder.highlighter_opts = {:pygments_opts => {style:'default'}}
-  else
-    $stderr.puts "syntax-highlight must be none, monochrome, or color"
-    exit 1
-  end
+  builder.highlighter_opts = ReVIEW::Highlighter::highlighter_opts(:pygments, highlight)
   return builder
 end
 

--- a/bin/review-epubmaker
+++ b/bin/review-epubmaker
@@ -745,7 +745,7 @@ def output_chaps_by_file(l, values)
   filename = "#{file_id}.html"
   fork {
     STDOUT.reopen("#{@bookdir}/OEBPS/#{filename}")
-    exec("review-compile --target=html --level=#{values["secnolevel"]} --htmlversion=#{values["htmlversion"]} --epubversion=#{values["epubversion"]} #{values["params"]} #{l}")
+    exec("review-compile --target=html --level=#{values["secnolevel"]} --htmlversion=#{values["htmlversion"]} --epubversion=#{values["epubversion"]} --syntax-highlight=#{values["syntax-highlight"]} #{values["params"]} #{l}")
   }
   Process.waitall
   getanchors("#{@bookdir}/OEBPS/#{filename}")

--- a/bin/review-pdfmaker
+++ b/bin/review-pdfmaker
@@ -198,8 +198,8 @@ def get_template(values)
   okuduke += <<EOB
 発行所 & #{values["prt"]} \\\\
 EOB
-
-  highlighter_preamble = ReVIEW::Highlighter::highlighter_preamble('latex', :pygments, values['syntax-highlight']) || ''
+  highlighter =  ReVIEW::Highlighter.new(:pygments, values['syntax-highlight'])
+  highlighter_preamble = highlighter.preamble('latex') || ''
 
   custom_titlepage = make_custom_titlepage(values["coverfile"])
 

--- a/bin/review-pdfmaker
+++ b/bin/review-pdfmaker
@@ -19,6 +19,7 @@ bindir = Pathname.new(__FILE__).realpath.dirname
 $LOAD_PATH.unshift((bindir + '../lib').realpath)
 
 require 'review'
+require 'review/highlighter'
 
 def error(msg)
   $stderr.puts "#{File.basename($0, '.*')}: error: #{msg}"
@@ -197,6 +198,8 @@ def get_template(values)
   okuduke += <<EOB
 発行所 & #{values["prt"]} \\\\
 EOB
+
+  highlighter_preamble = ReVIEW::Highlighter::highlighter_preamble('latex', :pygments, values['syntax-highlight']) || ''
 
   custom_titlepage = make_custom_titlepage(values["coverfile"])
 

--- a/bin/review-pdfmaker
+++ b/bin/review-pdfmaker
@@ -121,7 +121,7 @@ def output_chaps(filename, values)
   fork {
     STDOUT.reopen("#{@path}/#{filename}")
     $stderr.puts "compiling #{filename}"
-    exec("review-compile --target=latex --level=#{values["secnolevel"]} --toclevel=#{values["toclevel"]} #{values["params"]} #{filename}")
+    exec("review-compile --target=latex --level=#{values["secnolevel"]} --toclevel=#{values["toclevel"]} --syntax-highlight=#{values["syntax-highlight"]} #{values["params"]} #{filename}")
   }
   Process.waitall
 end
@@ -130,7 +130,7 @@ def output_parts(filename, values)
   fork {
     STDOUT.reopen("#{@path}/#{filename}.tex")
     $stderr.puts "compiling #{filename}.tex"
-    exec("review-compile --target=latex --level=#{values["secnolevel"]} --toclevel=#{values["toclevel"]} #{values["params"]} #{filename}.re | sed -e s/\\chapter{/\\part{/")
+    exec("review-compile --target=latex --level=#{values["secnolevel"]} --toclevel=#{values["toclevel"]} --syntax-highlight=#{values["syntax-highlight"]} #{values["params"]} #{filename}.re | sed -e s/\\chapter{/\\part{/")
 
   }
   Process.waitall

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -28,12 +28,13 @@ module ReVIEW
       nil
     end
 
-    def initialize(strict = false, *args)
+    def initialize(strict = false, pygments_opts = nil, *args)
       @strict = strict
       @tabwidth = nil
       if ReVIEW.book.param && ReVIEW.book.param["tabwidth"]
         @tabwidth = ReVIEW.book.param["tabwidth"]
       end
+      @pygments_opts = pygments_opts  # nil to avoid use of Pygments
       builder_init(*args)
     end
 

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -21,7 +21,14 @@ module ReVIEW
 
     CAPTION_TITLES = %w(note memo tip info planning best important security caution term link notice point shoot reference practice expert)
 
-    attr_accessor :highlighter
+    def highlighter
+      @highlighter
+    end
+
+    def highlighter=(highlighter)
+      @highlighter = highlighter
+      @highlighter.builder = self
+    end
 
     def pre_paragraph
       nil

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -21,6 +21,8 @@ module ReVIEW
 
     CAPTION_TITLES = %w(note memo tip info planning best important security caution term link notice point shoot reference practice expert)
 
+    attr_writer :highlighter_opts
+
     def pre_paragraph
       nil
     end
@@ -28,13 +30,13 @@ module ReVIEW
       nil
     end
 
-    def initialize(strict = false, pygments_opts = nil, *args)
+    def initialize(strict = false, *args)
       @strict = strict
       @tabwidth = nil
       if ReVIEW.book.param && ReVIEW.book.param["tabwidth"]
         @tabwidth = ReVIEW.book.param["tabwidth"]
       end
-      @pygments_opts = pygments_opts  # nil to avoid use of Pygments
+      @highlighter_opts = {}
       builder_init(*args)
     end
 

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -21,7 +21,7 @@ module ReVIEW
 
     CAPTION_TITLES = %w(note memo tip info planning best important security caution term link notice point shoot reference practice expert)
 
-    attr_writer :highlighter_opts
+    attr_accessor :highlighter
 
     def pre_paragraph
       nil
@@ -36,7 +36,7 @@ module ReVIEW
       if ReVIEW.book.param && ReVIEW.book.param["tabwidth"]
         @tabwidth = ReVIEW.book.param["tabwidth"]
       end
-      @highlighter_opts = {}
+      @highlighter = nil
       builder_init(*args)
     end
 

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -32,6 +32,7 @@ module ReVIEW
         "toc" => true, # Use table of contents
         "colophon" => nil, # Use colophon
         "debug" => nil, # debug flag
+        "syntax-highlight" => "none", # "none", "mononochrome", or "color"
       }
     end
   end

--- a/lib/review/highlighter.rb
+++ b/lib/review/highlighter.rb
@@ -1,25 +1,28 @@
 module ReVIEW
   module Highlighter
     def highlight(ops)
+      if ops[:pygments_opts]
+        return highlight_with_pygments(ops)
+      end
+      body = ops[:body] || ''
+      return body
+    end
+
+    def highlight_with_pygments(ops)
+      require 'pygments'
       body = ops[:body] || ''
       lexer = ops[:lexer] || ''
       format = ops[:format] || ''
-      pygments_opts = ops[:pygments_opts] || nil
+      pygments_opts = ops[:pygments_opts]
       # e.g. {style:'emacs'}
-
-      if pygments_opts
-        require 'pygments'
-        Pygments.highlight(
-                 body,
-                 :options => {
-                             :nowrap => true,
-                             :noclasses => true,
-                           }.merge(pygments_opts),
-                 :formatter => format,
-                 :lexer => lexer)
-      else
-        body
-      end
+      Pygments.highlight(
+               body,
+               :options => {
+                           :nowrap => true,
+                           :noclasses => true,
+                         }.merge(pygments_opts),
+               :formatter => format,
+               :lexer => lexer)
     end
   end
 end

--- a/lib/review/highlighter.rb
+++ b/lib/review/highlighter.rb
@@ -1,7 +1,27 @@
 module ReVIEW
   module Highlighter
+    def Highlighter::highlighter_opts(engine = :pygments, style = none)
+      case engine
+      when :pygments
+        case style
+        when nil, 'none'
+          return nil
+        when 'monochrome'
+          return {:pygments_opts => {:style =>'bw'}}
+        when 'color'
+          return {:pygments_opts => {:style => 'default'}}
+        else
+          $stderr.puts "syntax-highlight must be none, monochrome, or color"
+          exit 1
+        end
+      else
+        $stderr.puts "highlight engine #{engine} is not supported"
+        exit 1
+      end
+    end
+
     def highlight(ops)
-      if @highlighter_opts[:pygments_opts]
+      if @highlighter_opts and @highlighter_opts[:pygments_opts]
         return highlight_with_pygments(ops)
       end
       body = ops[:body] || ''

--- a/lib/review/highlighter.rb
+++ b/lib/review/highlighter.rb
@@ -2,6 +2,7 @@ module ReVIEW
   class Highlighter
 
     attr_accessor :opts
+    attr_accessor :builder
 
     def initialize(engine = :pygments, style = 'none')
       @engine = engine
@@ -60,7 +61,7 @@ module ReVIEW
       if @opts and @opts[:pygments_opts]
         return highlight_with_pygments(ops)
       end
-      body = ops[:body] || ''
+      body = @builder.escape(ops[:body]) || ''
       return body
     end
 

--- a/lib/review/highlighter.rb
+++ b/lib/review/highlighter.rb
@@ -1,7 +1,7 @@
 module ReVIEW
   module Highlighter
     def highlight(ops)
-      if ops[:pygments_opts]
+      if @highlighter_opts[:pygments_opts]
         return highlight_with_pygments(ops)
       end
       body = ops[:body] || ''
@@ -13,7 +13,7 @@ module ReVIEW
       body = ops[:body] || ''
       lexer = ops[:lexer] || ''
       format = ops[:format] || ''
-      pygments_opts = ops[:pygments_opts]
+      pygments_opts = @highlighter_opts[:pygments_opts]
       # e.g. {style:'emacs'}
       Pygments.highlight(
                body,

--- a/lib/review/highlighter.rb
+++ b/lib/review/highlighter.rb
@@ -1,0 +1,25 @@
+module ReVIEW
+  module Highlighter
+    def highlight(ops)
+      body = ops[:body] || ''
+      lexer = ops[:lexer] || ''
+      format = ops[:format] || ''
+      pygments_opts = ops[:pygments_opts] || nil
+      # e.g. {style:'emacs'}
+
+      if pygments_opts
+        require 'pygments'
+        Pygments.highlight(
+                 body,
+                 :options => {
+                             :nowrap => true,
+                             :noclasses => true,
+                           }.merge(pygments_opts),
+                 :formatter => format,
+                 :lexer => lexer)
+      else
+        body
+      end
+    end
+  end
+end

--- a/lib/review/highlighter.rb
+++ b/lib/review/highlighter.rb
@@ -20,6 +20,34 @@ module ReVIEW
       end
     end
 
+    def Highlighter::highlighter_preamble(format, engine = :pygments, style = 'none')
+      # also does sanity check for engine and style
+      highlighter_opts = Highlighter::highlighter_opts(engine, style)
+      case engine
+      when :pygments
+        case style
+        when nil, 'none'
+          return nil
+        when 'monochrome'
+          case format
+          when 'latex'
+            return Highlighter::Preamble::Pygments::Latex::Bw
+          when 'html'
+            return ''
+          else
+          end
+        when 'color'
+          case format
+          when 'latex'
+            return Highlighter::Preamble::Pygments::Latex::Default
+          when 'html'
+            return ''
+          else
+          end
+        end
+      end
+    end
+
     def highlight(ops)
       if @highlighter_opts and @highlighter_opts[:pygments_opts]
         return highlight_with_pygments(ops)
@@ -43,6 +71,177 @@ module ReVIEW
                          }.merge(pygments_opts),
                :formatter => format,
                :lexer => lexer)
+    end
+
+    module Preamble
+      module Pygments
+        module Latex
+          Bw = <<'_Pygments_Bw_End' # pygmentize -S bw -f latex
+\usepackage{fancyvrb}
+\makeatletter
+\def\PY@reset{\let\PY@it=\relax \let\PY@bf=\relax%
+    \let\PY@ul=\relax \let\PY@tc=\relax%
+    \let\PY@bc=\relax \let\PY@ff=\relax}
+\def\PY@tok#1{\csname PY@tok@#1\endcsname}
+\def\PY@toks#1+{\ifx\relax#1\empty\else%
+    \PY@tok{#1}\expandafter\PY@toks\fi}
+\def\PY@do#1{\PY@bc{\PY@tc{\PY@ul{%
+    \PY@it{\PY@bf{\PY@ff{#1}}}}}}}
+\def\PY#1#2{\PY@reset\PY@toks#1+\relax+\PY@do{#2}}
+
+\expandafter\def\csname PY@tok@gu\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@gs\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@cm\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@gp\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@ge\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@cs\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@gh\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@ni\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@nn\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@s2\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@s1\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@nc\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@ne\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@si\endcsname{\let\PY@bf=\textbf\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@nt\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@ow\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@c1\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@kc\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@c\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@sx\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@err\endcsname{\def\PY@bc##1{\setlength{\fboxsep}{0pt}\fcolorbox[rgb]{1.00,0.00,0.00}{1,1,1}{\strut ##1}}}
+\expandafter\def\csname PY@tok@kd\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@ss\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@sr\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@k\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@kn\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@kr\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@s\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@sh\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@sc\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@sb\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@se\endcsname{\let\PY@bf=\textbf\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@sd\endcsname{\let\PY@it=\textit}
+
+\def\PYZbs{\char`\\}
+\def\PYZus{\char`\_}
+\def\PYZob{\char`\{}
+\def\PYZcb{\char`\}}
+\def\PYZca{\char`\^}
+\def\PYZam{\char`\&}
+\def\PYZlt{\char`\<}
+\def\PYZgt{\char`\>}
+\def\PYZsh{\char`\#}
+\def\PYZpc{\char`\%}
+\def\PYZdl{\char`\$}
+\def\PYZhy{\char`\-}
+\def\PYZsq{\char`\'}
+\def\PYZdq{\char`\"}
+\def\PYZti{\char`\~}
+% for compatibility with earlier versions
+\def\PYZat{@}
+\def\PYZlb{[}
+\def\PYZrb{]}
+\makeatother
+_Pygments_Bw_End
+
+          Default = <<'_Pygments_Default_End' # pygmentize -S default -f latex
+\usepackage{fancyvrb}
+\makeatletter
+\def\PY@reset{\let\PY@it=\relax \let\PY@bf=\relax%
+    \let\PY@ul=\relax \let\PY@tc=\relax%
+    \let\PY@bc=\relax \let\PY@ff=\relax}
+\def\PY@tok#1{\csname PY@tok@#1\endcsname}
+\def\PY@toks#1+{\ifx\relax#1\empty\else%
+    \PY@tok{#1}\expandafter\PY@toks\fi}
+\def\PY@do#1{\PY@bc{\PY@tc{\PY@ul{%
+    \PY@it{\PY@bf{\PY@ff{#1}}}}}}}
+\def\PY#1#2{\PY@reset\PY@toks#1+\relax+\PY@do{#2}}
+
+\expandafter\def\csname PY@tok@gd\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.63,0.00,0.00}{##1}}}
+\expandafter\def\csname PY@tok@gu\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.50,0.00,0.50}{##1}}}
+\expandafter\def\csname PY@tok@gt\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.27,0.87}{##1}}}
+\expandafter\def\csname PY@tok@gs\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@gr\endcsname{\def\PY@tc##1{\textcolor[rgb]{1.00,0.00,0.00}{##1}}}
+\expandafter\def\csname PY@tok@cm\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
+\expandafter\def\csname PY@tok@vg\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
+\expandafter\def\csname PY@tok@m\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@mh\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@go\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.53,0.53,0.53}{##1}}}
+\expandafter\def\csname PY@tok@ge\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@vc\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
+\expandafter\def\csname PY@tok@il\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@cs\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
+\expandafter\def\csname PY@tok@cp\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.74,0.48,0.00}{##1}}}
+\expandafter\def\csname PY@tok@gi\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.63,0.00}{##1}}}
+\expandafter\def\csname PY@tok@gh\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,0.50}{##1}}}
+\expandafter\def\csname PY@tok@ni\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.60,0.60,0.60}{##1}}}
+\expandafter\def\csname PY@tok@nl\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.63,0.63,0.00}{##1}}}
+\expandafter\def\csname PY@tok@nn\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,1.00}{##1}}}
+\expandafter\def\csname PY@tok@no\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.53,0.00,0.00}{##1}}}
+\expandafter\def\csname PY@tok@na\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.49,0.56,0.16}{##1}}}
+\expandafter\def\csname PY@tok@nb\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@nc\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,1.00}{##1}}}
+\expandafter\def\csname PY@tok@nd\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.67,0.13,1.00}{##1}}}
+\expandafter\def\csname PY@tok@ne\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.82,0.25,0.23}{##1}}}
+\expandafter\def\csname PY@tok@nf\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,1.00}{##1}}}
+\expandafter\def\csname PY@tok@si\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.73,0.40,0.53}{##1}}}
+\expandafter\def\csname PY@tok@s2\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@vi\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
+\expandafter\def\csname PY@tok@nt\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@nv\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
+\expandafter\def\csname PY@tok@s1\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@sh\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@sc\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@sx\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@bp\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@c1\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
+\expandafter\def\csname PY@tok@kc\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@c\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
+\expandafter\def\csname PY@tok@mf\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@err\endcsname{\def\PY@bc##1{\setlength{\fboxsep}{0pt}\fcolorbox[rgb]{1.00,0.00,0.00}{1,1,1}{\strut ##1}}}
+\expandafter\def\csname PY@tok@kd\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@ss\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
+\expandafter\def\csname PY@tok@sr\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.40,0.53}{##1}}}
+\expandafter\def\csname PY@tok@mo\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@kn\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@mi\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@gp\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,0.50}{##1}}}
+\expandafter\def\csname PY@tok@o\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@kr\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@s\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@kp\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@w\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.73,0.73}{##1}}}
+\expandafter\def\csname PY@tok@kt\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.69,0.00,0.25}{##1}}}
+\expandafter\def\csname PY@tok@ow\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.67,0.13,1.00}{##1}}}
+\expandafter\def\csname PY@tok@sb\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@k\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@se\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.73,0.40,0.13}{##1}}}
+\expandafter\def\csname PY@tok@sd\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+
+\def\PYZbs{\char`\\}
+\def\PYZus{\char`\_}
+\def\PYZob{\char`\{}
+\def\PYZcb{\char`\}}
+\def\PYZca{\char`\^}
+\def\PYZam{\char`\&}
+\def\PYZlt{\char`\<}
+\def\PYZgt{\char`\>}
+\def\PYZsh{\char`\#}
+\def\PYZpc{\char`\%}
+\def\PYZdl{\char`\$}
+\def\PYZhy{\char`\-}
+\def\PYZsq{\char`\'}
+\def\PYZdq{\char`\"}
+\def\PYZti{\char`\~}
+% for compatibility with earlier versions
+\def\PYZat{@}
+\def\PYZlb{[}
+\def\PYZrb{]}
+\makeatother
+_Pygments_Default_End
+        end
+      end
     end
   end
 end

--- a/lib/review/highlighter.rb
+++ b/lib/review/highlighter.rb
@@ -1,6 +1,6 @@
 module ReVIEW
   module Highlighter
-    def Highlighter::highlighter_opts(engine = :pygments, style = none)
+    def Highlighter::highlighter_opts(engine = :pygments, style = 'none')
       case engine
       when :pygments
         case style

--- a/lib/review/highlighter.rb
+++ b/lib/review/highlighter.rb
@@ -1,9 +1,18 @@
 module ReVIEW
-  module Highlighter
-    def Highlighter::highlighter_opts(engine = :pygments, style = 'none')
-      case engine
+  class Highlighter
+
+    attr_accessor :opts
+
+    def initialize(engine = :pygments, style = 'none')
+      @engine = engine
+      @style = style
+      @opts = highlighter_opts
+    end
+
+    def highlighter_opts
+      case @engine
       when :pygments
-        case style
+        case @style
         when nil, 'none'
           return nil
         when 'monochrome'
@@ -20,12 +29,11 @@ module ReVIEW
       end
     end
 
-    def Highlighter::highlighter_preamble(format, engine = :pygments, style = 'none')
+    def preamble(format)
       # also does sanity check for engine and style
-      highlighter_opts = Highlighter::highlighter_opts(engine, style)
-      case engine
+      case @engine
       when :pygments
-        case style
+        case @style
         when nil, 'none'
           return nil
         when 'monochrome'
@@ -49,7 +57,7 @@ module ReVIEW
     end
 
     def highlight(ops)
-      if @highlighter_opts and @highlighter_opts[:pygments_opts]
+      if @opts and @opts[:pygments_opts]
         return highlight_with_pygments(ops)
       end
       body = ops[:body] || ''
@@ -61,7 +69,7 @@ module ReVIEW
       body = ops[:body] || ''
       lexer = ops[:lexer] || ''
       format = ops[:format] || ''
-      pygments_opts = @highlighter_opts[:pygments_opts]
+      pygments_opts = @opts[:pygments_opts]
       # e.g. {style:'emacs'}
       Pygments.highlight(
                body,

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -426,7 +426,7 @@ EOT
       print %Q[<pre class="list">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => body, :lexer => lexer, :format => 'html')
+      puts highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html')
       puts '</pre>'
     end
 

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -13,6 +13,7 @@ require 'review/builder'
 require 'review/htmlutils'
 require 'review/htmllayout'
 require 'review/textutils'
+require 'review/highlighter'
 require 'review/sec_counter'
 
 module ReVIEW
@@ -21,6 +22,7 @@ module ReVIEW
 
     include TextUtils
     include HTMLUtils
+    include Highlighter
 
     [:ref].each {|e| Compiler.definline(e) }
     Compiler.defblock(:memo, 0..1)

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -451,7 +451,7 @@ EOT
       print %Q[<pre class="source">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => body, :lexer => lexer, :format => 'html', :pygments_opts => @pygments_opts)
+      puts highlight(:body => body, :lexer => lexer, :format => 'html', :highlighter_opts => @highlighter_opts)
       puts '</pre>'
     end
 

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -428,7 +428,11 @@ EOT
       print %Q[<pre class="list">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts @highlighter.highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html')
+      if @highlighter
+        puts @highlighter.highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html')
+      else
+        puts body
+      end
       puts '</pre>'
     end
 
@@ -450,7 +454,11 @@ EOT
       print %Q[<pre class="source">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts @highlighter.highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html')
+      if @highlighter
+        puts @highlighter.highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html')
+      else
+        puts body
+      end
       puts '</pre>'
     end
 

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -450,7 +450,7 @@ EOT
       print %Q[<pre class="source">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts @highlighter.highlight(:body => body, :lexer => lexer, :format => 'html')
+      puts @highlighter.highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html')
       puts '</pre>'
     end
 

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -426,7 +426,7 @@ EOT
       print %Q[<pre class="list">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html')
+      puts highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html', :pygments_opts => @pygments_opts)
       puts '</pre>'
     end
 
@@ -448,7 +448,7 @@ EOT
       print %Q[<pre class="source">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => body, :lexer => lexer, :format => 'html')
+      puts highlight(:body => body, :lexer => lexer, :format => 'html', :pygments_opts => @pygments_opts)
       puts '</pre>'
     end
 

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -22,7 +22,6 @@ module ReVIEW
 
     include TextUtils
     include HTMLUtils
-    include Highlighter
 
     [:ref].each {|e| Compiler.definline(e) }
     Compiler.defblock(:memo, 0..1)
@@ -429,7 +428,7 @@ EOT
       print %Q[<pre class="list">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html', :highlighter_opts => @highlighter_opts)
+      puts @highlighter.highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html')
       puts '</pre>'
     end
 
@@ -451,7 +450,7 @@ EOT
       print %Q[<pre class="source">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => body, :lexer => lexer, :format => 'html', :highlighter_opts => @highlighter_opts)
+      puts @highlighter.highlight(:body => body, :lexer => lexer, :format => 'html')
       puts '</pre>'
     end
 

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -429,7 +429,7 @@ EOT
       print %Q[<pre class="list">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html', :pygments_opts => @pygments_opts)
+      puts highlight(:body => unescape_html(body), :lexer => lexer, :format => 'html', :highlighter_opts => @highlighter_opts)
       puts '</pre>'
     end
 

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -23,10 +23,14 @@ module ReVIEW
       str.gsub(/[&"<>]/) {|c| t[c] }
     end
 
+    alias escape escape_html
+
     def unescape_html(str)
       # FIXME better code
       str.gsub('&quot;', '"').gsub('&gt;', '>').gsub('&lt;', '<').gsub('&amp;', '&')
     end
+
+    alias unescape unescape_html
 
     def strip_html(str)
       str.gsub(/<\/?[^>]*>/, "")

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -31,29 +31,5 @@ module ReVIEW
     def strip_html(str)
       str.gsub(/<\/?[^>]*>/, "")
     end
-
-    def highlight(ops)
-      body = ops[:body] || ''
-      lexer = ops[:lexer] || ''
-      format = ops[:format] || ''
-
-      begin
-        require 'pygments'
-        begin
-          Pygments.highlight(
-                   unescape_html(body),
-                   :options => {
-                               :nowrap => true,
-                               :noclasses => true
-                             },
-                   :formatter => format,
-                   :lexer => lexer)
-        rescue MentosError
-          body
-        end
-      rescue LoadError
-          body
-      end
-    end
   end
 end   # module ReVIEW

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -297,7 +297,7 @@ module ReVIEW
       id ||= ''
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex', :pygments_opts => @pygments_opts)
+      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex', :highlighter_opts => @highlighter_opts)
     end
 
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -13,6 +13,7 @@
 require 'review/builder'
 require 'review/latexutils'
 require 'review/textutils'
+require 'review/highlighter'
 
 module ReVIEW
 
@@ -20,6 +21,7 @@ module ReVIEW
 
     include LaTeXUtils
     include TextUtils
+    include Highlighter
 
     [:dtp, :hd_chap].each {|e|
       Compiler.definline(e)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -21,7 +21,6 @@ module ReVIEW
 
     include LaTeXUtils
     include TextUtils
-    include Highlighter
 
     [:dtp, :hd_chap].each {|e|
       Compiler.definline(e)
@@ -276,7 +275,7 @@ module ReVIEW
       puts '\begin{reviewlist}'
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex', :highlighter_opts => @highlighter_opts)
+      puts @highlighter.highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex')
       puts '\end{reviewlist}'
       puts ""
     end
@@ -297,7 +296,7 @@ module ReVIEW
       id ||= ''
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex', :highlighter_opts => @highlighter_opts)
+      puts @highlighter.highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex')
     end
 
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -275,7 +275,11 @@ module ReVIEW
       puts '\begin{reviewlist}'
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts @highlighter.highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex')
+      if @highlighter
+        puts @highlighter.highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex')
+      else
+        puts body
+      end
       puts '\end{reviewlist}'
       puts ""
     end
@@ -296,7 +300,11 @@ module ReVIEW
       id ||= ''
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts @highlighter.highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex')
+      if @highlighter
+        puts @highlighter.highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex')
+      else
+        puts body
+      end
     end
 
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -276,7 +276,7 @@ module ReVIEW
       puts '\begin{reviewlist}'
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex', :pygments_opts => @pygments_opts)
+      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex', :highlighter_opts => @highlighter_opts)
       puts '\end{reviewlist}'
       puts ""
     end

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -274,7 +274,7 @@ module ReVIEW
       puts '\begin{reviewlist}'
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex')
+      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex', :pygments_opts => @pygments_opts)
       puts '\end{reviewlist}'
       puts ""
     end
@@ -295,7 +295,7 @@ module ReVIEW
       id ||= ''
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = File.extname(id).gsub(/\./, '')
-      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex')
+      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex', :pygments_opts => @pygments_opts)
     end
 
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -270,10 +270,11 @@ module ReVIEW
     end
 
     def list_body(id, lines)
+      id ||= ''
       puts '\begin{reviewlist}'
-      lines.each do |line|
-        puts detab(line)
-      end
+      body = lines.inject(''){|i, j| i + detab(j) + "\n"}
+      lexer = File.extname(id).gsub(/\./, '')
+      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex')
       puts '\end{reviewlist}'
       puts ""
     end
@@ -281,7 +282,7 @@ module ReVIEW
     def source(lines, caption)
       puts '\begin{reviewlist}'
       source_header caption
-      source_body lines
+      source_body caption, lines
       puts '\end{reviewlist}'
       puts ""
     end
@@ -290,10 +291,11 @@ module ReVIEW
       puts macro('reviewlistcaption', compile_inline(caption))
     end
 
-    def source_body(lines)
-      lines.each do |line|
-        puts detab(line)
-      end
+    def source_body(id, lines)
+      id ||= ''
+      body = lines.inject(''){|i, j| i + detab(j) + "\n"}
+      lexer = File.extname(id).gsub(/\./, '')
+      puts highlight(:body => unescape_latex(body), :lexer => lexer, :format => 'latex')
     end
 
 

--- a/lib/review/latexutils.rb
+++ b/lib/review/latexutils.rb
@@ -70,6 +70,8 @@ module ReVIEW
       }
     end
 
+    alias unescape unescape_latex
+
     def escape_index(str)
       str.gsub(/[@!|"]/) {|s| '"' + s }
     end

--- a/lib/review/review.tex.erb
+++ b/lib/review/review.tex.erb
@@ -1,5 +1,6 @@
 \documentclass[<%= documentclassoption %>]{<%= documentclass %>}
 \usepackage[deluxe]{otf}
+\usepackage{fancyvrb}
 \usepackage[dvipdfmx]{color}
 \usepackage[dvipdfmx]{graphicx}
 \usepackage{framed}
@@ -11,6 +12,101 @@
 \usepackage{float}
 \usepackage{alltt}
 \usepackage{amsmath}
+
+%% Pygments
+% echo | pygmentize -l latex -f latex -O full
+\makeatletter
+\def\PY@reset{\let\PY@it=\relax \let\PY@bf=\relax%
+    \let\PY@ul=\relax \let\PY@tc=\relax%
+    \let\PY@bc=\relax \let\PY@ff=\relax}
+\def\PY@tok#1{\csname PY@tok@#1\endcsname}
+\def\PY@toks#1+{\ifx\relax#1\empty\else%
+    \PY@tok{#1}\expandafter\PY@toks\fi}
+\def\PY@do#1{\PY@bc{\PY@tc{\PY@ul{%
+    \PY@it{\PY@bf{\PY@ff{#1}}}}}}}
+\def\PY#1#2{\PY@reset\PY@toks#1+\relax+\PY@do{#2}}
+
+\expandafter\def\csname PY@tok@gd\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.63,0.00,0.00}{##1}}}
+\expandafter\def\csname PY@tok@gu\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.50,0.00,0.50}{##1}}}
+\expandafter\def\csname PY@tok@gt\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.27,0.87}{##1}}}
+\expandafter\def\csname PY@tok@gs\endcsname{\let\PY@bf=\textbf}
+\expandafter\def\csname PY@tok@gr\endcsname{\def\PY@tc##1{\textcolor[rgb]{1.00,0.00,0.00}{##1}}}
+\expandafter\def\csname PY@tok@cm\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
+\expandafter\def\csname PY@tok@vg\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
+\expandafter\def\csname PY@tok@m\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@mh\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@go\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.53,0.53,0.53}{##1}}}
+\expandafter\def\csname PY@tok@ge\endcsname{\let\PY@it=\textit}
+\expandafter\def\csname PY@tok@vc\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
+\expandafter\def\csname PY@tok@il\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@cs\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
+\expandafter\def\csname PY@tok@cp\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.74,0.48,0.00}{##1}}}
+\expandafter\def\csname PY@tok@gi\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.63,0.00}{##1}}}
+\expandafter\def\csname PY@tok@gh\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,0.50}{##1}}}
+\expandafter\def\csname PY@tok@ni\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.60,0.60,0.60}{##1}}}
+\expandafter\def\csname PY@tok@nl\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.63,0.63,0.00}{##1}}}
+\expandafter\def\csname PY@tok@nn\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,1.00}{##1}}}
+\expandafter\def\csname PY@tok@no\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.53,0.00,0.00}{##1}}}
+\expandafter\def\csname PY@tok@na\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.49,0.56,0.16}{##1}}}
+\expandafter\def\csname PY@tok@nb\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@nc\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,1.00}{##1}}}
+\expandafter\def\csname PY@tok@nd\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.67,0.13,1.00}{##1}}}
+\expandafter\def\csname PY@tok@ne\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.82,0.25,0.23}{##1}}}
+\expandafter\def\csname PY@tok@nf\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,1.00}{##1}}}
+\expandafter\def\csname PY@tok@si\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.73,0.40,0.53}{##1}}}
+\expandafter\def\csname PY@tok@s2\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@vi\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
+\expandafter\def\csname PY@tok@nt\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@nv\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
+\expandafter\def\csname PY@tok@s1\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@sh\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@sc\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@sx\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@bp\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@c1\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
+\expandafter\def\csname PY@tok@kc\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@c\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
+\expandafter\def\csname PY@tok@mf\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@err\endcsname{\def\PY@bc##1{\setlength{\fboxsep}{0pt}\fcolorbox[rgb]{1.00,0.00,0.00}{1,1,1}{\strut ##1}}}
+\expandafter\def\csname PY@tok@kd\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@ss\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
+\expandafter\def\csname PY@tok@sr\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.40,0.53}{##1}}}
+\expandafter\def\csname PY@tok@mo\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@kn\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@mi\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@gp\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,0.50}{##1}}}
+\expandafter\def\csname PY@tok@o\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
+\expandafter\def\csname PY@tok@kr\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@s\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@kp\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@w\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.73,0.73}{##1}}}
+\expandafter\def\csname PY@tok@kt\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.69,0.00,0.25}{##1}}}
+\expandafter\def\csname PY@tok@ow\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.67,0.13,1.00}{##1}}}
+\expandafter\def\csname PY@tok@sb\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+\expandafter\def\csname PY@tok@k\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
+\expandafter\def\csname PY@tok@se\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.73,0.40,0.13}{##1}}}
+\expandafter\def\csname PY@tok@sd\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
+
+\def\PYZbs{\char`\\}
+\def\PYZus{\char`\_}
+\def\PYZob{\char`\{}
+\def\PYZcb{\char`\}}
+\def\PYZca{\char`\^}
+\def\PYZam{\char`\&}
+\def\PYZlt{\char`\<}
+\def\PYZgt{\char`\>}
+\def\PYZsh{\char`\#}
+\def\PYZpc{\char`\%}
+\def\PYZdl{\char`\$}
+\def\PYZhy{\char`\-}
+\def\PYZsq{\char`\'}
+\def\PYZdq{\char`\"}
+\def\PYZti{\char`\~}
+% for compatibility with earlier versions
+\def\PYZat{@}
+\def\PYZlb{[}
+\def\PYZrb{]}
+\makeatother
 
 %% if you use @<u>{} (underline), use jumoline.sty
 %%\usepackage{jumoline}

--- a/lib/review/review.tex.erb
+++ b/lib/review/review.tex.erb
@@ -1,6 +1,5 @@
 \documentclass[<%= documentclassoption %>]{<%= documentclass %>}
 \usepackage[deluxe]{otf}
-\usepackage{fancyvrb}
 \usepackage[dvipdfmx]{color}
 \usepackage[dvipdfmx]{graphicx}
 \usepackage{framed}
@@ -14,6 +13,7 @@
 \usepackage{amsmath}
 
 %% Pygments
+\usepackage{fancyvrb}
 % echo | pygmentize -l latex -f latex -O full
 \makeatletter
 \def\PY@reset{\let\PY@it=\relax \let\PY@bf=\relax%

--- a/lib/review/review.tex.erb
+++ b/lib/review/review.tex.erb
@@ -12,102 +12,6 @@
 \usepackage{alltt}
 \usepackage{amsmath}
 
-%% Pygments
-\usepackage{fancyvrb}
-% echo | pygmentize -l latex -f latex -O full
-\makeatletter
-\def\PY@reset{\let\PY@it=\relax \let\PY@bf=\relax%
-    \let\PY@ul=\relax \let\PY@tc=\relax%
-    \let\PY@bc=\relax \let\PY@ff=\relax}
-\def\PY@tok#1{\csname PY@tok@#1\endcsname}
-\def\PY@toks#1+{\ifx\relax#1\empty\else%
-    \PY@tok{#1}\expandafter\PY@toks\fi}
-\def\PY@do#1{\PY@bc{\PY@tc{\PY@ul{%
-    \PY@it{\PY@bf{\PY@ff{#1}}}}}}}
-\def\PY#1#2{\PY@reset\PY@toks#1+\relax+\PY@do{#2}}
-
-\expandafter\def\csname PY@tok@gd\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.63,0.00,0.00}{##1}}}
-\expandafter\def\csname PY@tok@gu\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.50,0.00,0.50}{##1}}}
-\expandafter\def\csname PY@tok@gt\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.27,0.87}{##1}}}
-\expandafter\def\csname PY@tok@gs\endcsname{\let\PY@bf=\textbf}
-\expandafter\def\csname PY@tok@gr\endcsname{\def\PY@tc##1{\textcolor[rgb]{1.00,0.00,0.00}{##1}}}
-\expandafter\def\csname PY@tok@cm\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
-\expandafter\def\csname PY@tok@vg\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
-\expandafter\def\csname PY@tok@m\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
-\expandafter\def\csname PY@tok@mh\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
-\expandafter\def\csname PY@tok@go\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.53,0.53,0.53}{##1}}}
-\expandafter\def\csname PY@tok@ge\endcsname{\let\PY@it=\textit}
-\expandafter\def\csname PY@tok@vc\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
-\expandafter\def\csname PY@tok@il\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
-\expandafter\def\csname PY@tok@cs\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
-\expandafter\def\csname PY@tok@cp\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.74,0.48,0.00}{##1}}}
-\expandafter\def\csname PY@tok@gi\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.63,0.00}{##1}}}
-\expandafter\def\csname PY@tok@gh\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,0.50}{##1}}}
-\expandafter\def\csname PY@tok@ni\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.60,0.60,0.60}{##1}}}
-\expandafter\def\csname PY@tok@nl\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.63,0.63,0.00}{##1}}}
-\expandafter\def\csname PY@tok@nn\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,1.00}{##1}}}
-\expandafter\def\csname PY@tok@no\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.53,0.00,0.00}{##1}}}
-\expandafter\def\csname PY@tok@na\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.49,0.56,0.16}{##1}}}
-\expandafter\def\csname PY@tok@nb\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
-\expandafter\def\csname PY@tok@nc\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,1.00}{##1}}}
-\expandafter\def\csname PY@tok@nd\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.67,0.13,1.00}{##1}}}
-\expandafter\def\csname PY@tok@ne\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.82,0.25,0.23}{##1}}}
-\expandafter\def\csname PY@tok@nf\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,1.00}{##1}}}
-\expandafter\def\csname PY@tok@si\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.73,0.40,0.53}{##1}}}
-\expandafter\def\csname PY@tok@s2\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
-\expandafter\def\csname PY@tok@vi\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
-\expandafter\def\csname PY@tok@nt\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
-\expandafter\def\csname PY@tok@nv\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
-\expandafter\def\csname PY@tok@s1\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
-\expandafter\def\csname PY@tok@sh\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
-\expandafter\def\csname PY@tok@sc\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
-\expandafter\def\csname PY@tok@sx\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
-\expandafter\def\csname PY@tok@bp\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
-\expandafter\def\csname PY@tok@c1\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
-\expandafter\def\csname PY@tok@kc\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
-\expandafter\def\csname PY@tok@c\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.25,0.50,0.50}{##1}}}
-\expandafter\def\csname PY@tok@mf\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
-\expandafter\def\csname PY@tok@err\endcsname{\def\PY@bc##1{\setlength{\fboxsep}{0pt}\fcolorbox[rgb]{1.00,0.00,0.00}{1,1,1}{\strut ##1}}}
-\expandafter\def\csname PY@tok@kd\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
-\expandafter\def\csname PY@tok@ss\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.10,0.09,0.49}{##1}}}
-\expandafter\def\csname PY@tok@sr\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.40,0.53}{##1}}}
-\expandafter\def\csname PY@tok@mo\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
-\expandafter\def\csname PY@tok@kn\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
-\expandafter\def\csname PY@tok@mi\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
-\expandafter\def\csname PY@tok@gp\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.00,0.50}{##1}}}
-\expandafter\def\csname PY@tok@o\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.40,0.40,0.40}{##1}}}
-\expandafter\def\csname PY@tok@kr\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
-\expandafter\def\csname PY@tok@s\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
-\expandafter\def\csname PY@tok@kp\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
-\expandafter\def\csname PY@tok@w\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.73,0.73}{##1}}}
-\expandafter\def\csname PY@tok@kt\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.69,0.00,0.25}{##1}}}
-\expandafter\def\csname PY@tok@ow\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.67,0.13,1.00}{##1}}}
-\expandafter\def\csname PY@tok@sb\endcsname{\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
-\expandafter\def\csname PY@tok@k\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.00,0.50,0.00}{##1}}}
-\expandafter\def\csname PY@tok@se\endcsname{\let\PY@bf=\textbf\def\PY@tc##1{\textcolor[rgb]{0.73,0.40,0.13}{##1}}}
-\expandafter\def\csname PY@tok@sd\endcsname{\let\PY@it=\textit\def\PY@tc##1{\textcolor[rgb]{0.73,0.13,0.13}{##1}}}
-
-\def\PYZbs{\char`\\}
-\def\PYZus{\char`\_}
-\def\PYZob{\char`\{}
-\def\PYZcb{\char`\}}
-\def\PYZca{\char`\^}
-\def\PYZam{\char`\&}
-\def\PYZlt{\char`\<}
-\def\PYZgt{\char`\>}
-\def\PYZsh{\char`\#}
-\def\PYZpc{\char`\%}
-\def\PYZdl{\char`\$}
-\def\PYZhy{\char`\-}
-\def\PYZsq{\char`\'}
-\def\PYZdq{\char`\"}
-\def\PYZti{\char`\~}
-% for compatibility with earlier versions
-\def\PYZat{@}
-\def\PYZlb{[}
-\def\PYZrb{]}
-\makeatother
-
 %% if you use @<u>{} (underline), use jumoline.sty
 %%\usepackage{jumoline}
 
@@ -267,6 +171,8 @@
 <%= values["usepackage"] %>
 
 \usepackage[T1]{fontenc}
+
+<%= highlighter_preamble %>
 
 \begin{document}
 

--- a/lib/review/textutils.rb
+++ b/lib/review/textutils.rb
@@ -62,5 +62,29 @@ module ReVIEW
         str
       end
     end
+
+    def highlight(ops)
+      body = ops[:body] || ''
+      lexer = ops[:lexer] || ''
+      format = ops[:format] || ''
+
+      begin
+        require 'pygments'
+        begin
+          Pygments.highlight(
+                   body,
+                   :options => {
+                               :nowrap => true,
+                               :noclasses => true,
+                             },
+                   :formatter => format,
+                   :lexer => lexer)
+        rescue MentosError
+          body
+        end
+      rescue LoadError
+          body
+      end
+    end
   end
 end

--- a/lib/review/textutils.rb
+++ b/lib/review/textutils.rb
@@ -67,23 +67,21 @@ module ReVIEW
       body = ops[:body] || ''
       lexer = ops[:lexer] || ''
       format = ops[:format] || ''
+      pygments_opts = ops[:pygments_opts] || nil
+      # e.g. {style:'emacs'}
 
-      begin
+      if pygments_opts
         require 'pygments'
-        begin
-          Pygments.highlight(
-                   body,
-                   :options => {
-                               :nowrap => true,
-                               :noclasses => true,
-                             },
-                   :formatter => format,
-                   :lexer => lexer)
-        rescue MentosError
-          body
-        end
-      rescue LoadError
-          body
+        Pygments.highlight(
+                 body,
+                 :options => {
+                             :nowrap => true,
+                             :noclasses => true,
+                           }.merge(pygments_opts),
+                 :formatter => format,
+                 :lexer => lexer)
+      else
+        body
       end
     end
   end

--- a/lib/review/textutils.rb
+++ b/lib/review/textutils.rb
@@ -62,27 +62,5 @@ module ReVIEW
         str
       end
     end
-
-    def highlight(ops)
-      body = ops[:body] || ''
-      lexer = ops[:lexer] || ''
-      format = ops[:format] || ''
-      pygments_opts = ops[:pygments_opts] || nil
-      # e.g. {style:'emacs'}
-
-      if pygments_opts
-        require 'pygments'
-        Pygments.highlight(
-                 body,
-                 :options => {
-                             :nowrap => true,
-                             :noclasses => true,
-                           }.merge(pygments_opts),
-                 :formatter => format,
-                 :lexer => lexer)
-      else
-        body
-      end
-    end
   end
 end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -692,4 +692,6 @@ begin
     end
   end
 rescue LoadError
+  warn "#{File.basename(__FILE__)}: Error in requiring 'pygments'. Related tests are skipped"
+  # pygments may be insalled with, e.g.: gem install pygments.rb
 end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -666,7 +666,8 @@ begin
     include ReVIEW
 
     def setup
-      @builder = HTMLBuilder.new(false, {})
+      @builder = HTMLBuilder.new(false)
+      @builder.highlighter_opts = {pygments_opts:{}}
       @param = {
         "secnolevel" => 2,    # for IDGXMLBuilder, HTMLBuilder
         "inencoding" => "UTF-8",

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -11,6 +11,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
 
   def setup
     @builder = HTMLBuilder.new()
+    @builder.highlighter = ReVIEW::Highlighter.new(:pygments)
     @param = {
       "secnolevel" => 2,    # for IDGXMLBuilder, HTMLBuilder
       "inencoding" => "UTF-8",
@@ -667,7 +668,7 @@ begin
 
     def setup
       @builder = HTMLBuilder.new(false)
-      @builder.highlighter_opts = {:pygments_opts => {}}
+      @builder.highlighter = ReVIEW::Highlighter.new(:pygments)
       @param = {
         "secnolevel" => 2,    # for IDGXMLBuilder, HTMLBuilder
         "inencoding" => "UTF-8",

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -667,7 +667,7 @@ begin
 
     def setup
       @builder = HTMLBuilder.new(false)
-      @builder.highlighter_opts = {pygments_opts:{}}
+      @builder.highlighter_opts = {:pygments_opts => {}}
       @param = {
         "secnolevel" => 2,    # for IDGXMLBuilder, HTMLBuilder
         "inencoding" => "UTF-8",

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -11,7 +11,6 @@ class HTMLBuidlerTest < Test::Unit::TestCase
 
   def setup
     @builder = HTMLBuilder.new()
-    @builder.highlighter = ReVIEW::Highlighter.new(:pygments)
     @param = {
       "secnolevel" => 2,    # for IDGXMLBuilder, HTMLBuilder
       "inencoding" => "UTF-8",
@@ -668,7 +667,7 @@ begin
 
     def setup
       @builder = HTMLBuilder.new(false)
-      @builder.highlighter = ReVIEW::Highlighter.new(:pygments)
+      @builder.highlighter = ReVIEW::Highlighter.new(:pygments, 'color')
       @param = {
         "secnolevel" => 2,    # for IDGXMLBuilder, HTMLBuilder
         "inencoding" => "UTF-8",

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -297,12 +297,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     end
     @builder.list(["test1", "test1.5", "", "test<i>2</i>"], "samplelist", "this is @<b>{test}<&>_")
 
-    begin # FIXME: Use params instead of exception handling
-      require 'pygments'
-      assert_equal %Q|<div class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list">test1\ntest1.5\n\ntest<span style="color: #008000; font-weight: bold">&lt;i&gt;</span>2<span style="color: #008000; font-weight: bold">&lt;/i&gt;</span>\n</pre>\n</div>\n|, @builder.raw_result
-    rescue LoadError
-      assert_equal %Q|<div class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list">test1\ntest1.5\n\ntest<i>2</i>\n</pre>\n</div>\n|, @builder.raw_result
-    end
+    assert_equal %Q|<div class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list">test1\ntest1.5\n\ntest<i>2</i>\n</pre>\n</div>\n|, @builder.raw_result
   end
 
   def test_emlist
@@ -661,4 +656,39 @@ EOS
 EOS
     assert_equal expect, @builder.raw_result
   end
+end
+
+begin
+  # test syntax highlighting when Pygments is available
+  require 'pygments'
+
+  class HTMLBuidlerWithPygmentsTest < Test::Unit::TestCase
+    include ReVIEW
+
+    def setup
+      @builder = HTMLBuilder.new(false, {})
+      @param = {
+        "secnolevel" => 2,    # for IDGXMLBuilder, HTMLBuilder
+        "inencoding" => "UTF-8",
+        "outencoding" => "UTF-8",
+        "subdirmode" => nil,
+        "stylesheet" => nil,  # for HTMLBuilder
+      }
+      ReVIEW.book.param = @param
+      @compiler = ReVIEW::Compiler.new(@builder)
+      @chapter = Book::Chapter.new(Book::Base.new(nil), 1, '-', nil, StringIO.new)
+      location = Location.new(nil, nil)
+      @builder.bind(@compiler, @chapter, location)
+    end
+
+    def test_list
+      def @chapter.list(id)
+        Book::ListIndex::Item.new("samplelist",1)
+      end
+      @builder.list(["test1", "test1.5", "", "test<i>2</i>"], "samplelist", "this is @<b>{test}<&>_")
+
+      assert_equal %Q|<div class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list">test1\ntest1.5\n\ntest<span style="color: #008000; font-weight: bold">&lt;i&gt;</span>2<span style="color: #008000; font-weight: bold">&lt;/i&gt;</span>\n</pre>\n</div>\n|, @builder.raw_result
+    end
+  end
+rescue LoadError
 end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -10,6 +10,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def setup
     @builder = LATEXBuilder.new()
+    @builder.highlighter = ReVIEW::Highlighter.new(:pygments)
     @param = {
       "secnolevel" => 2,    # for IDGXMLBuilder, EPUBBuilder
       "toclevel" => 2,

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -699,7 +699,8 @@ begin
     include ReVIEW
 
     def setup
-      @builder = LATEXBuilder.new(false, {})
+      @builder = LATEXBuilder.new(false)
+      @builder.highlighter_opts = {pygments_opts:{}}
       @param = {
         "secnolevel" => 2,    # for IDGXMLBuilder, EPUBBuilder
         "toclevel" => 2,

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -700,7 +700,7 @@ begin
 
     def setup
       @builder = LATEXBuilder.new(false)
-      @builder.highlighter_opts = {pygments_opts:{}}
+      @builder.highlighter_opts = {:pygments_opts => {}}
       @param = {
         "secnolevel" => 2,    # for IDGXMLBuilder, EPUBBuilder
         "toclevel" => 2,

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -701,7 +701,7 @@ begin
 
     def setup
       @builder = LATEXBuilder.new(false)
-      @builder.highlighter_opts = {:pygments_opts => {}}
+      @builder.highlighter = ReVIEW::Highlighter.new(:pygments)
       @param = {
         "secnolevel" => 2,    # for IDGXMLBuilder, EPUBBuilder
         "toclevel" => 2,

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -726,4 +726,6 @@ begin
     end
   end
 rescue LoadError
+  warn "#{File.basename(__FILE__)}: Error in requiring 'pygments'. Related tests are skipped"
+  # pygments may be insalled with, e.g.: gem install pygments.rb
 end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -10,7 +10,6 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def setup
     @builder = LATEXBuilder.new()
-    @builder.highlighter = ReVIEW::Highlighter.new(:pygments)
     @param = {
       "secnolevel" => 2,    # for IDGXMLBuilder, EPUBBuilder
       "toclevel" => 2,
@@ -701,7 +700,7 @@ begin
 
     def setup
       @builder = LATEXBuilder.new(false)
-      @builder.highlighter = ReVIEW::Highlighter.new(:pygments)
+      @builder.highlighter = ReVIEW::Highlighter.new(:pygments, 'color')
       @param = {
         "secnolevel" => 2,    # for IDGXMLBuilder, EPUBBuilder
         "toclevel" => 2,


### PR DESCRIPTION
Requires pygments installed with, e.g.
$ sudo apt-get install python-pygments
$ sudo gem install pygments.rb
- Move highlight method from htmlutils.rb to textutils.rb and stop
  unescaping inside the method
- Call highlight from list_body method in latexbuilder.rb
- Add preamble needed to review.tex.erb
