### PR TITLE
refactor I18n and add instance methods

### DIFF
--- a/lib/review/i18n.rb
+++ b/lib/review/i18n.rb
@@ -3,27 +3,69 @@ require 'yaml'
 
 module ReVIEW
   class I18n
-    def self.setup
-      lfile = File.expand_path "locale.yml", Dir.pwd
-      # backward compatibility
-      lfile = File.expand_path "locale.yaml", Dir.pwd unless File.exist?(lfile)
-      user_i18n = YAML.load_file(lfile)
-      I18n.i18n user_i18n["locale"], user_i18n
+    def self.setup(ymlfile = "locale.yml")
+      lfile = nil
+      if ymlfile
+        lfile = File.expand_path(ymlfile, Dir.pwd)
+
+        # backward compatibility
+        if !File.exist?(lfile) && (ymlfile == "locale.yml")
+          lfile = File.expand_path("locale.yaml", Dir.pwd)
+        end
+      end
+
+      I18n.i18n "ja"
+      if lfile && File.file?(lfile)
+        @i18n.update_localefile(lfile)
+      end
     rescue
       I18n.i18n "ja"
     end
 
     def self.i18n(locale, user_i18n = {})
       locale ||= "ja"
-      i18n_yaml_path = File.expand_path "i18n.yml", File.dirname(__FILE__)
-      @i18n = YAML.load_file(i18n_yaml_path)[locale]
-      if @i18n
-        @i18n.merge!(user_i18n)
+      @i18n = ReVIEW::I18n.new(locale)
+      unless user_i18n.empty?
+        @i18n.update(user_i18n)
       end
     end
 
     def self.t(str, args = nil)
-      @i18n[str] % args
+      @i18n.t(str, args)
+    end
+
+
+    attr_accessor :locale
+
+    def initialize(locale = nil)
+      @locale = locale
+      load_default
+    end
+
+    def load_default
+      load_file(File.expand_path "i18n.yml", File.dirname(__FILE__))
+    end
+
+    def load_file(path)
+      @store = YAML.load_file(path)
+    end
+
+    def update_localefile(path)
+      user_i18n = YAML.load_file(path)
+      locale = user_i18n["locale"]
+      user_i18n.delete("locale")
+      @store[locale].merge!(user_i18n)
+    end
+
+    def update(user_i18n, locale = nil)
+      locale ||= @locale
+      if @store[locale]
+        @store[locale].merge!(user_i18n)
+      end
+    end
+
+    def t(str, args = nil)
+      @store[@locale][str] % args
     rescue
       str
     end

--- a/lib/review/i18n.rb
+++ b/lib/review/i18n.rb
@@ -23,7 +23,7 @@ module ReVIEW
     end
 
     def self.i18n(locale, user_i18n = {})
-      locale ||= "ja"
+      locale ||= "en"
       @i18n = ReVIEW::I18n.new(locale)
       unless user_i18n.empty?
         @i18n.update(user_i18n)
@@ -61,6 +61,8 @@ module ReVIEW
       locale ||= @locale
       if @store[locale]
         @store[locale].merge!(user_i18n)
+      else
+        @store[locale] = user_i18n
       end
     end
 

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -126,8 +126,16 @@ class I18nTest < Test::Unit::TestCase
 
   def test_update
     i18n = ReVIEW::I18n.new("ja")
-    hash = {"locale"=>"ja","foo"=>"bar"}
+    hash = {"foo"=>"bar"}
     i18n.update(hash)
+    assert_equal "bar", i18n.t("foo")
+  end
+
+  def test_update_newlocale
+    i18n = ReVIEW::I18n.new("ja")
+    hash = {"foo"=>"bar"}
+    i18n.update(hash, "abc")
+    i18n.locale = "abc"
     assert_equal "bar", i18n.t("foo")
   end
 

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -32,6 +32,41 @@ class I18nTest < Test::Unit::TestCase
         end
       end
     end
+
+    def test_load_foo_yaml
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          file = File.join(dir, "foo.yml")
+          File.open(file, "w"){|f| f.write("locale: ja\nfoo: \"bar\"\n")}
+          I18n.setup("foo.yml")
+          assert_equal "bar", I18n.t("foo")
+        end
+      end
+    end
+
+    def test_update_foo_yaml
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          file = File.join(dir, "foo.yml")
+          File.open(file, "w"){|f| f.write("locale: ja\nfoo: \"bar\"\n")}
+          i18n = ReVIEW::I18n.new("ja")
+          i18n.update_localefile(File.join(Dir.pwd, "foo.yml"))
+          assert_equal "bar", i18n.t("foo")
+        end
+      end
+    end
+
+    def test_update_foo_yaml_i18nclass
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          file = File.join(dir, "foo.yml")
+          File.open(file, "w"){|f| f.write("locale: ja\nfoo: \"bar\"\n")}
+          I18n.setup(nil)
+          I18n.setup("foo.yml")
+          assert_equal "bar", I18n.t("foo")
+        end
+      end
+    end
   end
 
   def test_ja
@@ -87,6 +122,13 @@ class I18nTest < Test::Unit::TestCase
     @chapter = Book::Chapter.new(@book, 1, '-', nil, StringIO.new)
     location = Location.new(nil, nil)
     @builder.bind(@compiler, @chapter, location)
+  end
+
+  def test_update
+    i18n = ReVIEW::I18n.new("ja")
+    hash = {"locale"=>"ja","foo"=>"bar"}
+    i18n.update(hash)
+    assert_equal "bar", i18n.t("foo")
   end
 
   def teardown


### PR DESCRIPTION
#331 の「決めうち名のファイルが増えていくのが嫌だなぁ」に対応するべくReVIEW::I18nクラスに手を入れてみました。

* ReVIEW::I18nにインスタンスメソッドを追加しました
* I18n.setup(nil)とすると、locale.ymlとかを読まないようにしました。これで、最初は`I18n.setup(nil)`にしておいて、localeファイル名が決まったあとで`I18n.setup(locale_filename)`とすると、locale.y(a)ml以外のファイル名も陽に指定できるようになります（例えばconfig.ymlで指定したファイル名とかにできるはず）。