### PR TITLE
use @maker to fix travis error

### DIFF
--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -153,8 +153,7 @@ class PDFMakerTest < Test::Unit::TestCase
 
         expect = File.read(File.join(assets_dir,"test_template_backmatter.tex"))
 
-        maker = ReVIEW::PDFMaker.new
-        tmpl = maker.get_template(@config)
+        tmpl = @maker.get_template(@config)
         tmpl.gsub!(/\A.*%% backmatter begins\n/m,"")
         assert_equal(expect, tmpl)
       end


### PR DESCRIPTION
Travisの1.8.7でtest_gettemplateは通るのにtest_gettemplate_with_backmatterはコケる現象の対策で、test_gettemplateに合わせてみました