### PR TITLE
OptionParserを受け取る変数をoptsに一本化する

### DIFF
--- a/bin/review-check
+++ b/bin/review-check
@@ -40,34 +40,34 @@ def main
 
   modes = nil
   files = ARGV unless ARGV.empty?
-  parser = OptionParser.new
-  parser.version = ReVIEW::VERSION
-  parser.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and SJIS)') {|enc|
+  opts = OptionParser.new
+  opts.version = ReVIEW::VERSION
+  opts.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and SJIS)') {|enc|
     @config["inencoding"] = enc
   }
-  parser.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC, JIS, and SJIS)') {|enc|
+  opts.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC, JIS, and SJIS)') {|enc|
     @config["outencoding"] = enc
   }
-  parser.on('-a', '--all-chapters', 'Check all chapters.') {
+  opts.on('-a', '--all-chapters', 'Check all chapters.') {
     files = ReVIEW.book.chapters.map {|ent| ent.path }
   }
-  parser.on('-s', '--section N', 'Check section N. (deprecated)') {|n|
+  opts.on('-s', '--section N', 'Check section N. (deprecated)') {|n|
     ents = ReVIEW.env.parts[Integer(n) - 1] or
         raise ReVIEW::ApplicationError, "section #{n} not exist"
     files = ents.map {|ent| ent.path }
   }
-  parser.on('--text', 'Check text.') {
+  opts.on('--text', 'Check text.') {
     (modes ||= []).push :text
   }
-  parser.on('--help', 'print this message and quit.') {
-    puts parser.help
+  opts.on('--help', 'print this message and quit.') {
+    puts opts.help
     exit 0
   }
   begin
-    parser.parse!
+    opts.parse!
   rescue OptionParser::ParseError => err
     $stderr.puts err.message
-    $stderr.puts parser.help
+    $stderr.puts opts.help
     exit 1
   end
   unless files

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -63,73 +63,73 @@ def _main
     "htmlversion" => 4,
   })
 
-  parser = OptionParser.new
-  parser.version = ReVIEW::VERSION
-  parser.banner = "Usage: #{File.basename($0)} [--target=FMT]"
-  parser.on('--yaml=YAML', 'Read configurations from YAML file.') do |yaml|
+  opts = OptionParser.new
+  opts.version = ReVIEW::VERSION
+  opts.banner = "Usage: #{File.basename($0)} [--target=FMT]"
+  opts.on('--yaml=YAML', 'Read configurations from YAML file.') do |yaml|
     require 'yaml'
     config = config.merge(YAML.load_file(yaml))
   end
-  parser.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and SJIS)') {|enc| config["inencoding"] = enc }
-  parser.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC, JIS, and SJIS)') {|enc| config["outencoding"] = enc }
-  parser.on('-c', '--check', 'Check manuscript') { check_only = true }
-  parser.on('--level=LVL', 'Section level to append number.') {|lvl| config["secnolevel"] = lvl.to_i }
-  parser.on('--toclevel=LVL', 'Section level to append number.') {|lvl| config["toclevel"] = lvl.to_i }
-  parser.on('--nolfinxml', 'Do not insert LF in XML. (idgxml)') { config["nolf"] = true }
-  parser.on('--structuredxml', 'Produce XML with structured sections. (idgxml)') { config["structuredxml"] = true }
-  parser.on('--table=WIDTH', 'Default table width. (idgxml)') {|tbl| config["tableopt"] = tbl }
-  parser.on('--listinfo', 'Append listinfo tag to lists to indicate begin/end. (idgxml)') { config["listinfo"] = true }
-  parser.on('--chapref="before,middle,after"', 'Chapref decoration.') {|cdec| config["chapref"] = cdec }
-  parser.on('--subdirmode', 'Use chapter/id.ext path style to find images. (deprecated)') do
+  opts.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and SJIS)') {|enc| config["inencoding"] = enc }
+  opts.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC, JIS, and SJIS)') {|enc| config["outencoding"] = enc }
+  opts.on('-c', '--check', 'Check manuscript') { check_only = true }
+  opts.on('--level=LVL', 'Section level to append number.') {|lvl| config["secnolevel"] = lvl.to_i }
+  opts.on('--toclevel=LVL', 'Section level to append number.') {|lvl| config["toclevel"] = lvl.to_i }
+  opts.on('--nolfinxml', 'Do not insert LF in XML. (idgxml)') { config["nolf"] = true }
+  opts.on('--structuredxml', 'Produce XML with structured sections. (idgxml)') { config["structuredxml"] = true }
+  opts.on('--table=WIDTH', 'Default table width. (idgxml)') {|tbl| config["tableopt"] = tbl }
+  opts.on('--listinfo', 'Append listinfo tag to lists to indicate begin/end. (idgxml)') { config["listinfo"] = true }
+  opts.on('--chapref="before,middle,after"', 'Chapref decoration.') {|cdec| config["chapref"] = cdec }
+  opts.on('--subdirmode', 'Use chapter/id.ext path style to find images. (deprecated)') do
     STDERR.puts "Warning: --subdirmode is deprecated. Images are automatically detected."
   end
