### PR TITLE
Add entry to ImageFinder#entries with Builder#plot

### DIFF
--- a/lib/review/book/image_finder.rb
+++ b/lib/review/book/image_finder.rb
@@ -25,6 +25,13 @@ module ReVIEW
         Dir.glob(File.join(@basedir, "**/*.*"))
       end
 
+      def add_entry(path)
+        unless @entries.include?(path)
+          @entries << path
+        end
+        @entries
+      end
+
       def find_path(id)
         targets = target_list(id)
         targets.each do |target|

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -370,6 +370,7 @@ module ReVIEW
       cmd = cmds[command.to_sym]
       warn cmd
       system cmd
+      @chapter.image_index.image_finder.add_entry(file_path)
 
       image(lines, id, caption ||= "")
     end


### PR DESCRIPTION
graph 命令で作成したグラフが2つ目以降のものが image not bound になってしまうのを修正してみました。

1つ目のものはImageFInderが作成されるためちゃんと見つかるのですが、ふたつめ以降のものは使いまわすため、新しく生成した画像をみつけることができません。
普通に作業している場合は、ファイルが事前に生成されていることが多いため問題にならないようです。

graph で生成した場合に imageFinder の `@entries` に path を追加するようにしてみました。
