### PR TITLE
review-initで作成されるreファイルのエンコーディングを明示する

### DIFF
--- a/bin/review-init
+++ b/bin/review-init
@@ -64,7 +64,7 @@ def generate_dir(dir)
 end
 
 def generate_sample(dir)
-  File.open("#{dir}/#{File.basename(dir)}.re", "w") do |file|
+  File.open("#{dir}/#{File.basename(dir)}.re", "w:utf8") do |file|
     file.write("= ")
   end
 end


### PR DESCRIPTION
``` 
$ review-init hoge
```
で作成されるhoge.reファイルのエンコードが、自分の環境ではSJISになります。
環境：ubuntu12(virtualbox on Windows8.1 64bit)

SJISのreファイルではreview-pdfmakerした際に正しく日本語が解釈されないので、
UTF-8エンコードを明示してデフォルトのファイルを作成するほうが良いと思います。