### PR TITLE
add an argument lang to //list, //listnum, //emlist, //emlistnum, and //cmd and highlighting

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -130,15 +130,15 @@ module ReVIEW
 
     defblock :read, 0
     defblock :lead, 0
-    defblock :list, 2
-    defblock :emlist, 0..1
+    defblock :list, 2..3
+    defblock :emlist, 0..2
     defblock :cmd, 0..1
     defblock :table, 0..2
     defblock :quote, 0
     defblock :image, 2..3, true
     defblock :source, 0..1
-    defblock :listnum, 2
-    defblock :emlistnum, 0..1
+    defblock :listnum, 2..3
+    defblock :emlistnum, 0..2
     defblock :bibpaper, 2..3, true
     defblock :doorquote, 1
     defblock :talk, 0

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -425,14 +425,14 @@ EOT
 
     alias_method :lead, :read
 
-    def list(lines, id, caption)
+    def list(lines, id, caption, lang = nil)
       puts %Q[<div class="caption-code">]
       begin
         list_header id, caption
       rescue KeyError
         error "no such list: #{id}"
       end
-      list_body id, lines
+      list_body id, lines, lang
       puts '</div>'
     end
 
@@ -444,11 +444,11 @@ EOT
       end
     end
 
-    def list_body(id, lines)
+    def list_body(id, lines, lang)
       id ||= ''
       print %Q[<pre class="list">]
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
-      lexer = File.extname(id).gsub(/\./, '')
+      lexer = lang || File.extname(id).gsub(/\./, '')
       puts highlight(:body => body, :lexer => lexer, :format => 'html')
       puts '</pre>'
     end
@@ -475,47 +475,49 @@ EOT
       puts '</pre>'
     end
 
-    def listnum(lines, id, caption)
+    def listnum(lines, id, caption, lang = nil)
       puts %Q[<div class="code">]
       begin
         list_header id, caption
       rescue KeyError
         error "no such list: #{id}"
       end
-      listnum_body lines
+      listnum_body lines, lang
       puts '</div>'
     end
 
-    def listnum_body(lines)
+    def listnum_body(lines, lang)
       print %Q[<pre class="list">]
-      lines.each_with_index do |line, i|
-        puts detab((i+1).to_s.rjust(2) + ": " + line)
-      end
+      body = lines.inject(''){|i, j| i + detab(j) + "\n"}
+      lexer = lang
+      puts highlight(:body => body, :lexer => lexer, :format => 'html',
+                     :options => {:linenos => 'inline'})
       puts '</pre>'
     end
 
-    def emlist(lines, caption = nil)
+    def emlist(lines, caption = nil, lang = nil)
       puts %Q[<div class="emlist-code">]
       if caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
       print %Q[<pre class="emlist">]
-      lines.each do |line|
-        puts detab(line)
-      end
+      body = lines.inject(''){|i, j| i + detab(j) + "\n"}
+      lexer = lang
+      puts highlight(:body => body, :lexer => lexer, :format => 'html')
       puts '</pre>'
       puts '</div>'
     end
 
-    def emlistnum(lines, caption = nil)
+    def emlistnum(lines, caption = nil, lang = nil)
       puts %Q[<div class="emlistnum-code">]
       if caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
       print %Q[<pre class="emlist">]
-      lines.each_with_index do |line, i|
-        puts detab((i+1).to_s.rjust(2) + ": " + line)
-      end
+      body = lines.inject(''){|i, j| i + detab(j) + "\n"}
+      lexer = lang
+      puts highlight(:body => body, :lexer => lexer, :format => 'html',
+                     :options => {:linenos => 'inline'})
       puts '</pre>'
       puts '</div>'
     end
@@ -526,9 +528,9 @@ EOT
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
       print %Q[<pre class="cmd">]
