### PR TITLE
Raise errors if no latex tools are installed

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -22,6 +22,10 @@ module ReVIEW
     include FileUtils
     include ReVIEW::LaTeXUtils
 
+    def system(*args)
+      Kernel.system(*args) or raise("failed to run command: #{args.join(' ')}")
+    end
+
     def error(msg)
       $stderr.puts "#{File.basename($0, '.*')}: error: #{msg}"
       exit 1


### PR DESCRIPTION
review-pdfmaker(1)でLaTeXが入っていない時のエラーメッセージがとてもわかりにくいので、system()の戻り値をチェックしてもっとわかりやすいエラーを出すようにしました。
