### PR TITLE
support multiple names with using array for colophon.

### DIFF
--- a/bin/review-pdfmaker
+++ b/bin/review-pdfmaker
@@ -87,6 +87,10 @@ def main
     values["usepackage"] = "\\usepackage{#{values['texstyle']}}"
   end
 
+  %w[aut csl trl dsr ill cov edt].each do |item|
+    values[item] = [values[item]] if !values[item].nil? && values[item].instance_of?(String)
+  end
+
   copy_images("./images", "#{@path}/images")
   copyStyToDir(Dir.pwd + "/sty", @path)
   copyStyToDir(Dir.pwd, @path, "tex")
@@ -174,29 +178,29 @@ def get_template(values)
 
   okuduke = ""
   authors = ""
-  if values["aut"]
-    okuduke += "著　者 & #{values["aut"]} \\\\\n"
-    authors = values["aut"]+ ReVIEW::I18n.t("author_postfix")
+  if !values["aut"].nil? && !values["aut"].empty?
+    okuduke += "著　者 & #{values["aut"].join(ReVIEW::I18n.t("names_splitter"))} \\\\\n"
+    authors = values["aut"].join(ReVIEW::I18n.t("names_splitter")) + ReVIEW::I18n.t("author_postfix")
   end
-  if values["csl"]
-    okuduke += "監　修 & #{values["csl"]} \\\\\n"
-    authors += " \\\\\n"+values["csl"]+ ReVIEW::I18n.t("supervisor_postfix")
+  if !values["csl"].nil? && !values["csl"].empty?
+    okuduke += "監　修 & #{values["csl"].join(ReVIEW::I18n.t("names_splitter"))} \\\\\n"
+    authors += " \\\\\n"+values["csl"].join(ReVIEW::I18n.t("names_splitter")) + ReVIEW::I18n.t("supervisor_postfix")
   end
-  if values["trl"]
-    authors += " \\\\\n"+values["trl"]+ ReVIEW::I18n.t("translator_postfix")
-    okuduke += "翻　訳 & #{values["trl"]} \\\\\n"
+  if !values["trl"].nil? && !values["trl"].empty?
+    okuduke += "翻　訳 & #{values["trl"].join(ReVIEW::I18n.t("names_splitter"))} \\\\\n"
+    authors += " \\\\\n"+values["trl"].join(ReVIEW::I18n.t("names_splitter")) + ReVIEW::I18n.t("translator_postfix")
   end
-  if values["dsr"]
-    okuduke += "デザイン & #{values["dsr"]} \\\\\n"
+  if !values["dsr"].nil? && !values["dsr"].empty?
+    okuduke += "デザイン & #{values["dsr"].join(ReVIEW::I18n.t("names_splitter"))} \\\\\n"
   end
-  if values["ill"]
-    okuduke += "イラスト & #{values["ill"]} \\\\\n"
+  if !values["ill"].nil? && !values["ill"].empty?
+    okuduke += "イラスト & #{values["ill"].join(ReVIEW::I18n.t("names_splitter"))} \\\\\n"
   end
-  if values["cov"]
-    okuduke += "表　紙 & #{values["cov"]} \\\\\n"
+  if !values["cov"].nil? && !values["cov"].empty?
+    okuduke += "表　紙 & #{values["cov"].join(ReVIEW::I18n.t("names_splitter"))} \\\\\n"
   end
-  if values["edt"]
-    okuduke += "編集者 & #{values["edt"]} \\\\\n"
+  if !values["edt"].nil? && !values["edt"].empty?
+    okuduke += "編集者 & #{values["edt"].join(ReVIEW::I18n.t("names_splitter"))} \\\\\n"
   end
   okuduke += <<EOB
 発行所 & #{values["prt"]} \\\\

--- a/lib/review/i18n.yaml
+++ b/lib/review/i18n.yaml
@@ -19,6 +19,7 @@ ja:
   author_postfix: "　著"
   supervisor_postfix: "　監修"
   translator_postfix: "　訳"
+  names_splitter: "、"
 
 en:
   image: "Figure "
@@ -36,6 +37,7 @@ en:
   caption_prefix_idgxml: "　"
   ruby_prefix: "("
   ruby_postfix: ")"
+  names_splitter: ", "
 
 zh_TW:
   image: 圖
@@ -54,3 +56,4 @@ zh_TW:
   caption_prefix_idgxml: "　"
   ruby_prefix: "（"
   ruby_postfix: "）"
+  names_splitter: ", "


### PR DESCRIPTION
epubmaker-ng同様にYAML配列表現で列挙できる ＆ 互換性保持 ＆ i18n可能 にしてみました。