-      lines.each do |line|
-        puts detab(line)
-      end
+      body = lines.inject(''){|i, j| i + detab(j) + "\n"}
+      lexer = 'shell-session'
+      puts highlight(:body => body, :lexer => lexer, :format => 'html')
       puts '</pre>'
       puts '</div>'
     end

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -491,7 +491,7 @@ EOT
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = lang
       puts highlight(:body => body, :lexer => lexer, :format => 'html',
-                     :options => {:linenos => 'inline'})
+                     :options => {:linenos => 'inline', :nowrap => false})
       puts '</pre>'
     end
 
@@ -517,7 +517,7 @@ EOT
       body = lines.inject(''){|i, j| i + detab(j) + "\n"}
       lexer = lang
       puts highlight(:body => body, :lexer => lexer, :format => 'html',
-                     :options => {:linenos => 'inline'})
+                     :options => {:linenos => 'inline', :nowrap => false})
       puts '</pre>'
       puts '</div>'
     end

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -44,7 +44,10 @@ module ReVIEW
       body = ops[:body] || ''
       lexer = ops[:lexer] || ''
       format = ops[:format] || ''
-
+      options = {:nowrap => true, :noclasses => true}
+      if ops[:options] && ops[:options].kind_of?(Hash)
+        options.merge!(ops[:options])
+      end
       return body if @book.config["pygments"].nil?
 
       begin
@@ -52,10 +55,7 @@ module ReVIEW
         begin
           Pygments.highlight(
                    unescape_html(body),
-                   :options => {
-                               :nowrap => true,
-                               :noclasses => true
-                             },
+                   :options => options,
                    :formatter => format,
                    :lexer => lexer)
         rescue MentosError

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -475,9 +475,56 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|<div class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list">test1\ntest1.5\n\ntest<span style="color: #008000; font-weight: bold">&lt;i&gt;</span>2<span style="color: #008000; font-weight: bold">&lt;/i&gt;</span>\n</pre>\n</div>\n|, actual
   end
 
