### PR TITLE
HTMLBuilder: markup section number by span

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -193,6 +193,9 @@ EOT
 
     def headline(level, label, caption)
       prefix, anchor = headline_prefix(level)
+      unless prefix.nil?
+        prefix = %Q[<span class="secno">#{prefix}</span>]
+      end
       puts '' if level > 1
       a_id = ""
       unless anchor.nil?

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -39,7 +39,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
 
   def test_headline_level1
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q|<h1 id="test"><a id="h1"></a>第1章　this is test.</h1>\n|, actual
+    assert_equal %Q|<h1 id="test"><a id="h1"></a><span class="secno">第1章　</span>this is test.</h1>\n|, actual
   end
 
   def test_headline_level1_postdef
@@ -49,7 +49,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
       end
     end
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q|<h1 id="test"><a id="h1"></a>付録1　this is test.</h1>\n|, actual
+    assert_equal %Q|<h1 id="test"><a id="h1"></a><span class="secno">付録1　</span>this is test.</h1>\n|, actual
   end
 
   def test_headline_level2_postdef
@@ -59,7 +59,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
       end
     end
     actual = compile_block("=={test} this is test.\n")
-    assert_equal %Q|\n<h2 id="test"><a id="h1-1"></a>1.1　this is test.</h2>\n|, actual
+    assert_equal %Q|\n<h2 id="test"><a id="h1-1"></a><span class="secno">1.1　</span>this is test.</h2>\n|, actual
   end
 
   def test_headline_level1_postdef_roman
@@ -70,7 +70,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
       end
     end
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q|<h1 id="test"><a id="hI"></a>付録I　this is test.</h1>\n|, actual
+    assert_equal %Q|<h1 id="test"><a id="hI"></a><span class="secno">付録I　</span>this is test.</h1>\n|, actual
   end
 
   def test_headline_level2_postdef_roman
@@ -81,7 +81,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
       end
     end
     actual = compile_block("=={test} this is test.\n")
-    assert_equal %Q|\n<h2 id="test"><a id="hI-1"></a>I.1　this is test.</h2>\n|, actual
+    assert_equal %Q|\n<h2 id="test"><a id="hI-1"></a><span class="secno">I.1　</span>this is test.</h2>\n|, actual
   end
 
   def test_headline_level1_postdef_alpha
@@ -92,7 +92,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
       end
     end
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q|<h1 id="test"><a id="hA"></a>付録A　this is test.</h1>\n|, actual
+    assert_equal %Q|<h1 id="test"><a id="hA"></a><span class="secno">付録A　</span>this is test.</h1>\n|, actual
   end
 
   def test_headline_level2_postdef_alpha
@@ -103,7 +103,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
       end
     end
     actual = compile_block("=={test} this is test.\n")
-    assert_equal %Q|\n<h2 id="test"><a id="hA-1"></a>A.1　this is test.</h2>\n|, actual
+    assert_equal %Q|\n<h2 id="test"><a id="hA-1"></a><span class="secno">A.1　</span>this is test.</h2>\n|, actual
   end
 
   def test_headline_level1_without_secno
@@ -114,17 +114,17 @@ class HTMLBuidlerTest < Test::Unit::TestCase
 
   def test_headline_level1_with_tricky_id
     actual = compile_block("={123 あ_;} this is test.\n")
-    assert_equal %Q|<h1 id="id_123-_E3_81_82___3B"><a id="h1"></a>第1章　this is test.</h1>\n|, actual
+    assert_equal %Q|<h1 id="id_123-_E3_81_82___3B"><a id="h1"></a><span class="secno">第1章　</span>this is test.</h1>\n|, actual
   end
 
   def test_headline_level1_with_inlinetag
     actual = compile_block("={test} this @<b>{is} test.<&\">\n")
-    assert_equal %Q|<h1 id="test"><a id="h1"></a>第1章　this <b>is</b> test.&lt;&amp;&quot;&gt;</h1>\n|, actual
+    assert_equal %Q|<h1 id="test"><a id="h1"></a><span class="secno">第1章　</span>this <b>is</b> test.&lt;&amp;&quot;&gt;</h1>\n|, actual
   end
 
   def test_headline_level2
     actual = compile_block("=={test} this is test.\n")
-    assert_equal %Q|\n<h2 id="test"><a id="h1-1"></a>1.1　this is test.</h2>\n|, actual
+    assert_equal %Q|\n<h2 id="test"><a id="h1-1"></a><span class="secno">1.1　</span>this is test.</h2>\n|, actual
   end
 
   def test_headline_level3
@@ -135,7 +135,7 @@ class HTMLBuidlerTest < Test::Unit::TestCase
   def test_headline_level3_with_secno
     @book.config["secnolevel"] = 3
     actual = compile_block("==={test} this is test.\n")
-    assert_equal %Q|\n<h3 id="test"><a id="h1-0-1"></a>1.0.1　this is test.</h3>\n|, actual
+    assert_equal %Q|\n<h3 id="test"><a id="h1-0-1"></a><span class="secno">1.0.1　</span>this is test.</h3>\n|, actual
   end
 
   def test_label

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -128,7 +128,7 @@ class I18nTest < Test::Unit::TestCase
   def test_htmlbuilder
     _setup_htmlbuilder
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q|<h1 id="test"><a id="h1"></a>Chapter 1. this is test.</h1>\n|, actual
+    assert_equal %Q|<h1 id="test"><a id="h1"></a><span class="secno">Chapter 1. </span>this is test.</h1>\n|, actual
   end
 
   def _setup_htmlbuilder


### PR DESCRIPTION
#414 の別回答になります。

章番号に限らず、セクション番号すべてを以下のようにspanでマークアップします。
使用するclass名は、W3CのSpecなどでも使われている、secnoを使用しました。

```html
<h1 id="test"><a id="h1"></a><span class="secno">第1章　</span>this is test.</h1>
<h2 id="test"><a id="h1-1"></a><span class="secno">1.1　</span>this is test.</h2>
```

このようなCSSによって、h1 の装飾を図右のように変更できます。

```css
h1 .secno {
  display: block;
  font-size: .7em;
}
```

![2015-03-29 01 11 26](https://cloud.githubusercontent.com/assets/9573681/6889556/aaa6bfcc-d6d3-11e4-900e-dcbf4c33658b.png)
