### PR TITLE
fix I18n class to allow delayed initialization

### DIFF
--- a/bin/review-compile
+++ b/bin/review-compile
@@ -19,6 +19,7 @@ $LOAD_PATH.unshift((bindir + '../lib').realpath)
 require 'review'
 require 'review/compiler'
 require 'review/book'
+require 'review/i18n'
 require 'fileutils'
 require 'optparse'
 
@@ -143,6 +144,7 @@ def _main
 
   begin
     config["builder"] = target
+    ReVIEW::I18n.setup(config["language"])
 
     case mode
     when :files

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -36,6 +36,7 @@ module ReVIEW
 
   def produce(yamlfile, bookname=nil)
     load_yaml(yamlfile)
+    I18n.setup(@params["language"])
     bookname = @params["bookname"] if bookname.nil?
     booktmpname = "#{bookname}-epub"
 

--- a/lib/review/i18n.rb
+++ b/lib/review/i18n.rb
@@ -3,7 +3,9 @@ require 'yaml'
 
 module ReVIEW
   class I18n
-    def self.setup(ymlfile = "locale.yml")
+    def self.setup(locale="ja", ymlfile = "locale.yml")
+      @i18n = ReVIEW::I18n.new(locale)
+
       lfile = nil
       if ymlfile
         lfile = File.expand_path(ymlfile, Dir.pwd)
@@ -14,24 +16,17 @@ module ReVIEW
         end
       end
 
-      I18n.i18n "ja"
       if lfile && File.file?(lfile)
         @i18n.update_localefile(lfile)
-      end
-    rescue
-      I18n.i18n "ja"
-    end
-
-    def self.i18n(locale, user_i18n = {})
-      locale ||= "en"
-      @i18n = ReVIEW::I18n.new(locale)
-      unless user_i18n.empty?
-        @i18n.update(user_i18n)
       end
     end
 
     def self.t(str, args = nil)
       @i18n.t(str, args)
+    end
+
+    def self.update(user_i18n, locale = nil)
+      @i18n.update(user_i18n, locale)
     end
 
 
@@ -72,6 +67,4 @@ module ReVIEW
       str
     end
   end
-
-  I18n.setup
 end

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -91,6 +91,7 @@ module ReVIEW
       config.merge!(YAML.load_file(yamlfile))
       # YAML configs will be overridden by command line options.
       config.merge!(cmd_config)
+      I18n.setup(config["language"])
       generate_pdf(config, yamlfile)
     end
 

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -24,6 +24,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     @chapter = Book::Chapter.new(@book, 1, '-', nil, StringIO.new)
     location = Location.new(nil, nil)
     @builder.bind(@compiler, @chapter, location)
+    I18n.setup("ja")
   end
 
   def test_xmlns_ops_prefix_epub3

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -38,7 +38,7 @@ class I18nTest < Test::Unit::TestCase
         Dir.chdir(dir) do
           file = File.join(dir, "foo.yml")
           File.open(file, "w"){|f| f.write("locale: ja\nfoo: \"bar\"\n")}
-          I18n.setup("foo.yml")
+          I18n.setup("ja","foo.yml")
           assert_equal "bar", I18n.t("foo")
         end
       end
@@ -61,8 +61,7 @@ class I18nTest < Test::Unit::TestCase
         Dir.chdir(dir) do
           file = File.join(dir, "foo.yml")
           File.open(file, "w"){|f| f.write("locale: ja\nfoo: \"bar\"\n")}
-          I18n.setup(nil)
-          I18n.setup("foo.yml")
+          I18n.setup("ja", "foo.yml")
           assert_equal "bar", I18n.t("foo")
         end
       end
@@ -70,7 +69,7 @@ class I18nTest < Test::Unit::TestCase
   end
 
   def test_ja
-    I18n.i18n "ja"
+    I18n.setup("ja")
     assert_equal "図", I18n.t("image")
     assert_equal "表", I18n.t("table")
     assert_equal "第1章", I18n.t("chapter", 1)
@@ -78,15 +77,16 @@ class I18nTest < Test::Unit::TestCase
   end
 
   def test_ja_with_user_i18n
