### PR TITLE
remove ReVIEW.book

### DIFF
--- a/lib/review/book/compilable.rb
+++ b/lib/review/book/compilable.rb
@@ -44,7 +44,7 @@ module ReVIEW
         @title = ''
         open {|f|
           f.each_line {|l|
-            l = convert_inencoding(l, ReVIEW.book.config["inencoding"])
+            l = convert_inencoding(l, book.config["inencoding"])
             if l =~ /\A=+/
               @title = l.sub(/\A=+(\[.+?\])?(\{.+?\})?/, '').strip
               break
@@ -71,7 +71,7 @@ module ReVIEW
 
       def content
         @content = convert_inencoding(File.read(path()),
-                                      ReVIEW.book.config["inencoding"])
+                                      book.config["inencoding"])
       rescue
         @content
       end

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -30,10 +30,6 @@ module ReVIEW
 
     def initialize(strict = false, *args)
       @strict = strict
-      @tabwidth = nil
-      if ReVIEW.book.config && ReVIEW.book.config["tabwidth"]
-        @tabwidth = ReVIEW.book.config["tabwidth"]
-      end
       builder_init(*args)
     end
 
@@ -47,6 +43,10 @@ module ReVIEW
       @location = location
       @output = StringIO.new
       @book = ReVIEW.book
+      @tabwidth = nil
+      if @book.config && @book.config["tabwidth"]
+        @tabwidth = @book.config["tabwidth"]
+      end
       builder_init_file
     end
 
@@ -62,13 +62,13 @@ module ReVIEW
 
     def print(*s)
       @output.print(*s.map{|i|
-        convert_outencoding(i, ReVIEW.book.config["outencoding"])
+        convert_outencoding(i, @book.config["outencoding"])
       })
     end
 
     def puts(*s)
       @output.puts *s.map{|i|
-        convert_outencoding(i, ReVIEW.book.config["outencoding"])
+        convert_outencoding(i, @book.config["outencoding"])
       }
     end
 
@@ -319,7 +319,7 @@ module ReVIEW
     end
 
     def get_chap(chapter = @chapter)
-      if ReVIEW.book.config["secnolevel"] > 0 && !chapter.number.nil? && !chapter.number.to_s.empty?
+      if @book.config["secnolevel"] > 0 && !chapter.number.nil? && !chapter.number.to_s.empty?
         return "#{chapter.number}"
       end
       return nil
@@ -376,12 +376,12 @@ module ReVIEW
 
     def inline_include(file_name)
       compile_inline convert_inencoding(File.open(file_name).read,
-                                        ReVIEW.book.config["inencoding"])
+                                        @book.config["inencoding"])
     end
 
     def include(file_name)
       File.foreach(file_name) do |line|
-        paragraph([convert_inencoding(line, ReVIEW.book.config["inencoding"])])
+        paragraph([convert_inencoding(line, @book.config["inencoding"])])
       end
     end
 

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -43,7 +43,7 @@ module ReVIEW
     end
 
     def extname
-      ".#{ReVIEW.book.config["htmlext"]}"
+      ".#{@book.config["htmlext"]}"
     end
 
     def builder_init(no_error = false)
@@ -68,7 +68,7 @@ module ReVIEW
         if ENV["REVIEW_SAFE_MODE"].to_i & 4 > 0
           warn "user's layout is prohibited in safe mode. ignored."
         else
-          title = convert_outencoding(strip_html(compile_inline(@chapter.title)), ReVIEW.book.config["outencoding"])
+          title = convert_outencoding(strip_html(compile_inline(@chapter.title)), @book.config["outencoding"])
 
           toc = ""
           toc_level = 0
@@ -100,27 +100,27 @@ module ReVIEW
 
       # default XHTML header/footer
       header = <<EOT
-<?xml version="1.0" encoding="#{ReVIEW.book.config["outencoding"] || :UTF-8}"?>
+<?xml version="1.0" encoding="#{@book.config["outencoding"] || :UTF-8}"?>
 EOT
-      if ReVIEW.book.config["htmlversion"].to_i == 5
+      if @book.config["htmlversion"].to_i == 5
         header += <<EOT
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:#{xmlns_ops_prefix}="http://www.idpf.org/2007/ops" xml:lang="#{ReVIEW.book.config["language"]}">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:#{xmlns_ops_prefix}="http://www.idpf.org/2007/ops" xml:lang="#{@book.config["language"]}">
 <head>
