### PR TITLE
Escape hyphens in HTML comments

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -684,7 +684,7 @@ QUOTE
         puts %Q(<div class="draft-comment">#{str}</div>)
       else
         str = lines.join("\n")
-        puts %Q(<!-- #{str} -->)
+        puts %Q(<!-- #{escape_comment(str)} -->)
       end
     end
 
@@ -806,7 +806,7 @@ QUOTE
         then escape_html(word + " (#{alt.strip})")
         else escape_html(word)
         end +
-        "</b><!-- IDX:#{escape_html(word)} -->"
+        "</b><!-- IDX:#{escape_comment(escape_html(word))} -->"
     end
 
     def inline_i(str)
@@ -854,11 +854,11 @@ QUOTE
     end
 
     def inline_idx(str)
-      %Q(#{escape_html(str)}<!-- IDX:#{escape_html(str)} -->)
+      %Q(#{escape_html(str)}<!-- IDX:#{escape_comment(escape_html(str))} -->)
     end
 
     def inline_hidx(str)
-      %Q(<!-- IDX:#{escape_html(str)} -->)
+      %Q(<!-- IDX:#{escape_comment(escape_html(str))} -->)
     end
 
     def inline_br(str)
@@ -1065,7 +1065,7 @@ QUOTE
       if ReVIEW.book.param["draft"]
         %Q(<span class="draft-comment">#{escape_html(str)}</span>)
       else
-        %Q(<!-- #{escape_html(str)} -->)
+        %Q(<!-- #{escape_comment(escape_html(str))} -->)
       end
     end
 

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -32,6 +32,10 @@ module ReVIEW
       str.gsub(/<\/?[^>]*>/, "")
     end
 
+    def escape_comment(str)
+      str.gsub('-', '&#45;')
+    end
+
     def highlight(ops)
       body = ops[:body] || ''
       lexer = ops[:lexer] || ''

--- a/test/test_htmlutils.rb
+++ b/test/test_htmlutils.rb
@@ -25,4 +25,13 @@ class HTMLUtilsTest < Test::Unit::TestCase
   def test_strip_html
     assert_equal 'thisistest.', strip_html('<h3>this<b>is</b>test</h3>.')
   end
+
+  def test_escape_comment
+    assert_equal '<', escape_comment('<')
+    assert_equal '>', escape_comment('>')
+    assert_equal '&', escape_comment('&')
+    assert_equal '&#45;', escape_comment('-')
+    assert_equal '&#45;&#45;', escape_comment('--')
+  end
+
 end


### PR DESCRIPTION
HTMLコメント内に`-`を入れるとき、それを`&#45;`にエスケープします。`//comment`や`@<kw>`などで「`--`」とか書いても大丈夫になります。

ついでに、`//comment`の中の行が2重に`escape_html`されていたのを直しました。
