### PR TITLE
review-pdfmaker remove a PDF file if already exists

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -37,9 +37,7 @@ module ReVIEW
 
     def check_book(config)
       pdf_file = config["bookname"]+".pdf"
-      if File.exist? pdf_file
-        error "file already exists:#{pdf_file}"
-      end
+      File.unlink(pdf_file) if File.exist?(pdf_file)
     end
 
     def build_path(config)

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -23,16 +23,10 @@ class PDFMakerTest < Test::Unit::TestCase
   def test_check_book_existed
     Dir.mktmpdir do |dir|
       Dir.chdir(dir) do
-        FileUtils.touch(File.join(dir, "sample.pdf"))
-        tmperr = $stderr
-        $stderr = StringIO.new
-        begin
-          assert_raises SystemExit do
-            @maker.check_book(@config)
-          end
-        ensure
-          $stderr = tmperr
-        end
+        pdf_file = File.join(dir, "sample.pdf")
+        FileUtils.touch(pdf_file)
+        @maker.check_book(@config)
+        assert !File.exist?(pdf_file)
       end
     end
   end


### PR DESCRIPTION
As a PDF file can be re-generated from source files, `review-pdfmaker` should
remove the file when the file exists rather than exiting with error.

`review-epubmaker` do the same way:
https://github.com/kmuto/review/blob/master/lib/review/epubmaker.rb#L44

This change simplify a continuous integration of books.