### PR TITLE
support --version option

### DIFF
--- a/bin/review-check
+++ b/bin/review-check
@@ -41,6 +41,7 @@ def main
   modes = nil
   files = ARGV unless ARGV.empty?
   parser = OptionParser.new
+  parser.version = ReVIEW::VERSION
   parser.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and SJIS)') {|enc|
     @config["inencoding"] = enc
   }

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -64,6 +64,7 @@ def _main
   })
 
   parser = OptionParser.new
+  parser.version = ReVIEW::VERSION
   parser.banner = "Usage: #{File.basename($0)} [--target=FMT]"
   parser.on('--yaml=YAML', 'Read configurations from YAML file.') do |yaml|
     require 'yaml'

--- a/bin/review-index
+++ b/bin/review-index
@@ -18,6 +18,7 @@ $LOAD_PATH.unshift((bindir + '../lib').realpath)
 require 'review/book'
 require 'review/tocparser'
 require 'review/tocprinter'
+require 'review/version'
 require 'optparse'
 
 def main
@@ -42,6 +43,7 @@ def _main
   }
 
   parser = OptionParser.new
+  parser.version = ReVIEW::VERSION
   parser.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and SJIS)') {|enc|
     param["inencoding"] = enc
   }

--- a/bin/review-init
+++ b/bin/review-init
@@ -9,9 +9,11 @@
 
 require 'fileutils'
 require 'optparse'
+require 'review/version'
 
 def main
   parser = OptionParser.new
+  parser.version = ReVIEW::VERSION
   parser.banner = "Usage: #{File.basename($0)} dirname"
   parser.on('-h', '--help', 'print this message and quit.') {
     puts parser.help

--- a/bin/review-pdfmaker
+++ b/bin/review-pdfmaker
@@ -63,6 +63,7 @@ def main
   # Options
   opts = OptionParser.new
   opts.banner = "Usage: #{File.basename($0)} configfile"
+  opts.version = ReVIEW::VERSION
 
   opts.on('--help', 'Prints this message and quit.') do
     puts opts.help

--- a/bin/review-preproc
+++ b/bin/review-preproc
@@ -18,6 +18,7 @@ $LOAD_PATH.unshift((bindir + '../lib').realpath)
 
 require 'review/preprocessor'
 require 'review/unfold'
+require 'review/version'
 require 'lineinput'
 require 'stringio'
 require 'fileutils'
@@ -43,6 +44,7 @@ def main
 
   mode = :output
   parser = OptionParser.new
+  parser.version = ReVIEW::VERSION
   parser.banner = "Usage: #{File.basename($0)} [-c|-d|-s|--replace] [<file>...]"
   parser.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and
 SJIS)') {|enc|

--- a/bin/review-vol
+++ b/bin/review-vol
@@ -32,6 +32,7 @@ def main
   part_sensitive = false
   basedir = nil
   parser = OptionParser.new
+  parser.version = ReVIEW::VERSION
   parser.on('-P', '--part-sensitive', 'Prints volume of each parts.') {
     part_sensitive = true
   }


### PR DESCRIPTION
いくつかのコマンドに--versionオプションを追加します。ReVIEW::VERSIONの値を出力します。

（optparseにある機能を使っているので、optparseを使ってない review-epubmaker(-ng)、review-validateはサポートしていないのでした…）
