### PR TITLE
support multi languages in locale.yml

### DIFF
--- a/lib/review/i18n.rb
+++ b/lib/review/i18n.rb
@@ -52,8 +52,16 @@ module ReVIEW
     def update_localefile(path)
       user_i18n = YAML.load_file(path)
       locale = user_i18n["locale"]
-      user_i18n.delete("locale")
-      @store[locale].merge!(user_i18n)
+      if locale
+        user_i18n.delete("locale")
+        @store[locale].merge!(user_i18n)
+      else
+        key = user_i18n.keys.first
+        if !user_i18n[key].kind_of? Hash
+          raise KeyError, "Invalid locale file: #{path}"
+        end
+        @store.merge!(user_i18n)
+      end
     end
 
     def update(user_i18n, locale = nil)

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -66,6 +66,31 @@ class I18nTest < Test::Unit::TestCase
         end
       end
     end
+
+    def test_load_locale_yml_i18n
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          file = File.join(dir, "locale.yml")
+          File.open(file, "w"){|f| f.write("ja:\n  foo: \"bar\"\nen:\n  foo: \"buz\"\n")}
+          I18n.setup
+          assert_equal "bar", I18n.t("foo")
+          I18n.setup("en")
+          assert_equal "buz", I18n.t("foo")
+        end
+      end
+    end
+
+    def test_load_locale_invalid_yml
+      Dir.mktmpdir do |dir|
+        Dir.chdir(dir) do
+          file = File.join(dir, "locale.yml")
+          File.open(file, "w"){|f| f.write("local: ja\nfoo: \"bar\"\n")}
+          assert_raises(ReVIEW::KeyError) do
+            I18n.setup
+          end
+        end
+      end
+    end
   end
 
   def test_ja


### PR DESCRIPTION
#379 に関連して、locale.ymlにi18n.ymlのように複数言語のL10Nを入れられるようにしました。
`locale: XXX` というところがあれば単一のロケール、そうでなくてハッシュの入れ子になっていれば複数のロケール、という様に判別するようになります。