### PR TITLE
remove Rake version in gemspec

### DIFF
--- a/review.gemspec
+++ b/review.gemspec
@@ -24,6 +24,6 @@ Gem::Specification.new do |gem|
   ]
   gem.require_paths = ["lib"]
 
-  gem.add_development_dependency("rake", ["0.8.7"])
+  gem.add_development_dependency("rake")
 end
 


### PR DESCRIPTION
さっきgemspecを見て思ったのですが、ここのバージョン指定は不要ですよね？
