### PR TITLE
ReVIEW::Book::Base.load_default() -> ReVIEW::Book::Base.load()

### DIFF
--- a/bin/review-check
+++ b/bin/review-check
@@ -37,7 +37,7 @@ def main
     "inencoding" => "UTF-8",
     "outencoding" => "UTF-8"
   })
-  @book = ReVIEW::Book::Base.load_default
+  @book = ReVIEW::Book::Base.load
   @book.config = @config
 
   modes = nil

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -166,7 +166,7 @@ def _main
         end
       end
     when :dir
-      book = basedir ? ReVIEW::Book.load(basedir) : ReVIEW::Book::Base.load_default
+      book = basedir ? ReVIEW::Book.load(basedir) : ReVIEW::Book::Base.load
       book.config = config
       compiler = ReVIEW::Compiler.new(load_strategy_class(target, check_only))
       book.chapters.each do |chap|

--- a/bin/review-index
+++ b/bin/review-index
@@ -41,7 +41,7 @@ def _main
     "inencoding" => "UTF-8",
     "outencoding" => "UTF-8"
   }
-  book = ReVIEW::Book::Base.load_default
+  book = ReVIEW::Book::Base.load
 
   opts = OptionParser.new
   opts.version = ReVIEW::VERSION

--- a/bin/review-vol
+++ b/bin/review-vol
@@ -61,7 +61,7 @@ def main
     exit 1
   end
 
-  book = basedir ? ReVIEW::Book.load(basedir) : ReVIEW::Book::Base.load_default
+  book = basedir ? ReVIEW::Book.load(basedir) : ReVIEW::Book::Base.load
   book.config = @config
   if yamlfile
     book.load_config(yamlfile)

--- a/lib/review/book.rb
+++ b/lib/review/book.rb
@@ -26,7 +26,7 @@ module ReVIEW
   @default_book = nil
 
   def ReVIEW.book
-    @default_book ||= Book::Base.load_default
+    @default_book ||= Book::Base.load
   end
 
   module Book

--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -19,17 +19,11 @@ module ReVIEW
       attr_writer :config
 
       def self.load_default
-        basedir = "."
-        if File.file?("#{basedir}/CHAPS") ||
-            File.file?("#{basedir}/catalog.yml")
-          book = load(basedir)
-          book
-        else
-          new(basedir)
-        end
+        warn 'Book::Base.load_default() is obsoleted. Use Book::Base.load().'
+        load()
       end
 
-      def self.load(dir)
+      def self.load(dir = ".")
         update_rubyenv dir
         new(dir)
       end

--- a/lib/review/tocparser.rb
+++ b/lib/review/tocparser.rb
@@ -99,7 +99,7 @@ module ReVIEW
 
     def compile_label(line)
       b = ReVIEW::TEXTBuilder.new
-      dummy_book = ReVIEW::Book::Base.load_default
+      dummy_book = ReVIEW::Book::Base.load
       dummy_chapter = ReVIEW::Book::Chapter.new(dummy_book, 1, '-', nil, StringIO.new)
       dummy_loc = Location.new("", StringIO.new)
       b.bind(ReVIEW::Compiler.new(b), dummy_chapter, dummy_loc)

--- a/test/test_book.rb
+++ b/test/test_book.rb
@@ -11,15 +11,6 @@ class BookTest < Test::Unit::TestCase
     assert_equal ex_path, re_path, *options
   end
 
-  def test_s_load_default
-    Dir.mktmpdir do |dir|
-      File.open(File.join(dir, 'CHAPS'), 'w') {}
-      Dir.chdir(dir) do
-        assert_same_path dir, File.expand_path(Book.load_default.basedir), "error in dir CHAPS"
-      end
-    end
-  end
-
   def test_s_update_rubyenv
     save_load_path = $LOAD_PATH.dup
 

--- a/test/test_builder.rb
+++ b/test/test_builder.rb
@@ -26,7 +26,7 @@ class BuidlerTest < Test::Unit::TestCase
 
   def test_bind
     b = Builder.new
