### PR TITLE
Enable to use review-pdfmaker without an arg

### DIFF
--- a/bin/review-pdfmaker
+++ b/bin/review-pdfmaker
@@ -47,7 +47,7 @@ def build_path(values)
 end
 
 def main
-  if ARGV.size == 1 && !File.exist?(ARGV[0])
+  if ARGV.size >= 1 && !File.exist?(ARGV[0])
     error('configfile does not exist')
   elsif ARGV.size == 0 && !File.exist?('config.yml')
     usage


### PR DESCRIPTION
config.yml 決め打ちで引数なしでも実行可能に
