### PR TITLE
Require review/i18n for ReVIEW:I18n

### DIFF
--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/latexbuilder'
+require 'review/i18n'
 
 class LATEXBuidlerTest < Test::Unit::TestCase
   include ReVIEW


### PR DESCRIPTION
The patch fixes the error below:

$ ruby -I test test/test_latexbuilder.rb
Run options:

...................................EEE...........................................

Finished tests in 0.019946s, 4060.9852 tests/s, 3910.5783 assertions/s.

  1) Error:
test_indepimage(LATEXBuidlerTest):
NameError: uninitialized constant ReVIEW::LATEXBuilder::I18n
    /home/tomono/local/src/review/lib/review/latexbuilder.rb:370:in `indepimage'
    test/test_latexbuilder.rb:335:in`test_indepimage'

  2) Error:
test_indepimage_with_metric(LATEXBuidlerTest):
NameError: uninitialized constant ReVIEW::LATEXBuilder::I18n
    /home/tomono/local/src/review/lib/review/latexbuilder.rb:370:in `indepimage'
    test/test_latexbuilder.rb:358:in`test_indepimage_with_metric'

  3) Error:
test_indepimage_with_metric2(LATEXBuidlerTest):
NameError: uninitialized constant ReVIEW::LATEXBuilder::I18n
    /home/tomono/local/src/review/lib/review/latexbuilder.rb:370:in `indepimage'
    test/test_latexbuilder.rb:369:in`test_indepimage_with_metric2'

81 tests, 78 assertions, 0 failures, 3 errors, 0 skips
