### PR TITLE
use pygments with config.yml "highlight: {html: pygments}"

### DIFF
--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -40,6 +40,11 @@ module ReVIEW
       str.gsub('-', '&#45;')
     end
 
+    def highlight_pygments?
+      @book.config["pygments"].present? ||
+        @book.config["highlight"] && @book.config["highlight"]["html"] == "pygments"
+    end
+
     def highlight(ops)
       body = ops[:body] || ''
       lexer = ops[:lexer].blank? ? 'text' : ops[:lexer]
@@ -48,7 +53,7 @@ module ReVIEW
       if ops[:options] && ops[:options].kind_of?(Hash)
         options.merge!(ops[:options])
       end
-      return body if @book.config["pygments"].nil?
+      return body if !highlight_pygments?
 
       begin
         require 'pygments'


### PR DESCRIPTION
Pygmentsを使ったシンタックスハイライトを使う際、現状はconfig.ymlに、

```yml
pygments: true
```

と書いて使うことになっています。

が、他のシンタックスハイライトを使いたい場合や、builderごとに使い分けたい場合もあります。
そのため、以下の様な形で設定できればと思います。

```yml
highlight:
   html: pygments
   latex: listings
```

というわけで、上記のような形でHTML版のPygmentsを設定できるようにするための修正です(LaTeXのlistingsの方はすでに上記で対応済みです)。

### 考察
* 属性名は`highlight`じゃなくて`highlighting`の方がよい？ でも長いのがちょっと。
* #229 にも最終的には対応したいです（`latex: pygments`の時に有効になる）。その際にはReVIEW::Highlighterクラスをちゃんと作った方が良さそう
* Pygmentsのスタイルにも対応させるには、

  ```yml
  highlight:
     html:
       engine: pygments
       style: bw
  ```

  みたいにした方が良いかもしれないけど、ちょっと長いので今回の修正のようなショートカットは欲しくなるはず。
