### PR TITLE
epubmaker: matching coverimage strictly

### DIFF
--- a/lib/epubmaker/epubv3.rb
+++ b/lib/epubmaker/epubv3.rb
@@ -126,7 +126,7 @@ EOT
 
       if @producer.params["coverimage"]
         @producer.contents.each do |item|
-          if item.media =~ /\Aimage/ && item.file =~ /#{@producer.params["coverimage"]}\Z/
+          if item.media =~ /\Aimage/ && File.basename(item.file) == @producer.params["coverimage"]
             s << %Q[    <item properties="cover-image" id="cover-#{item.id}" href="#{item.file}" media-type="#{item.media}"/>\n]
             item.id = nil
             break


### PR DESCRIPTION
表紙画像の抽出に、ファイル名を取り出して完全一致のマッチにするようにしました。
（cover.jpgとしたらbackcover.jpgがマッチした事案がありまして… :scream: ）