### PR TITLE
LATEXBuilder: support syntax highlighting with listings

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -12,6 +12,7 @@ require 'review/extentions'
 require 'review/preprocessor'
 require 'review/exception'
 require 'lineinput'
+require 'strscan'
 
 module ReVIEW
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -240,7 +240,7 @@ module ReVIEW
       if highlight_listings?
         common_code_block_lst(lines, 'reviewemlistlst', 'title', caption, lang)
       else
-        common_code_block(lines, 'reviewemlist', caption, lang) do |line|
+        common_code_block(lines, 'reviewemlist', caption, lang) do |line, idx|
           detab(line) + "\n"
         end
       end

--- a/lib/review/layout.tex.erb
+++ b/lib/review/layout.tex.erb
@@ -6,6 +6,10 @@
 \usepackage{wrapfig}
 \definecolor{shadecolor}{gray}{0.9}
 \definecolor{shadecolorb}{gray}{0.1}
+\definecolor{reviewgreen}{rgb}{0,0.4,0}
+\definecolor{reviewblue}{rgb}{0.2,0.2,0.4}
+\definecolor{reviewred}{rgb}{0.7,0,0}
+\definecolor{reviewdarkred}{rgb}{0.3,0,0}
 \usepackage[utf8]{inputenc}
 \usepackage{ascmac}
 \usepackage{float}
@@ -41,6 +45,43 @@
 \usepackage[dvipdfm,bookmarks=true,bookmarksnumbered=true,colorlinks=true,%
             pdftitle={<%= values["booktitle"] %>},%
             pdfauthor={<%= values["aut"] %>}]{hyperref}
