### PR TITLE
implement list_header() and list_body() in markdownbuilder.rb

### DIFF
--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -49,6 +49,22 @@ module ReVIEW
       puts "\n"
     end
 
+    def list_header(id, caption)
+      if get_chap.nil?
+        puts %Q[リスト#{@chapter.list(id).number} #{compile_inline(caption)}]
+      else
+        puts %Q[リスト#{get_chap}.#{@chapter.list(id).number} #{compile_inline(caption)}]
+      end
+      puts '```'
+    end
+
+    def list_body(id, lines)
+      lines.each do |line|
+        puts detab(line)
+      end
+      puts '```'
+    end
+
     def ul_begin
       blank if @ul_indent == 0
       @ul_indent += 1

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -64,6 +64,23 @@ EOS
     assert_equal "```\nlineA\nlineB\n```\n", actual
   end
 
+  def test_list
+    actual = compile_block(<<-EOS)
+//list[name][caption]{
+AAA
+BBB
+//}
+    EOS
+
+    assert_equal <<-EOS, actual
+リスト1.1 caption
+```
+AAA
+BBB
+```
+    EOS
+  end
+
   def test_table
     actual = compile_block("//table{\ntestA\ttestB\n------------\ncontentA\tcontentB\n//}\n")
     assert_equal "|testA|testB|\n|:--|:--|\n|contentA|contentB|\n\n", actual


### PR DESCRIPTION
markdownbuilderがlist記法に対応していなかったので実装しました。

Re:VIEW記法のほうが表現力が高いので、キャプションについては「とりあえずつけているだけ」という状態です。
