### PR TITLE
fix `@<hd>` use appendix_format when chapter 1.

### DIFF
--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -353,7 +353,7 @@ module ReVIEW
 
       def number(id)
         n = @chap.number
-        if @chap.on_APPENDIX? && @chap.number > 1 && @chap.number < 28
+        if @chap.on_APPENDIX? && @chap.number > 0 && @chap.number < 28
           type = @chap.book.config["appendix_format"].blank? ? "arabic" : @chap.book.config["appendix_format"].downcase.strip
           n = case type
               when "roman"

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -226,6 +226,38 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|test 「1.1.1 te_st」 test2|, actual
   end
 
+  def test_inline_hd_chap_postdef_roman
+    @chapter.book.config["appendix_format"] = "roman"
+    @chapter.instance_eval do
+      def on_APPENDIX?
+        true
+      end
+    end
+    def @chapter.headline_index
+      items = [Book::HeadlineIndex::Item.new("test", [1], "te_st")]
+      Book::HeadlineIndex.new(items, self)
+    end
+
+    actual = compile_inline("test @<hd>{test} test2")
+    assert_equal %Q|test 「I.1 te_st」 test2|, actual
+  end
+
+  def test_inline_hd_chap_postdef_alpha
+    @chapter.book.config["appendix_format"] = "alpha"
+    @chapter.instance_eval do
+      def on_APPENDIX?
+        true
+      end
+    end
+    def @chapter.headline_index
+      items = [Book::HeadlineIndex::Item.new("test", [1], "te_st")]
+      Book::HeadlineIndex.new(items, self)
+    end
+
+    actual = compile_inline("test @<hd>{test} test2")
+    assert_equal %Q|test 「A.1 te_st」 test2|, actual
+  end
+
   def test_inline_uchar
     actual = compile_inline("test @<uchar>{2460} test2")
     assert_equal %Q|test &#x2460; test2|, actual


### PR DESCRIPTION
付録の第1章を `@<hd>` で参照した場合だけ、appendix_format が使用されていなかったので、使用するようにしました。