### PR TITLE
Prevent dlist with comments from separating

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -11,7 +11,6 @@
 require 'review/extentions'
 require 'review/preprocessor'
 require 'review/exception'
-require 'lineinput'
 require 'strscan'
 
 module ReVIEW
@@ -409,6 +408,7 @@ module ReVIEW
         @strategy.dt text(f.gets.sub(/\A\s*:/, '').strip)
         @strategy.dd f.break(/\A(\S|\s*:)/).map {|line| text(line.strip) }
         f.skip_blank_lines
+        f.skip_comment_lines
       end
       @strategy.dl_end
     end

--- a/lib/review/lineinput.rb
+++ b/lib/review/lineinput.rb
@@ -1,0 +1,17 @@
+require 'lineinput'
+
+module ReVIEW
+  class LineInput < LineInput
+    def skip_comment_lines
+      n = 0
+      while line = gets()
+        unless line.strip =~ /\A#/
+          ungets line
+          return n
+        end
+        n += 1
+      end
+      n
+    end
+  end
+end

--- a/lib/review/lineinput.rb
+++ b/lib/review/lineinput.rb
@@ -5,7 +5,7 @@ module ReVIEW
     def skip_comment_lines
       n = 0
       while line = gets()
-        unless line.strip =~ /\A#/
+        unless line.strip =~ /\A\#@/
           ungets line
           return n
         end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -453,6 +453,18 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|<dl>\n<dt>foo[bar]</dt>\n<dd>foo.bar.</dd>\n</dl>\n|, actual
   end
 
+  def test_dlist_with_comment
+    actual = compile_block(<<-EOS)
+: title
+  body
+#@ comment
+#@ comment
+: title2
+  body2
+EOS
+    assert_equal %Q|<dl>\n<dt>title</dt>\n<dd>body</dd>\n<dt>title2</dt>\n<dd>body2</dd>\n</dl>\n|, actual
+  end
+
   def test_list
     def @chapter.list(id)
       Book::ListIndex::Item.new("samplelist",1)

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -454,14 +454,8 @@ class HTMLBuidlerTest < Test::Unit::TestCase
   end
 
   def test_dlist_with_comment
-    actual = compile_block(<<-EOS)
-: title
-  body
-#@ comment
-#@ comment
-: title2
-  body2
-EOS
+    source = ": title\n  body\n\#@ comment\n\#@ comment\n: title2\n  body2\n"
+    actual = compile_block(source)
     assert_equal %Q|<dl>\n<dt>title</dt>\n<dd>body</dd>\n<dt>title2</dt>\n<dd>body2</dd>\n</dl>\n|, actual
   end
 


### PR DESCRIPTION
以下のようにdlistの途中に ``#@`` が挟まれていると、dlistが途中で終了してしまう（下記の例では2つのdlistができてしまう）。

```
: title
  body
#@ comment
: title2
  body2
```

途中に ``#@`` が挟まれていても、dlistを継続させる（1つのdlistにする）ように修正。