+
+<% if config["highlight"] && config["highlight"]["latex"] == "listings" %>
+<%   if config["language"] == "ja" %>
+\usepackage{listings,jlisting}
+<%   else %>
+\usepackage{listings}
+<%   end %>
+\renewcommand{\lstlistingname}{<%I18n.t("list")%>}
+\lstset{%
+  breaklines=true,%
+  breakautoindent=false,%
+  breakindent=0pt,%
+  fontadjust=true,%
+  backgroundcolor=\color{shadecolor},%
+  frame=single,%
+  framerule=0pt,%
+  basicstyle=\ttfamily\scriptsize,%
+  commentstyle=\color{reviewgreen},%
+  identifierstyle=\color{reviewblue},%
+  stringstyle=\color{reviewred},%
+  keywordstyle=\bfseries\color{reviewdarkred},%
+}
+\lstnewenvironment{reviewemlistlst}[1][]{%
+  \lstset{#1}}{}
+
+\lstnewenvironment{reviewemlistnumlst}[1][]{%
+  \lstset{numbers=left, #1}}{}
+
+\lstnewenvironment{reviewlistlst}[1][]{%
+  \lstset{#1}}{}
+
+\lstnewenvironment{reviewlistnumlst}[1][]{%
+  \lstset{numbers=left, #1}}{}
+
+\lstnewenvironment{reviewcmdlst}[1][]{%
+  \lstset{backgroundcolor=\color{white}, frameround=tttt, frame=trbl, #1}}{}
+<% end %>
 
 \newenvironment{reviewimage}{%
   \begin{figure}[H]
@@ -166,6 +207,8 @@
   \appendix}
 
 \makeatletter
+%% maxwidth is the original width if it is less than linewidth
+%% otherwise use linewidth (to make sure the graphics do not exceed the margin)
 \def\maxwidth{%
   \ifdim\Gin@nat@width>\linewidth
     \linewidth

--- a/test/sample-book/src/sty/reviewmacro.sty
+++ b/test/sample-book/src/sty/reviewmacro.sty
@@ -18,4 +18,22 @@
 %% using Helvetica as sans-serif
 \renewcommand{\sfdefault}{phv}
 
+%% for listings
+%\renewcommand{\lstlistingname}{List}
+%\lstset{%
+%  breaklines=true,%
+%  breakautoindent=false,%
+%  breakindent=0pt,%
+%  fontadjust=true,%
+%  backgroundcolor=\color{shadecolor},%
+%  frame=single,%
+%  framerule=0pt,%
+%  basicstyle=\ttfamily\scriptsize,%
+%  commentstyle=\color{reviewgreen},%
+%  identifierstyle=\color{reviewblue},%
+%  stringstyle=\color{reviewred},%
+%  keywordstyle=\bfseries\color{reviewdarkred},%
+%}
+
+
 \sloppy

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -235,9 +235,23 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|\n\\reviewcmdcaption{cap1}\n\\begin{reviewcmd}\nfoo\nbar\n\nbuz\n\\end{reviewcmd}\n|, actual
   end
 
+  def test_cmd_lst
+    @book.config["highlight"] = {}
+    @book.config["highlight"]["latex"] = "listings"
+    actual = compile_block("//cmd{\nfoo\nbar\n\nbuz\n//}\n")
+    assert_equal %Q|\\vspace{-1.5em}\\begin{reviewcmdlst}[title={\\relax},language={}]\nfoo\nbar\n\nbuz\n\\end{reviewcmdlst}\n|, actual
+  end
+
   def test_emlist
     actual = compile_block("//emlist{\nfoo\nbar\n\nbuz\n//}\n")
     assert_equal %Q|\n\\begin{reviewemlist}\nfoo\nbar\n\nbuz\n\\end{reviewemlist}\n|, actual
+  end
+
+  def test_emlist_lst
+    @book.config["highlight"] = {}
+    @book.config["highlight"]["latex"] = "listings"
+    actual = compile_block("//emlist[][sql]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
+    assert_equal %Q|\n\\vspace{-1.5em}\\begin{reviewemlistlst}[title={\\relax},language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewemlistlst}\n|, actual
   end
 
   def test_emlist_caption
@@ -254,6 +268,18 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     @config["tabwidth"] = 4
     actual = compile_block("//emlist{\n\tfoo\n\t\tbar\n\n\tbuz\n//}\n")
     assert_equal %Q|\n\\begin{reviewemlist}\n    foo\n        bar\n\n    buz\n\\end{reviewemlist}\n|, actual
+  end
+
+  def test_listnum
+    actual = compile_block("//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
+    assert_equal %Q|\\reviewlistcaption{リスト1.1: ruby}\n\\reviewlistcaption{ruby}\n\\begin{reviewlist}\n 1: class Foo\n 2:   def foo\n 3:     bar\n 4: \n 5:     buz\n 6:   end\n 7: end\n\\end{reviewlist}\n|, actual
+  end
+
+  def test_listnum_lst
+    @book.config["highlight"] = {}
+    @book.config["highlight"]["latex"] = "listings"
+    actual = compile_block("//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
+    assert_equal %Q|\\begin{reviewlistnumlst}[caption={ruby},language={}]\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n\\end{reviewlistnumlst}\n|, actual
   end
 
   def test_quote


### PR DESCRIPTION
LaTeX版の方で、listings packageをサポートしてみました。

こんな感じに書くと、

```review
== emlist

//listnum[hoge][Rubyコードのサンプル][ruby]{
##
# Fooクラスは云々かんぬん
#
class Foo

  ##
  #  doing foo
  #
  def foo(aa, bb = "test", cc = :test)
    return bar(aa, bb) + 1 + 2
  end
end
//}


== cmd

//cmd[コンソール出力のサンプル]{
$ sudo su
# cat hoge.txt
aaa
bbb
ccc

# cat hoge.txt
aaaaaaaaaaaaaaaaaaaaaaaaaa
bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb bbb 
ccc

//}
```

こうなります。

![2015-02-07 2 06 06](https://cloud.githubusercontent.com/assets/10401/6083676/ccf4b220-ae6d-11e4-852d-0f961540a5e5.png)
