### PR TITLE
review-pdfmaker: add parameters dvicommand and dvioptions in config.yml

### DIFF
--- a/doc/sample.yml
+++ b/doc/sample.yml
@@ -39,6 +39,8 @@ stylesheet: stylesheet.css
 # texdocumentclass: ["jsarticle", "b5paper,oneside"]
 # LaTeX用のコマンドを指定する(platex or lualatex)
 # texcommand: "platex"
+# LaTeX用のオプションを指定する(default: "-kanji=#{kanji}")
+# texoptions: "-kanji=utf-8"
 # LaTeX用のdvi変換コマンドを指定する(dvipdfmx)
 # dvicommand: "dvipdfmx"
 # LaTeX用のdvi変換コマンドのオプションを指定する

--- a/doc/sample.yml
+++ b/doc/sample.yml
@@ -39,6 +39,10 @@ stylesheet: stylesheet.css
 # texdocumentclass: ["jsarticle", "b5paper,oneside"]
 # LaTeX用のコマンドを指定する(platex or lualatex)
 # texcommand: "platex"
+# LaTeX用のdvi変換コマンドを指定する(dvipdfmx)
+# dvicommand: "dvipdfmx"
+# LaTeX用のdvi変換コマンドのオプションを指定する
+# dvioptions: "-d 5"
 # 目次として抽出するレベル
 toclevel: 3
 # セクション番号を表示するレベル

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -149,15 +149,25 @@ module ReVIEW
         ## do compile
         enc = config["params"].to_s.split(/\s+/).find{|i| i =~ /\A--outencoding=/ }
         kanji = 'utf8'
-        if enc
-          kanji = enc.split(/\=/).last.gsub(/-/, '').downcase
+        texcommand = "platex"
+        dvicommand = "dvipdfmx"
+        dvioptions = "-d 5"
+
+        if ENV["REVIEW_SAFE_MODE"].to_i & 4 > 0
+          warn "command configuration is prohibited in safe mode. ignored."
+        else
+          texcommand = config["texcommand"] if config["texcommand"]
+          dvicommand = config["dvicommand"] if config["dvicommand"]
+          dvioptions = config["dvioptions"] if config["dvioptions"]
+          if enc
+            kanji = enc.split(/\=/).last.gsub(/-/, '').downcase
+          end
         end
-        texcommand = config["texcommand"] || "platex"
         3.times do
           system_or_raise("#{texcommand} -kanji=#{kanji} book.tex")
         end
         if File.exist?("book.dvi")
-          system_or_raise("dvipdfmx -d 5 book.dvi")
+          system_or_raise("#{dvicommand} #{dvioptions} book.dvi")
         end
       }
       FileUtils.cp("#{@path}/book.pdf", "#{@basedir}/#{bookname}.pdf")

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -150,6 +150,7 @@ module ReVIEW
         enc = config["params"].to_s.split(/\s+/).find{|i| i =~ /\A--outencoding=/ }
         kanji = 'utf8'
         texcommand = "platex"
+        texoptions = "-kanji=#{kanji}"
         dvicommand = "dvipdfmx"
         dvioptions = "-d 5"
 
@@ -161,10 +162,12 @@ module ReVIEW
           dvioptions = config["dvioptions"] if config["dvioptions"]
           if enc
             kanji = enc.split(/\=/).last.gsub(/-/, '').downcase
+            texoptions = "-kanji=#{kanji}"
           end
+          texoptions = config["texoptions"] if config["texoptions"]
         end
         3.times do
-          system_or_raise("#{texcommand} -kanji=#{kanji} book.tex")
+          system_or_raise("#{texcommand} #{texoptions} book.tex")
         end
         if File.exist?("book.dvi")
           system_or_raise("#{dvicommand} #{dvioptions} book.dvi")


### PR DESCRIPTION
#342 に対応するべく、`dvicommand`と`dvioptions`というパラメタを`config.yml`に設定できるようにしてみました。

REVIEW_SAFE_MODEで有効にしないようにもしてあります。
