### PR TITLE
refactor: use mkdir_p and remove file existance check

### DIFF
--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -390,10 +390,10 @@ EOT
     def produce_write_common(basedir, tmpdir)
       File.open("#{tmpdir}/mimetype", "w") {|f| @producer.mimetype(f) }
 
-      Dir.mkdir("#{tmpdir}/META-INF") unless File.exist?("#{tmpdir}/META-INF")
+      FileUtils.mkdir_p("#{tmpdir}/META-INF")
       File.open("#{tmpdir}/META-INF/container.xml", "w") {|f| @producer.container(f) }
 
-      Dir.mkdir("#{tmpdir}/OEBPS") unless File.exist?("#{tmpdir}/OEBPS")
+      FileUtils.mkdir_p("#{tmpdir}/OEBPS")
       File.open("#{tmpdir}/OEBPS/#{@producer.params["bookname"]}.opf", "w") {|f| @producer.opf(f) }
 
       if File.exist?("#{basedir}/#{@producer.params["cover"]}")
@@ -406,7 +406,7 @@ EOT
         next if item.file =~ /#/ # skip subgroup
         fname = "#{basedir}/#{item.file}"
         raise "#{fname} doesn't exist. Abort." unless File.exist?(fname)
-        FileUtils.mkdir_p(File.dirname("#{tmpdir}/OEBPS/#{item.file}")) unless File.exist?(File.dirname("#{tmpdir}/OEBPS/#{item.file}"))
+        FileUtils.mkdir_p(File.dirname("#{tmpdir}/OEBPS/#{item.file}"))
         FileUtils.cp(fname, "#{tmpdir}/OEBPS/#{item.file}")
       end
     end


### PR DESCRIPTION
#407 と同様の修正で、不要なファイル存在チェックをやめるものです(epubv2.rb, epubv2.rbにはこの種のコードはありませんでした)。