+  def test_list_pygments_lang
+    def @chapter.list(id)
+      Book::ListIndex::Item.new("samplelist",1)
+    end
+    begin
+      require 'pygments'
+    rescue LoadError
+      return true
+    end
+    @book.config["pygments"] = true
+    actual = compile_block("//list[samplelist][this is @<b>{test}<&>_][ruby]{\ndef foo(a1, a2=:test)\n  (1..3).times{|i| a.include?(:foo)}\n  return true\nend\n\n//}\n")
+
+    assert_equal %Q|<div class=\"caption-code\">\n<p class=\"caption\">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n| +
+                 %Q|<pre class=\"list\"><span style=\"color: #008000; font-weight: bold\">def</span> <span style=\"color: #0000FF\">foo</span>(a1, a2<span style=\"color: #666666\">=</span><span style=\"color: #19177C\">:test</span>)\n| +
+                 %Q|  (<span style=\"color: #666666\">1.</span>.<span style=\"color: #666666\">3</span>)<span style=\"color: #666666\">.</span>times{<span style=\"color: #666666\">\|</span>i<span style=\"color: #666666\">\|</span> a<span style=\"color: #666666\">.</span>include?(<span style=\"color: #19177C\">:foo</span>)}\n| +
+                 %Q|  <span style=\"color: #008000; font-weight: bold\">return</span> <span style=\"color: #008000\">true</span>\n| +
+                 %Q|<span style=\"color: #008000; font-weight: bold\">end</span>\n| +
+                 %Q|</pre>\n| +
+                 %Q|</div>\n|, actual
+  end
+
+  def test_listnum_pygments_lang
+    def @chapter.list(id)
+      Book::ListIndex::Item.new("samplelist",1)
+    end
+    begin
+      require 'pygments'
+    rescue LoadError
+      return true
+    end
+    @book.config["pygments"] = true
+    actual = compile_block("//listnum[samplelist][this is @<b>{test}<&>_][ruby]{\ndef foo(a1, a2=:test)\n  (1..3).times{|i| a.include?(:foo)}\n  return true\nend\n\n//}\n")
+
+    assert_equal "<div class=\"code\">\n<p class=\"caption\">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class=\"list\"><span style=\"color: #008000; font-weight: bold\">def</span> <span style=\"color: #0000FF\">foo</span>(a1, a2<span style=\"color: #666666\">=</span><span style=\"color: #19177C\">:test</span>)\n  (<span style=\"color: #666666\">1.</span>.<span style=\"color: #666666\">3</span>)<span style=\"color: #666666\">.</span>times{<span style=\"color: #666666\">|</span>i<span style=\"color: #666666\">|</span> a<span style=\"color: #666666\">.</span>include?(<span style=\"color: #19177C\">:foo</span>)}\n  <span style=\"color: #008000; font-weight: bold\">return</span> <span style=\"color: #008000\">true</span>\n<span style=\"color: #008000; font-weight: bold\">end</span>\n</pre>\n</div>\n", actual
+  end
+
   def test_emlist
     actual = compile_block("//emlist{\nlineA\nlineB\n//}\n")
     assert_equal %Q|<div class="emlist-code">\n<pre class="emlist">lineA\nlineB\n</pre>\n</div>\n|, actual
+  end
+
+  def test_emlist_pygments_lang
+    begin
+      require 'pygments'
+    rescue LoadError
+      return true
+    end
+    @book.config["pygments"] = true
+    actual = compile_block("//emlist[][sql]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
+    assert_equal "<div class=\"emlist-code\">\n<pre class=\"emlist\"><span style=\"color: #008000; font-weight: bold\">SELECT</span> <span style=\"color: #008000; font-weight: bold\">COUNT</span>(<span style=\"color: #666666\">*</span>) <span style=\"color: #008000; font-weight: bold\">FROM</span> tests <span style=\"color: #008000; font-weight: bold\">WHERE</span> tests.<span style=\"color: #008000; font-weight: bold\">no</span> <span style=\"color: #666666\">&gt;</span> <span style=\"color: #666666\">10</span> <span style=\"color: #008000; font-weight: bold\">AND</span> test.name <span style=\"color: #008000; font-weight: bold\">LIKE</span> <span style=\"color: #BA2121\">&#39;ABC%&#39;</span>\n</pre>\n</div>\n", actual
   end
 
   def test_emlist_caption
@@ -499,6 +546,17 @@ class HTMLBuidlerTest < Test::Unit::TestCase
   def test_cmd
     actual = compile_block("//cmd{\nlineA\nlineB\n//}\n")
     assert_equal %Q|<div class="cmd-code">\n<pre class="cmd">lineA\nlineB\n</pre>\n</div>\n|, actual
+  end
+
+  def test_cmd_pygments
+    begin
+      require 'pygments'
+    rescue LoadError
+      return true
+    end
+    @book.config["pygments"] = true
+    actual = compile_block("//cmd{\nlineA\nlineB\n//}\n")
+    assert_equal "<div class=\"cmd-code\">\n<pre class=\"cmd\"><span style=\"color: #888888\">lineA</span>\n<span style=\"color: #888888\">lineB</span>\n</pre>\n</div>\n", actual
   end
 
   def test_cmd_caption


### PR DESCRIPTION
まずはPygments対応の拡張として、`//list`や`//emlist`等に引数を追加してlangを指定できるようにしました。

↓こんな感じのソースが、Pygments有効時には、

```review
== listnum

//listnum[foo][listnumのサンプル][ruby]{
def foo(aa, bb=nil, cc=:foo, dd="hoge")
  10.times do |i|
    "aaa" + %q|aaa| + 'hoge' + <<EOB
aaaaa
bbb
EOB
  end
  return 1
end
//}

== emlist

//emlist[][ruby]{
def foo(aa, bb=nil, cc=:foo, dd="hoge")
  10.times do |i|
    "aaa" + %q|aaa| + 'hoge' + <<EOB
aaaaa
bbb
EOB
  end
  return 1
end
//}
```

↓こんな感じになります。

![2015-02-04 3 36 02](https://cloud.githubusercontent.com/assets/10401/6026572/263b25b8-ac1f-11e4-9ad0-64b3669f3cb0.png)