-  parser.on('--singledirmode', 'Use id.ext path style to find images. (deprecated)') do
+  opts.on('--singledirmode', 'Use id.ext path style to find images. (deprecated)') do
     STDERR.puts "Warning: --singledirmode is deprecated. Images are automatically detected."
   end
-  parser.on('--chapterlink', 'make chapref hyperlink') { config["chapterlink"] = true }
-  parser.on('--stylesheet=file', 'Stylesheet file for HTML (comma separated)') {|files| config["stylesheet"] = files.split(/\s*,\s*/) }
-  parser.on('--mathml', 'Use MathML for TeX equation in HTML') do
+  opts.on('--chapterlink', 'make chapref hyperlink') { config["chapterlink"] = true }
+  opts.on('--stylesheet=file', 'Stylesheet file for HTML (comma separated)') {|files| config["stylesheet"] = files.split(/\s*,\s*/) }
+  opts.on('--mathml', 'Use MathML for TeX equation in HTML') do
     config["mathml"] = true
     require 'math_ml'
     require "math_ml/symbol/character_reference"
   end
-  parser.on('--htmlversion=VERSION', 'HTML version.') do |v|
+  opts.on('--htmlversion=VERSION', 'HTML version.') do |v|
     v = v.to_i
     config["htmlversion"] = v if v == 4 || v == 5
   end
-  parser.on('--epubversion=VERSION', 'EPUB version.') do |v|
+  opts.on('--epubversion=VERSION', 'EPUB version.') do |v|
     v = v.to_i
     config["epubversion"] = v if v == 2 || v == 3
   end