-  <meta charset="#{ReVIEW.book.config["outencoding"] || :UTF-8}" />
+  <meta charset="#{@book.config["outencoding"] || :UTF-8}" />
 EOT
       else
         header += <<EOT
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="#{ReVIEW.book.config["language"]}">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="#{@book.config["language"]}">
 <head>
-  <meta http-equiv="Content-Type" content="text/html;charset=#{ReVIEW.book.config["outencoding"] || :UTF-8}" />
+  <meta http-equiv="Content-Type" content="text/html;charset=#{@book.config["outencoding"] || :UTF-8}" />
   <meta http-equiv="Content-Style-Type" content="text/css" />
 EOT
       end
 
-      unless ReVIEW.book.config["stylesheet"].nil?
-        ReVIEW.book.config["stylesheet"].each do |style|
+      unless @book.config["stylesheet"].nil?
+        @book.config["stylesheet"].each do |style|
           header += <<EOT
   <link rel="stylesheet" type="text/css" href="#{style}" />
 EOT
@@ -128,7 +128,7 @@ EOT
       end
       header += <<EOT
   <meta name="generator" content="Re:VIEW" />
-  <title>#{convert_outencoding(strip_html(compile_inline(@chapter.title)), ReVIEW.book.config["outencoding"])}</title>
+  <title>#{convert_outencoding(strip_html(compile_inline(@chapter.title)), @book.config["outencoding"])}</title>
 </head>
 <body>
 EOT
@@ -136,11 +136,11 @@ EOT
 </body>
 </html>
 EOT
-      header + messages() + convert_outencoding(@output.string, ReVIEW.book.config["outencoding"]) + footer
+      header + messages() + convert_outencoding(@output.string, @book.config["outencoding"]) + footer
     end
 
     def xmlns_ops_prefix
-      if ReVIEW.book.config["epubversion"].to_i == 3
+      if @book.config["epubversion"].to_i == 3
         "epub"
       else
         "ops"
@@ -192,7 +192,7 @@ EOT
     def headline_prefix(level)
       @sec_counter.inc(level)
       anchor = @sec_counter.anchor(level)
-      prefix = @sec_counter.prefix(level, ReVIEW.book.config["secnolevel"])
+      prefix = @sec_counter.prefix(level, @book.config["secnolevel"])
       [prefix, anchor]
     end
     private :headline_prefix
