### PR TITLE
fix index error in shallow column

### DIFF
--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -294,7 +294,7 @@ module ReVIEW
         items = []
         indexs = []
         headlines = []
-        inside_column_level = nil
+        inside_column = false
         src.each do |line|
           if m = HEADLINE_PATTERN.match(line)
             next if m[1].size > 10 # Ignore too deep index
@@ -302,17 +302,17 @@ module ReVIEW
 
             # column
             if m[2] == 'column'
-              inside_column_level = index
+              inside_column = true
               next
             end
             if m[2] == '/column'
-              inside_column_level = nil
+              inside_column = false
               next
             end
-            if (indexs.present? and indexs[-1] <= index) || (inside_column_level && index <= inside_column_level)
-              inside_column_level = nil
+            if indexs.blank? || index <= indexs[-1]
+              inside_column = false
             end
-            if inside_column_level
+            if inside_column
               next
             end
 

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -83,5 +83,20 @@ class IndexTest < Test::Unit::TestCase
     assert_equal [3,1], index['sec1-3|sec1-3-1'].number
     assert_equal "1.3.1", index.number('sec1-3|sec1-3-1')
   end
+
+  def test_HeadelineIndex4
+    src = <<-EOB
+= chap1
+====[column] c1
+== sec1-1
+== sec1-2
+=== sec1-2-1
+=== sec1-2-2
+    EOB
+    chap = Book::Chapter.new(nil, 1, '-', nil) # dummy
+    index = Book::HeadlineIndex.parse(src, chap)
+    assert_equal [2,2], index['sec1-2|sec1-2-2'].number
+    assert_equal "1.2.2", index.number('sec1-2|sec1-2-2')
+  end
 end
 


### PR DESCRIPTION
浅いレベルのコラムがあった時に、コラムが正しく閉じられず、参照がおかしくなることがあったのでpatchを書きました。patchをあてない場合、test_HeadelineIndex2がこけます。

inside_columをtrue/falseではなくコラムのレベルを持たせるようにして、コラムを閉じる判別に使っています。
