### PR TITLE
コマンドでエラーがある場合に出力して欲しい

### DIFF
--- a/lib/epubmaker/epubv2.rb
+++ b/lib/epubmaker/epubv2.rb
@@ -553,8 +553,8 @@ EOT
     end
 
     def export_zip(tmpdir, epubfile)
-      Dir.chdir(tmpdir) {|d| system("#{@producer.params["zip_stage1"]} #{epubfile} mimetype") }
-      Dir.chdir(tmpdir) {|d| system("#{@producer.params["zip_stage2"]} #{epubfile} META-INF OEBPS #{@producer.params["zip_addpath"]}") }
+      Dir.chdir(tmpdir) {|d| `#{@producer.params["zip_stage1"]} #{epubfile} mimetype` }
+      Dir.chdir(tmpdir) {|d| `#{@producer.params["zip_stage2"]} #{epubfile} META-INF OEBPS #{@producer.params["zip_addpath"]}` }
     end
 
     def legacy_cover_and_title_file(loadfile, writefile)


### PR DESCRIPTION
CI サーバで review-epubmaker 実行してみてたのですが何も出力されないで困っていたのですが、zipコマンドがインストールされてないのが原因でした。

原因が特定されやすいように、実行時のエラー出力は流したくて変更してみました。

systemu を使う方法などもあると思いますが、とりあえず意見を聞きたくプルリクエストしました。

参考

```
> system("hoge")
=> nil
```

```
> `hoge`
Errno::ENOENT: No such file or directory - hoge
        from (irb):2:in ``'
        from (irb):2
        from ~/.rbenv/versions/2.1.2/bin/irb:11:in `<main>'
```

http://qiita.com/tyabe/items/56c9fa81ca89088c5627