@@ -288,7 +288,7 @@ EOT
       unless caption.nil?
         puts %Q[<p class="caption">#{compile_inline(caption)}</p>]
       end
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         blocked_lines = split_paragraph(lines)
         puts blocked_lines.join("\n")
       else
@@ -421,7 +421,7 @@ EOT
     end
 
     def read(lines)
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         blocked_lines = split_paragraph(lines)
         puts %Q[<div class="lead">\n#{blocked_lines.join("\n")}\n</div>]
       else
@@ -543,7 +543,7 @@ EOT
     private :quotedlist
 
     def quote(lines)
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         blocked_lines = split_paragraph(lines)
         puts "<blockquote>#{blocked_lines.join("\n")}</blockquote>"
       else
@@ -552,7 +552,7 @@ EOT
     end
 
     def doorquote(lines, ref)
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         blocked_lines = split_paragraph(lines)
         puts %Q[<blockquote style="text-align:right;">]
         puts "#{blocked_lines.join("\n")}"
@@ -571,7 +571,7 @@ QUOTE
 
     def talk(lines)
       puts %Q[<div class="talk">]
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         blocked_lines = split_paragraph(lines)
         puts "#{blocked_lines.join("\n")}"
       else
@@ -584,7 +584,7 @@ QUOTE
 
     def texequation(lines)
       puts %Q[<div class="equation">]
-      if ReVIEW.book.config["mathml"]
+      if @book.config["mathml"]
         p = MathML::LaTeX::Parser.new(:symbol=>MathML::Symbol::CharacterReference)
         puts p.parse(unescape_html(lines.join("\n")), true)
       else
@@ -711,7 +711,7 @@ QUOTE
     def comment(lines, comment = nil)
       lines ||= []
       lines.unshift comment unless comment.blank?
-      if ReVIEW.book.config["draft"]
+      if @book.config["draft"]
         str = lines.join("<br />")
         puts %Q(<div class="draft-comment">#{str}</div>)
       else
@@ -721,7 +721,7 @@ QUOTE
     end
 
     def footnote(id, str)
-      if ReVIEW.book.config["epubversion"].to_i == 3
+      if @book.config["epubversion"].to_i == 3
         puts %Q(<div class="footnote" epub:type="footnote" id="fn-#{normalize_id(id)}"><p class="footnote">[*#{@chapter.footnote(id).number}] #{compile_inline(str)}</p></div>)
       else
         puts %Q(<div class="footnote" id="fn-#{normalize_id(id)}"><p class="footnote">[<a href="#fnb-#{normalize_id(id)}">*#{@chapter.footnote(id).number}</a>] #{compile_inline(str)}</p></div>)
@@ -784,7 +784,7 @@ QUOTE
 
     def inline_chapref(id)
       title = super
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         %Q(<a href="./#{id}#{extname}">#{title}</a>)
       else
         title
@@ -795,7 +795,7 @@ QUOTE
     end
 
     def inline_chap(id)
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         %Q(<a href="./#{id}#{extname}">#{@chapter.env.chapter_index.number(id)}</a>)
       else
         @chapter.env.chapter_index.number(id)
@@ -806,7 +806,7 @@ QUOTE
     end
 
     def inline_title(id)
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         %Q(<a href="./#{id}#{extname}">#{compile_inline(@chapter.env.chapter_index.title(id))}</a>)
       else
         @chapter.env.chapter_index.title(id)
@@ -817,7 +817,7 @@ QUOTE
     end
 
     def inline_fn(id)
-      if ReVIEW.book.config["epubversion"].to_i == 3
+      if @book.config["epubversion"].to_i == 3
         %Q(<a id="fnb-#{normalize_id(id)}" href="#fn-#{normalize_id(id)}" class="noteref" epub:type="noteref">*#{@chapter.footnote(id).number}</a>)
       else
         %Q(<a id="fnb-#{normalize_id(id)}" href="#fn-#{normalize_id(id)}" class="noteref">*#{@chapter.footnote(id).number}</a>)
@@ -825,7 +825,7 @@ QUOTE
     end
 
     def compile_ruby(base, ruby)
-      if ReVIEW.book.config["htmlversion"].to_i == 5
+      if @book.config["htmlversion"].to_i == 5
         %Q[<ruby>#{escape_html(base)}<rp>#{I18n.t("ruby_prefix")}</rp><rt>#{escape_html(ruby)}</rt><rp>#{I18n.t("ruby_postfix")}</rp></ruby>]
       else
         %Q[<ruby><rb>#{escape_html(base)}</rb><rp>#{I18n.t("ruby_prefix")}</rp><rt>#{ruby}</rt><rp>#{I18n.t("ruby_postfix")}</rp></ruby>]
@@ -858,7 +858,7 @@ QUOTE
     end
 
     def inline_tti(str)
-      if ReVIEW.book.config["htmlversion"].to_i == 5
+      if @book.config["htmlversion"].to_i == 5
         %Q(<code class="tt"><i>#{escape_html(str)}</i></code>)
       else
         %Q(<tt><i>#{escape_html(str)}</i></tt>)
@@ -866,7 +866,7 @@ QUOTE
     end
 
     def inline_ttb(str)
-      if ReVIEW.book.config["htmlversion"].to_i == 5
+      if @book.config["htmlversion"].to_i == 5
         %Q(<code class="tt"><b>#{escape_html(str)}</b></code>)
       else
         %Q(<tt><b>#{escape_html(str)}</b></tt>)
@@ -878,7 +878,7 @@ QUOTE
     end
 
     def inline_code(str)
-      if ReVIEW.book.config["htmlversion"].to_i == 5
+      if @book.config["htmlversion"].to_i == 5
         %Q(<code class="inline-code tt">#{escape_html(str)}</code>)
       else
         %Q(<tt class="inline-code">#{escape_html(str)}</tt>)
@@ -898,7 +898,7 @@ QUOTE
     end
 
     def inline_m(str)
-      if ReVIEW.book.config["mathml"]
+      if @book.config["mathml"]
         p = MathML::LaTeX::Parser.new(:symbol=>MathML::Symbol::CharacterReference)
         %Q[<span class="equation">#{p.parse(str, nil)}</span>]
       else
@@ -936,12 +936,12 @@ QUOTE
 
     def inline_hd_chap(chap, id)
       n = chap.headline_index.number(id)
-      if chap.number and ReVIEW.book.config["secnolevel"] >= n.split('.').size
+      if chap.number and @book.config["secnolevel"] >= n.split('.').size
         str = "「#{n} #{compile_inline(chap.headline(id).caption)}」"
       else
         str = "「#{compile_inline(chap.headline(id).caption)}」"
       end
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         anchor = "h"+n.gsub(/\./, "-")
         %Q(<a href="#{chap.id}#{extname}##{anchor}">#{str}</a>)
       else
@@ -956,7 +956,7 @@ QUOTE
     private :column_label
 
     def inline_column(id)
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         %Q(<a href="\##{column_label(id)}" class="columnref">#{I18n.t("column", escape_html(@chapter.column(id).caption))}</a>)
       else
         escape_html(@chapter.column(id).caption)
@@ -986,7 +986,7 @@ QUOTE
       else
         str = "#{I18n.t("table")}#{I18n.t("format_number", [get_chap(chapter), chapter.table(id).number])}"
       end
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         %Q(<a href="./#{chapter.id}#{extname}##{id}">#{str}</a>)
       else
         str
@@ -1004,7 +1004,7 @@ QUOTE
       else
         str = "#{I18n.t("image")}#{I18n.t("format_number", [get_chap(chapter), chapter.image(id).number])}"
       end
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         %Q(<a href="./#{chapter.id}#{extname}##{normalize_id(id)}">#{str}</a>)
       else
         str
@@ -1071,7 +1071,7 @@ QUOTE
     end
 
     def inline_tt(str)
-      if ReVIEW.book.config["htmlversion"].to_i == 5
+      if @book.config["htmlversion"].to_i == 5
         %Q(<code class="tt">#{escape_html(str)}</code>)
       else
         %Q(<tt>#{escape_html(str)}</tt>)
@@ -1107,7 +1107,7 @@ QUOTE
     end
 
     def inline_comment(str)
-      if ReVIEW.book.config["draft"]
+      if @book.config["draft"]
         %Q(<span class="draft-comment">#{escape_html(str)}</span>)
       else
         %Q(<!-- #{escape_comment(escape_html(str))} -->)
@@ -1127,7 +1127,7 @@ QUOTE
     end
 
     def flushright(lines)
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         puts split_paragraph(lines).join("\n").gsub("<p>", "<p class=\"flushright\">")
       else
         puts %Q[<div style="text-align:right;">]

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -45,7 +45,7 @@ module ReVIEW
       lexer = ops[:lexer] || ''
       format = ops[:format] || ''
 
-      return body if ReVIEW.book.config["pygments"].nil?
+      return body if @book.config["pygments"].nil?
 
       begin
         require 'pygments'

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -76,14 +76,14 @@ module ReVIEW
 
       print %Q(<?xml version="1.0" encoding="UTF-8"?>\n)
       print %Q(<#{@rootelement} xmlns:aid="http://ns.adobe.com/AdobeInDesign/4.0/">)
-      if ReVIEW.book.config["nolf"].present?
+      if @book.config["nolf"].present?
         IDGXMLBuilder.class_eval do
           def puts(arg)
             print arg
           end
         end
       end
-      @secttags = true unless ReVIEW.book.config["structuredxml"].nil?
+      @secttags = true unless @book.config["structuredxml"].nil?
     end
     private :builder_init_file
 
@@ -180,7 +180,7 @@ module ReVIEW
         end
         @section += 1
         print %Q(<sect id="sect:#{@chapter.number}.#{@section}">) unless @secttags.nil?
-        if ReVIEW.book.config["secnolevel"] >= 2
+        if @book.config["secnolevel"] >= 2
           if @chapter.number.blank? or @chapter.on_POSTDEF?
             prefix = ""
           else
@@ -200,7 +200,7 @@ module ReVIEW
 
         @subsection += 1
         print %Q(<sect2 id="sect:#{@chapter.number}.#{@section}.#{@subsection}">) unless @secttags.nil?
-        if ReVIEW.book.config["secnolevel"] >= 3
+        if @book.config["secnolevel"] >= 3
           if @chapter.number.blank? or @chapter.on_POSTDEF?
             prefix = ""
           else
@@ -218,7 +218,7 @@ module ReVIEW
 
         @subsubsection += 1
         print %Q(<sect3 id="sect:#{@chapter.number}.#{@section}.#{@subsection}.#{@subsubsection}">) unless @secttags.nil?
-        if ReVIEW.book.config["secnolevel"] >= 4
+        if @book.config["secnolevel"] >= 4
           if @chapter.number.blank? or @chapter.on_POSTDEF?
             prefix = ""
           else
@@ -234,7 +234,7 @@ module ReVIEW
 
         @subsubsubsection += 1
         print %Q(<sect4 id="sect:#{@chapter.number}.#{@section}.#{@subsection}.#{@subsubsection}.#{@subsubsubsection}">) unless @secttags.nil?
-        if ReVIEW.book.config["secnolevel"] >= 5
+        if @book.config["secnolevel"] >= 5
           if @chapter.number.blank? or @chapter.on_POSTDEF?
             prefix = ""
           else
@@ -246,7 +246,7 @@ module ReVIEW
         raise "caption level too deep or unsupported: #{level}"
       end
 
-      prefix = "" if (level.to_i > ReVIEW.book.config["secnolevel"])
+      prefix = "" if (level.to_i > @book.config["secnolevel"])
       label = label.nil? ? "" : " id=\"#{label}\""
       toccaption = escape_html(compile_inline(caption.gsub(/@<fn>\{.+?\}/, '')).gsub(/<[^>]+>/, ''))
       puts %Q(<title#{label} aid:pstyle="h#{level}">#{prefix}#{compile_inline(caption)}</title><?dtp level="#{level}" section="#{prefix}#{toccaption}"?>)
@@ -343,7 +343,7 @@ module ReVIEW
     end
 
     def read(lines)
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         puts %Q[<lead>#{split_paragraph(lines).join}</lead>]
       else
         puts %Q[<p aid:pstyle="lead">#{lines.join}</p>]
@@ -359,7 +359,7 @@ module ReVIEW
     private :column_label
 
     def inline_column(id)
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         %Q(<link href="#{column_label(id)}">#{escape_html(@chapter.column(id).caption)}</link>)
       else
         escape_html(@chapter.column(id).caption)
@@ -390,7 +390,7 @@ module ReVIEW
     def codelines_body(lines)
       no = 1
       lines.each do |line|
-        unless ReVIEW.book.config["listinfo"].nil?
+        unless @book.config["listinfo"].nil?
           print "<listinfo line=\"#{no}\""
           print " begin=\"1\"" if no == 1
           print " end=\"#{no}\"" if no == lines.size
@@ -398,7 +398,7 @@ module ReVIEW
         end
         print detab(line)
         print "\n"
-        print "</listinfo>" unless ReVIEW.book.config["listinfo"].nil?
+        print "</listinfo>" unless @book.config["listinfo"].nil?
         no += 1
       end
     end
@@ -425,7 +425,7 @@ module ReVIEW
       print %Q(<pre>)
       no = 1
       lines.each_with_index do |line, i|
-        unless ReVIEW.book.config["listinfo"].nil?
+        unless @book.config["listinfo"].nil?
           print "<listinfo line=\"#{no}\""
           print " begin=\"1\"" if no == 1
           print " end=\"#{no}\"" if no == lines.size
@@ -433,7 +433,7 @@ module ReVIEW
         end
         print detab("<span type='lineno'>" + (i + 1).to_s.rjust(2) + ": </span>" + line)
         print "\n"
-        print "</listinfo>" unless ReVIEW.book.config["listinfo"].nil?
+        print "</listinfo>" unless @book.config["listinfo"].nil?
         no += 1
       end
       puts "</pre></codelist>"
@@ -449,7 +449,7 @@ module ReVIEW
       print %Q[<pre>]
       no = 1
       lines.each do |line|
-        unless ReVIEW.book.config["listinfo"].nil?
+        unless @book.config["listinfo"].nil?
           print "<listinfo line=\"#{no}\""
           print " begin=\"1\"" if no == 1
           print " end=\"#{no}\"" if no == lines.size
@@ -457,7 +457,7 @@ module ReVIEW
         end
         print detab(line)
         print "\n"
-        print "</listinfo>" unless ReVIEW.book.config["listinfo"].nil?
+        print "</listinfo>" unless @book.config["listinfo"].nil?
         no += 1
       end
       puts '</pre></list>'
@@ -465,7 +465,7 @@ module ReVIEW
     private :quotedlist
 
     def quote(lines)
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         blocked_lines = split_paragraph(lines)
         puts "<quote>#{blocked_lines.join("")}</quote>"
       else
@@ -540,8 +540,8 @@ module ReVIEW
     def table(lines, id = nil, caption = nil)
       tablewidth = nil
       col = 0
-      unless ReVIEW.book.config["tableopt"].nil?
-        tablewidth = ReVIEW.book.config["tableopt"].split(",")[0].to_f / 0.351 # mm -> pt
+      unless @book.config["tableopt"].nil?
+        tablewidth = @book.config["tableopt"].split(",")[0].to_f / 0.351 # mm -> pt
       end
       puts "<table>"
       rows = []
@@ -705,7 +705,7 @@ module ReVIEW
     end
 
     def inline_hint(str)
-      if ReVIEW.book.config["nolf"].nil?
+      if @book.config["nolf"].nil?
         %Q[\n<hint>#{escape_html(str)}</hint>]
       else
         %Q[<hint>#{escape_html(str)}</hint>]
@@ -922,7 +922,7 @@ module ReVIEW
     end
 
     def flushright(lines)
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         puts split_paragraph(lines).join.gsub("<p>", "<p align='right'>")
       else
         puts "<p align='right'>#{lines.join("\n")}</p>"
@@ -937,7 +937,7 @@ module ReVIEW
       print "<#{type}>"
       style = specialstyle.nil? ? "#{type}-title" : specialstyle
       puts "<title aid:pstyle='#{style}'>#{compile_inline(caption)}</title>" unless caption.nil?
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         blocked_lines = split_paragraph(lines)
         puts "#{blocked_lines.join}</#{type}>"
       else
@@ -1039,7 +1039,7 @@ module ReVIEW
       end
       no = 1
       lines.each do |line|
-        unless ReVIEW.book.config["listinfo"].nil?
+        unless @book.config["listinfo"].nil?
           print %Q[<listinfo line="#{no}"]
           print %Q[ begin="1"] if no == 1
           print %Q[ end="#{no}"] if no == lines.size
@@ -1047,7 +1047,7 @@ module ReVIEW
         end
         print detab(line)
         print "\n"
-        print "</listinfo>" unless ReVIEW.book.config["listinfo"].nil?
+        print "</listinfo>" unless @book.config["listinfo"].nil?
         no += 1
       end
       puts "</#{type}>"
@@ -1123,9 +1123,9 @@ module ReVIEW
 
     def inline_chapref(id)
       chs = ["", "「", "」"]
-      unless ReVIEW.book.config["chapref"].nil?
-        _chs = convert_inencoding(ReVIEW.book.config["chapref"],
-                                  ReVIEW.book.config["inencoding"]).split(",")
+      unless @book.config["chapref"].nil?
+        _chs = convert_inencoding(@book.config["chapref"],
+                                  @book.config["inencoding"]).split(",")
         if _chs.size != 3
           error "--chapsplitter must have exactly 3 parameters with comma."
         else
@@ -1134,7 +1134,7 @@ module ReVIEW
       else
       end
       s = "#{chs[0]}#{@chapter.env.chapter_index.number(id)}#{chs[1]}#{@chapter.env.chapter_index.title(id)}#{chs[2]}"
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         %Q(<link href="#{id}">#{s}</link>)
       else
         s
@@ -1145,7 +1145,7 @@ module ReVIEW
     end
 
     def inline_chap(id)
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         %Q(<link href="#{id}">#{@chapter.env.chapter_index.number(id)}</link>)
       else
         @chapter.env.chapter_index.number(id)
@@ -1156,7 +1156,7 @@ module ReVIEW
     end
 
     def inline_title(id)
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         %Q(<link href="#{id}">#{@chapter.env.chapter_index.title(id)}</link>)
       else
         @chapter.env.chapter_index.title(id)
@@ -1201,7 +1201,7 @@ module ReVIEW
     def inline_hd_chap(chap, id)
       if chap.number
         n = chap.headline_index.number(id)
-        if ReVIEW.book.config["secnolevel"] >= n.split('.').size
+        if @book.config["secnolevel"] >= n.split('.').size
           return "「#{n}　#{compile_inline(chap.headline(id).caption)}」"
         end
       end

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -79,7 +79,7 @@ module ReVIEW
     def headline_prefix(level)
       @sec_counter.inc(level)
       anchor = @sec_counter.anchor(level)
-      prefix = @sec_counter.prefix(level, ReVIEW.book.config["secnolevel"])
+      prefix = @sec_counter.prefix(level, @book.config["secnolevel"])
       [prefix, anchor]
     end
     private :headline_prefix
@@ -88,12 +88,12 @@ module ReVIEW
     def headline(level, label, caption)
       _, anchor = headline_prefix(level)
       prefix = ""
-      if level > ReVIEW.book.config["secnolevel"] || (@chapter.number.to_s.empty? && level > 1)
+      if level > @book.config["secnolevel"] || (@chapter.number.to_s.empty? && level > 1)
         prefix = "*"
       end
       blank unless @output.pos == 0
       puts macro(HEADLINE[level]+prefix, compile_inline(caption))
-      if prefix == "*" && level <= ReVIEW.book.config["toclevel"].to_i
+      if prefix == "*" && level <= @book.config["toclevel"].to_i
         puts "\\addcontentsline{toc}{#{HEADLINE[level]}}{#{compile_inline(caption)}}"
       end
       if level == 1
@@ -122,7 +122,7 @@ module ReVIEW
         puts "\\hypertarget{#{column_label(caption)}}{}"
       end
       puts macro('reviewcolumnhead', nil, compile_inline(caption))
-      if level <= ReVIEW.book.config["toclevel"].to_i
+      if level <= @book.config["toclevel"].to_i
         puts "\\addcontentsline{toc}{#{HEADLINE[level]}}{#{compile_inline(caption)}}"
       end
     end
@@ -138,7 +138,7 @@ module ReVIEW
         puts "\\reviewminicolumntitle{#{compile_inline(caption)}}\n"
       end
 
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         blocked_lines = split_paragraph(lines)
         puts blocked_lines.join("\n\n")
       else
@@ -531,7 +531,7 @@ module ReVIEW
     def latex_block(type, lines)
       blank
       puts macro('begin', type)
-      if ReVIEW.book.config["deprecated-blocklines"].nil?
+      if @book.config["deprecated-blocklines"].nil?
         blocked_lines = split_paragraph(lines)
         puts blocked_lines.join("\n\n")
       else
@@ -554,7 +554,7 @@ module ReVIEW
     def comment(lines, comment = nil)
       lines ||= []
       lines.unshift comment unless comment.blank?
-      if ReVIEW.book.config["draft"]
+      if @book.config["draft"]
         str = lines.join("")
         puts macro('pdfcomment', escape(str))
       end
@@ -582,7 +582,7 @@ module ReVIEW
 
     def inline_chapref(id)
       title = super
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         "\\hyperref[chap:#{id}]{#{title}}"
       else
         title
@@ -593,7 +593,7 @@ module ReVIEW
     end
 
     def inline_chap(id)
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         "\\hyperref[chap:#{id}]{#{@chapter.env.chapter_index.number(id)}}"
       else
         @chapter.env.chapter_index.number(id)
@@ -604,7 +604,7 @@ module ReVIEW
     end
 
     def inline_title(id)
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         "\\hyperref[chap:#{id}]{#{@chapter.env.chapter_index.title(id)}}"
       else
         @chapter.env.chapter_index.title(id)
@@ -632,14 +632,14 @@ module ReVIEW
     end
 
     def footnote(id, content)
-      if ReVIEW.book.config["footnotetext"]
+      if @book.config["footnotetext"]
         puts macro("footnotetext[#{@chapter.footnote(id).number}]",
                    compile_inline(content.strip))
       end
     end
 
     def inline_fn(id)
-      if ReVIEW.book.config["footnotetext"]
+      if @book.config["footnotetext"]
         macro("footnotemark[#{@chapter.footnote(id).number}]", "")
       else
         macro('footnote', compile_inline(@chapter.footnote(id).content.strip))
@@ -727,12 +727,12 @@ module ReVIEW
 
     def inline_hd_chap(chap, id)
       n = chap.headline_index.number(id)
-      if chap.number and ReVIEW.book.config["secnolevel"] >= n.split('.').size
+      if chap.number and @book.config["secnolevel"] >= n.split('.').size
         str = "「#{chap.headline_index.number(id)} #{compile_inline(chap.headline(id).caption)}」"
       else
         str = "「#{compile_inline(chap.headline(id).caption)}」"
       end
-      if ReVIEW.book.config["chapterlink"]
+      if @book.config["chapterlink"]
         anchor = n.gsub(/\./, "-")
         macro('reviewsecref', str, sec_label(anchor))
       else
@@ -782,7 +782,7 @@ module ReVIEW
     end
 
     def inline_comment(str)
-      if ReVIEW.book.config["draft"]
+      if @book.config["draft"]
         macro('pdfcomment', escape(str))
       else
         ""

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -171,7 +171,7 @@ module ReVIEW
       else
         raise "caption level too deep or unsupported: #{level}"
       end
-      prefix = "" if (level.to_i > ReVIEW.book.config["secnolevel"])
+      prefix = "" if (level.to_i > @book.config["secnolevel"])
       puts "■H#{level}■#{prefix}#{compile_inline(caption)}"
     end
 
@@ -740,9 +740,9 @@ module ReVIEW
 
     def inline_chapref(id)
       chs = ["", "「", "」"]
-      unless ReVIEW.book.config["chapref"].nil?
-        _chs = convert_inencoding(ReVIEW.book.config["chapref"],
-                                  ReVIEW.book.config["inencoding"]).split(",")
+      unless @book.config["chapref"].nil?
+        _chs = convert_inencoding(@book.config["chapref"],
+                                  @book.config["inencoding"]).split(",")
         if _chs.size != 3
           error "--chapsplitter must have exactly 3 parameters with comma."
         else

--- a/test/test_book_chapter.rb
+++ b/test/test_book_chapter.rb
@@ -161,11 +161,11 @@ class ChapterTest < Test::Unit::TestCase
 
   def test_title
     io = StringIO.new
-    ch = Book::Chapter.new(nil, nil, nil, nil, io)
+    ch = Book::Chapter.new(ReVIEW.book, nil, nil, nil, io)
     assert_equal '', ch.title
 
     io = StringIO.new("=1\n=2\n")
-    ch = Book::Chapter.new(nil, nil, nil, nil, io)
+    ch = Book::Chapter.new(ReVIEW.book, nil, nil, nil, io)
     assert_equal '1', ch.title
 
 
@@ -176,7 +176,7 @@ class ChapterTest < Test::Unit::TestCase
       ['XYZ', @eucjp_str],
     ].each do |enc, instr|
       io = StringIO.new("= #{instr}\n")
-      ch = Book::Chapter.new(nil, nil, nil, nil, io)
+      ch = Book::Chapter.new(ReVIEW.book, nil, nil, nil, io)
       ReVIEW.book.config = {'inencoding' => enc}
       assert_equal @utf8_str, ch.title
       assert_equal @utf8_str, ch.instance_eval { @title }
@@ -195,7 +195,7 @@ class ChapterTest < Test::Unit::TestCase
         tf.print instr
         tf.close
 
-        ch = Book::Chapter.new(nil, nil, nil, tf.path)
+        ch = Book::Chapter.new(ReVIEW.book, nil, nil, tf.path)
         ReVIEW.book.config = {'inencoding' => enc}
         assert_equal @utf8_str, ch.content
         assert_equal @utf8_str, ch.instance_eval { @content }
@@ -212,7 +212,7 @@ class ChapterTest < Test::Unit::TestCase
         tf2.puts instr
         tf1.close
 
-        ch = Book::Chapter.new(nil, nil, nil, tf1.path, tf2)
+        ch = Book::Chapter.new(ReVIEW.book, nil, nil, tf1.path, tf2)
         ReVIEW.book.config = {'inencoding' => enc}
         assert_equal "#{@utf8_str}\n#{@utf8_str}\n", ch.content # XXX: OK?
       ensure
@@ -228,7 +228,7 @@ class ChapterTest < Test::Unit::TestCase
     tf.print lines.join('')
     tf.close
 
-    ch = Book::Chapter.new(nil, nil, nil, tf.path)
+    ch = Book::Chapter.new(ReVIEW.book, nil, nil, tf.path)
     assert_equal lines, ch.lines
 
     lines = ["1\n", "2\n", "3"]
@@ -240,7 +240,7 @@ class ChapterTest < Test::Unit::TestCase
     tf2.puts lines.join('')
     tf2.close
 
-    ch = Book::Chapter.new(nil, nil, nil, tf1.path, tf2.path)
+    ch = Book::Chapter.new(ReVIEW.book, nil, nil, tf1.path, tf2.path)
     assert_equal lines, ch.lines # XXX: OK?
   end
 


### PR DESCRIPTION
`ReVIEW.book` is used as global variable.
In *builder, `@book` is better than `ReVIEW.book`.
(`ReVIEW.book` should be used in initialization and tests)