-    chap = ReVIEW::Book::Chapter.new(ReVIEW::Book::Base.load_default, nil, '-', nil)
+    chap = ReVIEW::Book::Chapter.new(ReVIEW::Book::Base.load, nil, '-', nil)
     assert_nothing_raised do
       b.bind(nil, chap, nil)
     end
@@ -39,7 +39,7 @@ class BuidlerTest < Test::Unit::TestCase
     end
 
     b = Builder.new
-    chapter = ReVIEW::Book::Chapter.new(ReVIEW::Book::Base.load_default, nil, '-', nil)
+    chapter = ReVIEW::Book::Chapter.new(ReVIEW::Book::Base.load, nil, '-', nil)
     b.bind(nil, chapter, nil)
     assert_equal '', b.result
   end
@@ -82,7 +82,7 @@ class BuidlerTest < Test::Unit::TestCase
         [:puts,  "#{utf8_str}\n", "#{expect}\n"],
       ].each do |m, instr, expstr|
         b = Builder.new
-        chapter = ReVIEW::Book::Chapter.new(ReVIEW::Book::Base.load_default, nil, '-', nil)
+        chapter = ReVIEW::Book::Chapter.new(ReVIEW::Book::Base.load, nil, '-', nil)
         b.bind(nil, chapter, nil)
         chapter.book.config = params
         b.__send__(m, instr)

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -42,7 +42,7 @@ class IndexTest < Test::Unit::TestCase
 == sec1-3
 ==== sec1-3-0-1
     EOB
-    book = Book::Base.load_default
+    book = Book::Base.load
     chap = Book::Chapter.new(book, 1, '-', nil) # dummy
     index = Book::HeadlineIndex.parse(src, chap)
     assert_equal [2,2], index['sec1-2|sec1-2-2'].number
@@ -59,7 +59,7 @@ class IndexTest < Test::Unit::TestCase
 == sec1-3
 === sec1-3-1
     EOB
-    book = Book::Base.load_default
+    book = Book::Base.load
     chap = Book::Chapter.new(book, 1, '-', nil) # dummy
     index = Book::HeadlineIndex.parse(src, chap)
     assert_equal [3,1], index['sec1-3|sec1-3-1'].number
@@ -77,7 +77,7 @@ class IndexTest < Test::Unit::TestCase
 == sec1-3
 === sec1-3-1
     EOB
-    book = Book::Base.load_default
+    book = Book::Base.load
     chap = Book::Chapter.new(book, 1, '-', nil) # dummy
     index = Book::HeadlineIndex.parse(src, chap)
     assert_equal [2,2], index['sec1-2|sec1-2-2'].number
@@ -96,7 +96,7 @@ class IndexTest < Test::Unit::TestCase
 === sec1-2-1
 === sec1-2-2
     EOB
-    book = Book::Base.load_default
+    book = Book::Base.load
     chap = Book::Chapter.new(book, 1, '-', nil) # dummy
     index = Book::HeadlineIndex.parse(src, chap)
     assert_equal [2,2], index['sec1-2|sec1-2-2'].number


### PR DESCRIPTION
ReVIEW::Book::Baseのコンストラクタを整理するものです。

ReVIEW::Book::Baseというのは「書籍」全体の情報を扱う、Re:VIEWのデータ構造の要にあたるクラスなのですが、現在コンストラクタが3種類あります。
- Base.new(basedir)
- Base.load(basedir)
- Base.load_deafult

`Base.new`が素のコンストラクタ、`Base.load`がreview-ext.rbの読み込みを行うコンストラクタで、`Base.load_default`がカレントのディレクトリ(実際には`"."`)をbasedirとした`Base.load`となっています。…というのはちょっと不正確で、以前はRe:VIEWのレポジトリで`*.re`が同一ディレクトリじゃなくてさらに深い階層のディレクトリに置かれていても動かせるようになっていたため、いろいろとトリックが入っていたのですが、その辺りは廃止の方向になっていた（一部で正しく動かなくなっていた）ので、整理されてほぼ`Base.load(".")`とほぼ同様の挙動になっています。

このpull requestは、Base.load_defaultを廃止して、今後は引数なしのBase.load()で同様の挙動になるようにするものです。
いきなり消すのはまずそうなので、まずはobsoleteのメッセージを出すようにしています。