-  parser.on('--hdnumberingmode', 'Output numbering headlines. (deprecated)') { config["hdnumberingmode"] = true }
-  parser.on('--deprecated-blocklines', 'Disable paragrahs in block tags. Treat physical line as a paragraph. (deprecated)') { config["deprecated-blocklines"] = true }
-  parser.on('--target=FMT', 'Target format.') {|fmt| target = fmt } unless target
-  parser.on('--footnotetext',
+  opts.on('--hdnumberingmode', 'Output numbering headlines. (deprecated)') { config["hdnumberingmode"] = true }
+  opts.on('--deprecated-blocklines', 'Disable paragrahs in block tags. Treat physical line as a paragraph. (deprecated)') { config["deprecated-blocklines"] = true }
+  opts.on('--target=FMT', 'Target format.') {|fmt| target = fmt } unless target
+  opts.on('--footnotetext',
             'Use footnotetext and footnotemark instead of footnote (latex)') {
     config["footnotetext"] = true
   }
-  parser.on('--draft', 'use draft mode(inline comment)') { config["draft"] = true }
-  parser.on('-a', '--all', 'Compile all chapters.') do
+  opts.on('--draft', 'use draft mode(inline comment)') { config["draft"] = true }
+  opts.on('-a', '--all', 'Compile all chapters.') do
     mode = :dir
     basedir = nil
   end
-  parser.on('--directory=DIR', 'Compile all chapters in DIR.') do |path|
+  opts.on('--directory=DIR', 'Compile all chapters in DIR.') do |path|
     mode = :dir
     basedir = path
   end
-  parser.on('--output-file=FILENAME', 'Write all results into file instead of stdout.') do |filename|
+  opts.on('--output-file=FILENAME', 'Write all results into file instead of stdout.') do |filename|
     output_filename = filename
   end
-  parser.on('--tabwidth=WIDTH', 'tab width') {|width| config["tabwidth"] = width.to_i }
-  parser.on('--catalogfile=FILENAME', 'Set catalog file') do |catalogfile|
+  opts.on('--tabwidth=WIDTH', 'tab width') {|width| config["tabwidth"] = width.to_i }
+  opts.on('--catalogfile=FILENAME', 'Set catalog file') do |catalogfile|
     config["catalogfile"] = catalogfile
   end
-  parser.on('--help', 'Prints this message and quit.') do
-    puts parser.help
+  opts.on('--help', 'Prints this message and quit.') do
+    puts opts.help
     exit 0
   end
   begin
-    parser.parse!
+    opts.parse!
     unless target
       if check_only
         target = 'html'
@@ -139,7 +139,7 @@ def _main
     end
   rescue OptionParser::ParseError => err
     error err.message
-    $stderr.puts parser.help
+    $stderr.puts opts.help
     exit 1
   end
 

--- a/bin/review-epubmaker
+++ b/bin/review-epubmaker
@@ -30,23 +30,27 @@ include ReVIEW::HTMLUtils
 
 $essential_files = ['top', 'toc', 'colophon']
 def main
-  parser = OptionParser.new
-  parser.version = ReVIEW::VERSION
-  parser.banner = "Usage: #{File.basename($0)} [options] configfile"
-  parser.on('-h', '--help', 'print this message and quit.') {
-    puts parser.help
+  opts = OptionParser.new
+  opts.version = ReVIEW::VERSION
+  opts.banner = "Usage: #{File.basename($0)} [options] configfile"
+  opts.on('-h', '--help', 'print this message and quit.') {
+    puts opts.help
     exit 0
   }
+  opts.on('--[no-]debug', 'Keep temporary files.') do |debug|
+    config["debug"] = debug
+  end
+
   begin
-    parser.parse!
+    opts.parse!
   rescue OptionParser::ParseError => err
     $stderr.puts err.message
-    $stderr.puts parser.help
+    $stderr.puts opts.help
     exit 1
   end
 
   if ARGV.empty?
-    $stderr.puts parser.help
+    $stderr.puts opts.help
     exit 1
   end
 

--- a/bin/review-index
+++ b/bin/review-index
@@ -42,57 +42,57 @@ def _main
     "outencoding" => "UTF-8"
   }
 
-  parser = OptionParser.new
-  parser.version = ReVIEW::VERSION
-  parser.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and SJIS)') {|enc|
+  opts = OptionParser.new
+  opts.version = ReVIEW::VERSION
+  opts.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and SJIS)') {|enc|
     param["inencoding"] = enc
   }
-  parser.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC, JIS, and SJIS)') {|enc|
+  opts.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC, JIS, and SJIS)') {|enc|
     param["outencoding"] = enc
   }
