### PR TITLE
EPUBMaker: make dummy item hidden in nav file.

### DIFF
--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -342,8 +342,9 @@ EOT
           (level + 1).upto(item.level) do |n|
             if e.size == 0
               # empty span for epubcheck
-              es = e.add_element("span") 
-              es.add_text(REXML::Text.new("　", false, nil, true))
+              e.attributes["style"] = "list-style-type: none;"
+              es = e.add_element("span", {"style"=>"display:none;"})
+              es.add_text(REXML::Text.new("&nbsp;", false, nil, true))
             end
 
             e2 = e.add_element(type, {"class" => "toc-h#{n}"})


### PR DESCRIPTION
ダミーの`<li>`要素を見せないようにするパッチです。ついでに全角空白もnbspにしています。

修正前

``` html
<li><span>　</span>
```

修正後

``` html
<li style="list-style-type: none;"><span style="display:none;">&nbsp;</span>
```
