### PR TITLE
params: in config.yml should be deprecated

### DIFF
--- a/doc/sample.yml
+++ b/doc/sample.yml
@@ -135,8 +135,8 @@ secnolevel: 2
 # fontdir内から取り込まれる対象となるファイル拡張子。省略した場合は以下
 # font_ext: ["ttf", "woff", "otf"]
 
-# review-compileに渡すパラメータ
-params: --stylesheet=sample.css
+# review-compileに渡すパラメータ(deprecated)
+# params: --stylesheet=sample.css
 # Pygmentsカラーリングを利用する (pygments外部gemが必要)
 # pygments: true
 

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -286,6 +286,10 @@ EOT
       stylesheet = "--stylesheet=#{@params["stylesheet"].join(",")}"
     end
 
+    if @params["params"].present?
+      warn "params: is deprecated. Use attributes of config.yml directly."
+    end
+
     ENV["REVIEWFNAME"] = filename
     system("#{ReVIEW::MakerHelper.bindir}/review-compile --yaml=#{yamlfile} --target=html --level=#{level} --htmlversion=#{@params["htmlversion"]} --epubversion=#{@params["epubversion"]} #{stylesheet} #{@params["params"]} #{filename} > \"#{basetmpdir}/#{htmlfile}\"")
 

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -154,6 +154,10 @@ module ReVIEW
 
         call_hook("hook_beforetexcompile", config)
 
+        if @params["params"].present?
+          warn "params: is deprecated. Use attributes of config.yml directly."
+        end
+
         ## do compile
         enc = config["params"].to_s.split(/\s+/).find{|i| i =~ /\A--outencoding=/ }
         kanji = 'utf8'


### PR DESCRIPTION
config.yml で `params:` でreview-compileへのオプションを指定するのは止めて、直接config.ymlの属性として書くようにするのがいいのでは、というものです。

要するに `params: --stylesheet=foo.css` ではなくて `stylesheets: ["foo.cs"]` にした方がよいのでは、と。