### PR TITLE
ReVIEWHeaderListenerのcontentをHTMLエスケープするように変更

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -11,6 +11,7 @@ require 'review'
 require 'rexml/document'
 require 'rexml/streamlistener'
 require 'epubmaker'
+require 'cgi'
 
 module ReVIEW
  class EPUBMaker
@@ -510,7 +511,7 @@ EOT
 
     def text(text)
       unless @level.nil?
-        @content << text.gsub("\t", "　") # FIXME:区切り文字
+        @content << CGI.escapeHTML(text.gsub("\t", "　")) # FIXME:区切り文字
       end
     end
   end


### PR DESCRIPTION
見出しの文字列中に「&、<、>」などの文字が入っていると、epubmakerが生成するtoc-html.txtにはこれらの文字がそのまま出力され、EPUBの目次が正しく生成されない。このためReVIEWHeaderListener内でCGI.escapeHTMLを用いてエスケープするように変更。