-    I18n.i18n "ja", {"image" => "ず"}
-    assert_equal "ず", I18n.t("image")
-    assert_equal "表", I18n.t("table")
-    assert_equal "第1章", I18n.t("chapter", 1) 
-    assert_equal "etc", I18n.t("etc")
+    i18n = I18n.new("ja")
+    i18n.update({"image" => "ず"}, "ja")
+    assert_equal "ず", i18n.t("image")
+    assert_equal "表", i18n.t("table")
+    assert_equal "第1章", i18n.t("chapter", 1)
+    assert_equal "etc", i18n.t("etc")
   end
 
   def test_en
-    I18n.i18n "en"
+    I18n.setup "en"
     assert_equal "Figure ", I18n.t("image")
     assert_equal "Table ", I18n.t("table")
     assert_equal "Chapter 1", I18n.t("chapter", 1)
@@ -94,7 +94,7 @@ class I18nTest < Test::Unit::TestCase
   end
 
   def test_nil
-    I18n.i18n "nil"
+    I18n.setup "nil"
     assert_equal "image", I18n.t("image")
     assert_equal "table", I18n.t("table")
     assert_equal "etc", I18n.t("etc")
@@ -107,7 +107,7 @@ class I18nTest < Test::Unit::TestCase
   end
 
   def _setup_htmlbuilder
-    I18n.i18n "en"
+    I18n.setup "en"
     @builder = HTMLBuilder.new()
     @config = {
       "secnolevel" => 2,    # for IDGXMLBuilder, HTMLBuilder
@@ -140,6 +140,6 @@ class I18nTest < Test::Unit::TestCase
   end
 
   def teardown
-    I18n.i18n "ja"
+    I18n.setup "ja"
   end
 end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -25,6 +25,7 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     @chapter = Book::Chapter.new(@book, 1, '-', nil, StringIO.new)
     location = Location.new(nil, nil)
     @builder.bind(@compiler, @chapter, location)
+    I18n.setup("ja")
   end
 
   def test_headline_level1

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -24,6 +24,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     @chapter = Book::Chapter.new(@book, 1, 'chap1', nil, StringIO.new)
     location = Location.new(nil, nil)
     @builder.bind(@compiler, @chapter, location)
+    I18n.setup("ja")
   end
 
   def test_headline_level1

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -15,9 +15,10 @@ class PDFMakerTest < Test::Unit::TestCase
                      "version" => 2,
                      "urnid" => "http://example.jp/",
                      "date" => "2011-01-01",
-                     "language" => "en",
+                     "language" => "ja",
                    })
     @output = StringIO.new
+    I18n.setup(@config["language"])
   end
 
   def test_check_book_existed
@@ -120,7 +121,7 @@ class PDFMakerTest < Test::Unit::TestCase
       "contact"=>"tarou@example.jp",
     })
     Dir.mktmpdir do |dir|
-      I18n.i18n("ja", {"prt" => "印刷所"})
+      I18n.update({"prt" => "印刷所"},"ja")
       okuduke = @maker.make_colophon(@config)
       assert_equal("著　者 & テスト太郎、テスト次郎 \\\\\n監　修 & 監修三郎 \\\\\nイラスト & イラスト七郎、イラスト八郎 \\\\\n発行所 & テスト出版 \\\\\n連絡先 & tarou@example.jp \\\\\n印刷所 & テスト印刷 \\\\\n",
                    okuduke)

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -15,7 +15,8 @@ class TOPBuidlerTest < Test::Unit::TestCase
     @config.merge!({
       "secnolevel" => 2,
       "inencoding" => "UTF-8",
-      "outencoding" => "UTF-8"
+      "outencoding" => "UTF-8",
+      "language" => "ja",
     })
     @book = Book::Base.new(nil)
     @book.config = @config
@@ -30,6 +31,7 @@ class TOPBuidlerTest < Test::Unit::TestCase
         puts msg
       end
     end
+    I18n.setup(@config["language"])
   end
 
   def test_headline_level1


### PR DESCRIPTION
* use `I18n.setup(language)` after `config["language"]` is loaded.
  * remove `I18n.setup` in lib/review/i18n.rb.
* `I18n.i18n()` is removed because you should use I18n.setup in your program.
  * If you need to update I18n catalog, use `I18n.update()`.
