### PR TITLE
epubmaker: fix NameError by unused variable

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -134,7 +134,7 @@ module ReVIEW
           build_part(part, basetmpdir, htmlfile)
           title = ReVIEW::I18n.t("part", part.number)
           title += ReVIEW::I18n.t("chapter_postfix") + part.name.strip if part.name.strip.present?
-          write_tochtmltxt(basetmpdir, "0\t#{filename}\t#{title}")
+          write_tochtmltxt(basetmpdir, "0\t#{htmlfile}\t#{title}")
         end
       end
 


### PR DESCRIPTION
変数名が間違っていたようなので修正です。
