### PR TITLE
Fix missing listing name when using syntax highlighting

### DIFF
--- a/lib/review/layout.tex.erb
+++ b/lib/review/layout.tex.erb
@@ -52,7 +52,7 @@
 <%   else %>
 \usepackage{listings}
 <%   end %>
-\renewcommand{\lstlistingname}{<%I18n.t("list")%>}
+\renewcommand{\lstlistingname}{<%= I18n.t("list")%>}
 \lstset{%
   breaklines=true,%
   breakautoindent=false,%


### PR DESCRIPTION
When using syntax highlighting in review-pdfmaker, a caption of list
does not have a prefix such as 'リスト' or 'List' etc.

Actual caption: 1.1 Sample Code
Expected caption: List 1.1 Sample Code

This is because the value of \lstlistingname is always empty.