### PR TITLE
dvipdfmxでフォントマップを指定したい

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -153,7 +153,13 @@ module ReVIEW
           system("#{texcommand} -kanji=#{kanji} book.tex")
         end
         if File.exist?("book.dvi")
-          system("dvipdfmx -d 5 book.dvi")
+          opt = "-d 5"
+          if config.has_key?("pdffontmap")
+            opt << " -f #{config["pdffontmap"]}"
+          end
+          cmd = "dvipdfmx #{opt} book.dvi"
+          $stderr.puts cmd
+          system(cmd)
         end
       }
       FileUtils.cp("#{@path}/book.pdf", "#{@basedir}/#{bookname}.pdf")


### PR DESCRIPTION
PDFのフォントを切り替えたり、埋め込んだりするためにdvipdfmxに-fオプションを指定できるようにしました。
DebianのTeX Live 2014だとtexlive-lang-japaneseパッケージにptex-hiragino.mapが付属しているので、
config.ymlにpdffontmap: ptex-hiragino と追記すればフォントを埋め込めるようになります。
ただしこのmapファイルはdeluxeフォント向けでは無いのでレイアウトの
\usepackage[deluxe]{otf}
をコメントにする必要があります。

あと、reviewで組版するPDFはdeluxeフォントが必須なのかどうかのご意見を伺いたいです。
deluxeフォントの使用・非使用もオプションで切り替えられたほうがよいか?、
そもそもdeluxeフォントの必要性があるのかどうか、など