-  parser.on('-a', '--all', 'print all chapters.') {
+  opts.on('-a', '--all', 'print all chapters.') {
     begin
       source = ReVIEW.book
     rescue ReVIEW::Error => err
       error_exit err.message
     end
   }
-  parser.on('-p', '--part N', 'list only part N.') {|n|
+  opts.on('-p', '--part N', 'list only part N.') {|n|
     source = ReVIEW.book.part(Integer(n)) or
         error_exit "part #{n} does not exist in this book"
   }
-  parser.on('-c', '--chapter C', 'list only chapter C.') {|c|
+  opts.on('-c', '--chapter C', 'list only chapter C.') {|c|
     begin
       source = ReVIEW::Book::Part.new(nil, 1, [ReVIEW.book.chapter(c)])
     rescue
       error_exit "chapter #{c} does not exist in this book"
     end
   }
-  parser.on('-l', '--level N', 'list upto N level (1..4, default=4)') {|n|
+  opts.on('-l', '--level N', 'list upto N level (1..4, default=4)') {|n|
     upper = Integer(n)
     unless (0..4).include?(upper)  # 0 is hidden option
       $stderr.puts "-l/--level option accepts only 1..4"
       exit 1
     end
   }
-  parser.on('--text', 'output in plain text (default)') {
+  opts.on('--text', 'output in plain text (default)') {
     printer_class = ReVIEW::TextTOCPrinter
   }
-  parser.on('--html', 'output in HTML (deprecated)') {
+  opts.on('--html', 'output in HTML (deprecated)') {
     printer_class = ReVIEW::HTMLTOCPrinter
   }
-  parser.on('--idg', 'output in InDesign XML') {
+  opts.on('--idg', 'output in InDesign XML') {
     printer_class = ReVIEW::IDGTOCPrinter
   }
-  parser.on('--help', 'print this message and quit.') {
-    puts parser.help
+  opts.on('--help', 'print this message and quit.') {
+    puts opts.help
     exit 0
   }
   begin
-    parser.parse!
+    opts.parse!
   rescue OptionParser::ParseError => err
     $stderr.puts err.message
-    $stderr.puts parser.help
+    $stderr.puts opts.help
     exit 1
   end
   if source
@@ -100,7 +100,7 @@ def _main
       error_exit '-a/-s option and file arguments are exclusive'
     end
   else
-    puts parser.help
+    puts opts.help
     exit 0
   end
 

--- a/bin/review-init
+++ b/bin/review-init
@@ -12,23 +12,23 @@ require 'optparse'
 require 'review/version'
 
 def main
-  parser = OptionParser.new
-  parser.version = ReVIEW::VERSION
-  parser.banner = "Usage: #{File.basename($0)} dirname"
-  parser.on('-h', '--help', 'print this message and quit.') {
-    puts parser.help
+  opts = OptionParser.new
+  opts.version = ReVIEW::VERSION
+  opts.banner = "Usage: #{File.basename($0)} dirname"
+  opts.on('-h', '--help', 'print this message and quit.') {
+    puts opts.help
     exit 0
   }
   begin
-    parser.parse!
+    opts.parse!
   rescue OptionParser::ParseError => err
     $stderr.puts err.message
-    $stderr.puts parser.help
+    $stderr.puts opts.help
     exit 1
   end
 
   if ARGV.empty?
-    $stderr.puts parser.help
+    $stderr.puts opts.help
     exit 1
   end
 

--- a/bin/review-preproc
+++ b/bin/review-preproc
@@ -43,42 +43,42 @@ def main
   }
 
   mode = :output
-  parser = OptionParser.new
-  parser.version = ReVIEW::VERSION
-  parser.banner = "Usage: #{File.basename($0)} [-c|-d|-s|--replace] [<file>...]"
-  parser.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and
+  opts = OptionParser.new
+  opts.version = ReVIEW::VERSION
+  opts.banner = "Usage: #{File.basename($0)} [-c|-d|-s|--replace] [<file>...]"
+  opts.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and
 SJIS)') {|enc|
     param["inencoding"] = enc
   }
-  parser.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC
+  opts.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC
 , JIS, and SJIS)') {|enc|
     param["outencoding"] = enc
   }
-  parser.on('-c', '--check', 'Check if preprocess is needed.') {
+  opts.on('-c', '--check', 'Check if preprocess is needed.') {
     mode = :check
   }
-  parser.on('-d', '--diff', 'Show diff from current file.') {
+  opts.on('-d', '--diff', 'Show diff from current file.') {
     mode = :diff
   }
-  parser.on('--replace', 'Replace file by preprocessed one.') {
+  opts.on('--replace', 'Replace file by preprocessed one.') {
     mode = :replace
   }
-  parser.on('-s', '--strip', 'Strip preprocessor tags.') {
+  opts.on('-s', '--strip', 'Strip preprocessor tags.') {
     mode = :strip
   }
-  parser.on('--final', 'Unfold text and strip preprocessor tags. (deprecated)') {
+  opts.on('--final', 'Unfold text and strip preprocessor tags. (deprecated)') {
     mode = :final
   }
-  parser.on('--tabwidth=WIDTH', "Replace tabs with space characters. (0: don't replace)") {|width| param["tabwidth"] = width.to_i }
-  parser.on('--help', 'Print this message and quit.') {
-    puts parser.help
+  opts.on('--tabwidth=WIDTH', "Replace tabs with space characters. (0: don't replace)") {|width| param["tabwidth"] = width.to_i }
+  opts.on('--help', 'Print this message and quit.') {
+    puts opts.help
     exit 0
   }
   begin
-    parser.parse!
+    opts.parse!
   rescue OptionParser::ParseError => err
     $stderr.puts err.message
-    $stderr.puts parser.help
+    $stderr.puts opts.help
     exit 1
   end
 

--- a/bin/review-vol
+++ b/bin/review-vol
@@ -31,29 +31,29 @@ def main
 
   part_sensitive = false
   basedir = nil
-  parser = OptionParser.new
-  parser.version = ReVIEW::VERSION
-  parser.on('-P', '--part-sensitive', 'Prints volume of each parts.') {
+  opts = OptionParser.new
+  opts.version = ReVIEW::VERSION
+  opts.on('-P', '--part-sensitive', 'Prints volume of each parts.') {
     part_sensitive = true
   }
-  parser.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and SJIS)') {|enc|
+  opts.on('--inencoding=ENCODING', 'Set input encoding. (UTF-8, EUC, JIS, and SJIS)') {|enc|
     @config["inencoding"] = enc
   }
-  parser.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC, JIS, and SJIS)') {|enc|
+  opts.on('--outencoding=ENCODING', 'Set output encoding. (UTF-8[default], EUC, JIS, and SJIS)') {|enc|
     @config["outencoding"] = enc
   }
-  parser.on('--directory=DIR', 'Compile all chapters in DIR.') {|path|
+  opts.on('--directory=DIR', 'Compile all chapters in DIR.') {|path|
     basedir = path
   }
-  parser.on('--help', 'Print this message and quit') {
-    puts parser.help
+  opts.on('--help', 'Print this message and quit') {
+    puts opts.help
     exit 0
   }
   begin
-    parser.parse!
+    opts.parse!
   rescue OptionParser::ParseError => err
     $stderr.puts err.message
-    $stderr.puts parser.help
+    $stderr.puts opts.help
     exit 1
   end
 


### PR DESCRIPTION
bin/ 配下のスクリプトでparserとoptsが両方使われていて最初に見た時に地味に混乱するため、一本化を試みます。

実はparserの方が出現数が多いのですが、ここではoptsを採用する前提でPRをしています。
どちらでも構いませんが、あえてoptsとした根拠は以下のとおりです。

理由1
tocparser.rbやRe:VIEWパーサーという表現と概念レベルで全く異なるものと名前がぶつかるため、
余計な混乱を感じました (個人の印象です)。

理由2
こちらは完全に後付ですが、ググって出るRubyの検索結果が割とoptsでした
http://docs.ruby-lang.org/ja/1.8.7/class/OptionParser.html
http://ruby-doc.org/stdlib-2.1.2/libdoc/optparse/rdoc/OptionParser.html

rake testと簡単なpdfmakerのビルドは通ることを確認しました。
この変更後、parserでgrepをするとtocparserへの参照と、
uuid.rbのGUID parserへの言及だけが残ります。

(ここまで書きましたが、主要開発者の方々の考え方次第で、parserへの一本化でも構いません)
