### PR TITLE
attributes in Configure should be got without maker's name

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 module ReVIEW
   class Configure < Hash
+
+    attr_accessor :maker
+
     def self.values
       Configure[
         # These parameters can be overridden by YAML file.
@@ -47,6 +50,15 @@ module ReVIEW
         "bib_file"     => "bib.re",
         "colophon_order" => %w(aut csl trl dsr ill cov edt pbl contact prt),
       ]
+    end
+
+    def [](key)
+      if self.key?(key)
+        return self.fetch(key)
+      end
+      if @maker && self.key?(@maker)
+        return self.fetch(@maker).fetch(key, nil)
+      end
     end
   end
 end

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -1,0 +1,46 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'review/pdfmaker'
+
+class PDFMakerTest < Test::Unit::TestCase
+  include ReVIEW
+
+  def setup
+    @maker = ReVIEW::PDFMaker.new
+    @config = ReVIEW::Configure.values
+    @config.merge!({
+                     "bookname" => "sample",
+                     "title" => "Sample Book",
+                     "version" => 2,
+                     "urnid" => "http://example.jp/",
+                     "date" => "2011-01-01",
+                     "language" => "ja",
+                     "epubmaker" => {"flattocindent" => true},
+                   })
+    @output = StringIO.new
+    I18n.setup(@config["language"])
+  end
+
+  def test_configure_get
+    bookname = @config["bookname"]
+    assert_equal "sample", bookname
+  end
+
+  def test_configure_get2
+    assert_equal true, @config["epubmaker"]["flattocindent"]
+  end
+
+  def test_configure_with_maker
+    @config.maker = "epubmaker"
+    assert_equal true, @config["flattocindent"]
+    assert_equal true, @config["epubmaker"]["flattocindent"]
+  end
+
+  def test_configure_with_invalidmaker
+    @config.maker = "pdfmaker"
+    assert_equal nil, @config["flattocindent"]
+    assert_equal true, @config["epubmaker"]["flattocindent"]
+  end
+
+end

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -1,13 +1,13 @@
 # encoding: utf-8
 
 require 'test_helper'
-require 'review/pdfmaker'
+require 'review/epubmaker'
 
-class PDFMakerTest < Test::Unit::TestCase
+class ConfigureTest < Test::Unit::TestCase
   include ReVIEW
 
   def setup
-    @maker = ReVIEW::PDFMaker.new
+    @maker = ReVIEW::EPUBMaker.new
     @config = ReVIEW::Configure.values
     @config.merge!({
                      "bookname" => "sample",
@@ -20,6 +20,10 @@ class PDFMakerTest < Test::Unit::TestCase
                    })
     @output = StringIO.new
     I18n.setup(@config["language"])
+  end
+
+  def test_configure_class
+    assert_equal ReVIEW::Configure, @config.class
   end
 
   def test_configure_get


### PR DESCRIPTION
`@config["foo"]` should be same as `@config["barmaker"]["foo"]` after `@config.maker = "barmaker"`
