### PR TITLE
HTMLBuilder: support line break after chapter prefix

### DIFF
--- a/doc/sample.yml
+++ b/doc/sample.yml
@@ -74,12 +74,14 @@ debug: null
 toclevel: 3
 
 # 採番の設定。採番させたくない見出しには「==[nonum]」のようにnonum指定をする
-# 
+#
 # 本文でセクション番号を表示する見出しレベル
 secnolevel: 2
 
 # 付録の連番のスタイル。null(アラビア数字1〜。デフォルト)、alpha(英字A〜)、roman(ローマ数字I〜)
 # appendix_format: null
+# 章番号の後に改行を入れる。省略した場合は改行しない
+# break_after_chapter_prefix: true
 
 # 以下のsecnolevelはまだ未実装。
 # 前付でセクション番号を表示する見出しレベル(未実装)
@@ -164,8 +166,8 @@ params: --stylesheet=sample.css
 #  flattocindent: true
 # NCX目次の見出しレベルごとの飾り(配列で設定)。EPUB3ではNCXは作られない
 #  ncxindent:
-#- 
-#- - 
+#-
+#- -
 # フックは、各段階で介入したいときのプログラムを指定する。自動で適切な引数が渡される
 # プログラムには実行権限が必要
 # ファイル変換処理の前に実行するプログラム。スタイルシートのコンパイルをしたいときなどに利用する。

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -200,7 +200,7 @@ EOT
       unless anchor.nil?
         a_id = %Q[<a id="h#{anchor}"></a>]
       end
-      if @book.config["break_after_chapter_prefix"] == true
+      if @book.config["break_after_chapter_prefix"] == true && level == 1
         br = "<br />"
       end
       if caption.empty?

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -195,16 +195,21 @@ EOT
       prefix, anchor = headline_prefix(level)
       puts '' if level > 1
       a_id = ""
+      br = ""
+
       unless anchor.nil?
         a_id = %Q[<a id="h#{anchor}"></a>]
+      end
+      if @book.config["break_after_chapter_prefix"] == true
+        br = "<br />"
       end
       if caption.empty?
         puts a_id unless label.nil?
       else
         if label.nil?
-          puts %Q[<h#{level}>#{a_id}#{prefix}#{compile_inline(caption)}</h#{level}>]
+          puts %Q[<h#{level}>#{a_id}#{prefix}#{br}#{compile_inline(caption)}</h#{level}>]
         else
-          puts %Q[<h#{level} id="#{normalize_id(label)}">#{a_id}#{prefix}#{compile_inline(caption)}</h#{level}>]
+          puts %Q[<h#{level} id="#{normalize_id(label)}">#{a_id}#{prefix}#{br}#{compile_inline(caption)}</h#{level}>]
         end
       end
     end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -42,6 +42,12 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|<h1 id="test"><a id="h1"></a>第1章　this is test.</h1>\n|, actual
   end
 
+  def test_headline_level1_break_after_prefix
+    @book.config["break_after_chapter_prefix"] = true
+    actual = compile_block("={test} this is test.\n")
+    assert_equal %Q|<h1 id="test"><a id="h1"></a>第1章　<br />this is test.</h1>\n|, actual
+  end
+
   def test_headline_level1_postdef
     @chapter.instance_eval do
       def on_APPENDIX?

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -133,6 +133,12 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|\n<h2 id="test"><a id="h1-1"></a>1.1　this is test.</h2>\n|, actual
   end
 
+  def test_headline_level2_doesnt_break_after_prefix
+    @book.config["break_after_chapter_prefix"] = true
+    actual = compile_block("=={test} this is test.\n")
+    assert_equal %Q|\n<h2 id="test"><a id="h1-1"></a>1.1　this is test.</h2>\n|, actual
+  end
+
   def test_headline_level3
     actual = compile_block("==={test} this is test.\n")
     assert_equal %Q|\n<h3 id="test"><a id="h1-0-1"></a>this is test.</h3>\n|, actual


### PR DESCRIPTION
章タイトルの章番号の後に改行を入れます。


## 使い方

```yaml
break_after_chapter_prefix: true
```

`config.yml` から、上記のオプションで有効化します。HTMLは次のようになります。

```html
<h1 id="test"><a id="h1"></a>第1章　<br />this is test.</h1>
```

左が通常（これまで通り）で右が改行入り（オプションを有効化した場合）になります。
![通常（左）／改行入り（右）](https://cloud.githubusercontent.com/assets/9573681/6881769/11b00d6e-d5b1-11e4-90cc-82f693e5d1bf.png)

## 実装の経緯

英語の書籍を作る際、日本語の「第N章」と比べて英語の「Chapter N」が長いため、
見た目が微妙になることから、必要にかられて実装しました。

眠らせておくものもったいないので、PRを出しましたが、Re:VIEWの方針に合わなければ、気兼ねなくリジェクトして下さい。

## 検討事項

他の実装方法として、章番号をspanでマークアップしてしまい、CSSを使って見た目的に改行を行なう方法も考えたのですが、
明確に「章番号の後ろで改行したい」という目的意識があったため、今回はbrを使った改行にしました。