### PR TITLE
Add footnote back link (fix #262)

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -692,7 +692,7 @@ QUOTE
       if ReVIEW.book.param["epubversion"].to_i == 3
         puts %Q(<div class="footnote" epub:type="footnote" id="fn-#{id}"><p class="footnote">[*#{@chapter.footnote(id).number}] #{compile_inline(str)}</p></div>)
       else
-        puts %Q(<div class="footnote"><p class="footnote">[<a id="fn-#{id}">*#{@chapter.footnote(id).number}</a>] #{compile_inline(str)}</p></div>)
+        puts %Q(<div class="footnote" id="fn-#{id}"><p class="footnote">[<a href="#fnb-#{id}">*#{@chapter.footnote(id).number}</a>] #{compile_inline(str)}</p></div>)
       end
     end
 
@@ -786,9 +786,9 @@ QUOTE
 
     def inline_fn(id)
       if ReVIEW.book.param["epubversion"].to_i == 3
-        %Q(<a href="#fn-#{id}" class="noteref" epub:type="noteref">*#{@chapter.footnote(id).number}</a>)
+        %Q(<a id="fnb-#{id}" href="#fn-#{id}" class="noteref" epub:type="noteref">*#{@chapter.footnote(id).number}</a>)
       else
-        %Q(<a href="#fn-#{id}" class="noteref">*#{@chapter.footnote(id).number}</a>)
+        %Q(<a id="fnb-#{id}" href="#fn-#{id}" class="noteref">*#{@chapter.footnote(id).number}</a>)
       end
     end
 

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -666,7 +666,7 @@ EOS
     @chapter.instance_eval{@footnote_index=fn}
     @builder.footnote("foo",'bar\\a\\$buz')
     expect =<<-'EOS'
-<div class="footnote"><p class="footnote">[<a id="fn-foo">*1</a>] bar\a\$buz</p></div>
+<div class="footnote" id="fn-foo"><p class="footnote">[<a href="#fnb-foo">*1</a>] bar\a\$buz</p></div>
 EOS
     assert_equal expect, @builder.raw_result
   end


### PR DESCRIPTION
HTMLで脚注から本文に戻るリンクを追加しました。
aタグにidをつけるとうまく戻れなかったので、divにidを振りなおしています。
