### PR TITLE
use ERB template

### DIFF
--- a/lib/epubmaker/epubv2.rb
+++ b/lib/epubmaker/epubv2.rb
@@ -23,24 +23,14 @@ module EPUBMaker
 
     # Return opf file content.
     def opf
-      s = <<EOT
-<?xml version="1.0" encoding="UTF-8"?>
-<package version="2.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookId">
-  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
-EOT
+      @opf_metainfo = opf_metainfo
+      @opf_coverimage = opf_coverimage
+      @opf_manifest = opf_manifest
+      @opf_toc = opf_tocx
 
-      s << opf_metainfo
-      s << opf_coverimage
-
-      s << %Q[  </metadata>\n]
-
-      s << opf_manifest
-      s << opf_tocx
-      s << opf_guide
-
-      s << %Q[</package>\n]
-
-      s
+      tmplfile = File.expand_path('./opf/epubv2.opf.erb', ReVIEW::Template::TEMPLATE_DIR)
+      tmpl = ReVIEW::Template.load(tmplfile)
+      return tmpl.result(binding)
     end
 
     def opf_metainfo
@@ -121,39 +111,15 @@ EOT
       s
     end
 
-    def opf_guide
-      s = ""
-      s << %Q[  <guide>\n]
-      s << %Q[    <reference type="cover" title="#{@producer.res.v("covertitle")}" href="#{@producer.params["cover"]}"/>\n]
-      s << %Q[    <reference type="title-page" title="#{@producer.res.v("titlepagetitle")}" href="titlepage.#{@producer.params["htmlext"]}"/>\n] unless @producer.params["titlepage"].nil?
-      s << %Q[    <reference type="toc" title="#{@producer.res.v("toctitle")}" href="#{@producer.params["bookname"]}-toc.#{@producer.params["htmlext"]}"/>\n] unless @producer.params["mytoc"].nil?
-      s << %Q[    <reference type="colophon" title="#{@producer.res.v("colophontitle")}" href="colophon.#{@producer.params["htmlext"]}"/>\n] unless @producer.params["colophon"].nil?
-      s << %Q[  </guide>\n]
-      s
-    end
-
     # Return ncx content. +indentarray+ has prefix marks for each level.
     def ncx(indentarray)
-      s = <<EOT
-<?xml version="1.0" encoding="UTF-8"?>
-<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
-  <head>
-    <meta name="dtb:depth" content="1"/>
-    <meta name="dtb:totalPageCount" content="0"/>
-    <meta name="dtb:maxPageNumber" content="0"/>
-EOT
-      s << ncx_isbn
+      @ncx_isbn = ncx_isbn
+      @ncx_doctitle = ncx_doctitle
+      @ncx_navmap = ncx_navmap(indentarray)
 
-      s << <<EOT
-  </head>
-EOT
-      s << ncx_doctitle
-      s << ncx_navmap(indentarray)
-
-      s << <<EOT
-</ncx>
-EOT
-      s
+      tmplfile = File.expand_path('./ncx/epubv2.ncx.erb', ReVIEW::Template::TEMPLATE_DIR)
+      tmpl = ReVIEW::Template.load(tmplfile)
+      return tmpl.result(binding)
     end
 
     # Produce EPUB file +epubfile+.
@@ -169,24 +135,5 @@ EOT
       export_zip(tmpdir, epubfile)
     end
 
-    private
-
-    # Return common XHTML headder
-    def common_header
-      s =<<EOT
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="#{@producer.params["language"]}">
-<head>
-  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
-  <meta http-equiv="Content-Style-Type" content="text/css"/>
-  <meta name="generator" content="Re:VIEW"/>
-EOT
-
-      @producer.params["stylesheet"].each do |file|
-        s << %Q[  <link rel="stylesheet" type="text/css" href="#{file}"/>\n]
-      end
-      s
-    end
   end
 end

--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -54,6 +54,18 @@ module EPUBMaker
       end
     end
 
+    def coverimage
+      if !params["coverimage"]
+        return nil
+      end
+      @contents.each do |item|
+        if item.media =~ /\Aimage/ && item.file =~ /#{params["coverimage"]}\Z/ # /
+          return item.file
+        end
+      end
+      return nil
+    end
+
     # Update parameters by merging from new parameter hash +params+.
     def merge_params(params)
       @params = @params.merge(params)

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -217,21 +217,23 @@ module ReVIEW
   def build_part(part, basetmpdir, htmlfile)
     log("Create #{htmlfile} from a template.")
     File.open("#{basetmpdir}/#{htmlfile}", "w") do |f|
-      f.puts header(CGI.escapeHTML(@params["booktitle"]))
-      f.puts <<EOT
-<div class="part">
-<h1 class="part-number">#{ReVIEW::I18n.t("part", part.number)}</h1>
-EOT
+      @body = ""
+      @body << "<div class=\"part\">\n"
+      @body << "<h1 class=\"part-number\">#{ReVIEW::I18n.t("part", part.number)}</h1>\n"
       if part.name.strip.present?
-        f.puts <<EOT
-<h2 class="part-title">#{part.name.strip}</h2>
-EOT
+        @body << "<h2 class=\"part-title\">#{part.name.strip}</h2>\n"
       end
+      @body << "</div>\n"
 
-      f.puts <<EOT
-</div>
-EOT
-      f.puts footer
+      @language = @producer.params['language']
+      @stylesheets = @producer.params["stylesheet"]
+      if @producer.params["htmlversion"].to_i == 5
+        tmplfile = File.expand_path('./html/layout-html5.html.erb', ReVIEW::Template::TEMPLATE_DIR)
+      else
+        tmplfile = File.expand_path('./html/layout-xhtml1.html.erb', ReVIEW::Template::TEMPLATE_DIR)
+      end
+      tmpl = ReVIEW::Template.load(tmplfile)
+      f.write tmpl.result(binding)
     end
   end
 
@@ -380,27 +382,26 @@ EOT
 
   def build_titlepage(basetmpdir, htmlfile)
     File.open("#{basetmpdir}/#{htmlfile}", "w") do |f|
-      f.puts header(CGI.escapeHTML(@params["booktitle"]))
-      f.puts <<EOT
-<div class="titlepage">
-<h1 class="tp-title">#{CGI.escapeHTML(@params["booktitle"])}</h1>
-EOT
-
+      @body = ""
+      @body << "<div class=\"titlepage\">"
+      @body << "<h1 class=\"tp-title\">#{CGI.escapeHTML(@params["booktitle"])}</h1>"
       if @params["aut"]
-        f.puts <<EOT
-<h2 class="tp-author">#{@params["aut"].join(", ")}</h2>
-EOT
+        @body << "<h2 class=\"tp-author\">#{@params["aut"].join(", ")}</h2>"
       end
       if @params["prt"]
-        f.puts <<EOT
-<h3 class="tp-publisher">#{@params["prt"].join(", ")}</h3>
-EOT
+        @body << "<h3 class=\"tp-publisher\">#{@params["prt"].join(", ")}</h3>"
       end
+      @body << "</div>"
 
-      f.puts <<EOT
-</div>
-EOT
-      f.puts footer
+      @language = @producer.params['language']
+      @stylesheets = @producer.params["stylesheet"]
+      if @producer.params["htmlversion"].to_i == 5
+        tmplfile = File.expand_path('./html/layout-html5.html.erb', ReVIEW::Template::TEMPLATE_DIR)
+      else
+        tmplfile = File.expand_path('./html/layout-xhtml1.html.erb', ReVIEW::Template::TEMPLATE_DIR)
+      end
+      tmpl = ReVIEW::Template.load(tmplfile)
+      f.write tmpl.result(binding)
     end
   end
 
@@ -434,49 +435,6 @@ EOT
     File.open("#{basetmpdir}/#{@buildlogtxt}", "a") do |f|
       f.puts "#{htmlfile},#{reviewfile}"
     end
-  end
-
-  def header(title)
-    # title should be escaped.
-    s = <<EOT
-<?xml version="1.0" encoding="UTF-8"?>
-EOT
-    if @params["htmlversion"] == 5
-      s << <<EOT
-<!DOCTYPE html>
-<html xml:lang='ja' xmlns:ops='http://www.idpf.org/2007/ops' xmlns='http://www.w3.org/1999/xhtml'>
-<head>
-  <meta charset="UTF-8" />
-EOT
-    else
-      s << <<EOT
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xml:lang='ja' xmlns:ops='http://www.idpf.org/2007/ops' xmlns='http://www.w3.org/1999/xhtml'>
-<head>
-  <meta http-equiv='Content-Type' content='text/html;charset=UTF-8' />
-  <meta http-equiv='Content-Style-Type' content='text/css' />
-EOT
-    end
-    if @params["stylesheet"].size > 0
-      @params["stylesheet"].each do |sfile|
-        s << <<EOT
-  <link rel='stylesheet' type='text/css' href='#{sfile}' />
-EOT
-      end
-    end
-    s << <<EOT
-  <meta content='Re:VIEW' name='generator'/>
-  <title>#{title}</title>
-</head>
-<body>
-EOT
-  end
-
-  def footer
-    <<EOT
-</body>
-</html>
-EOT
   end
 
   class ReVIEWHeaderListener

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -101,44 +101,21 @@ module ReVIEW
       end
 
       # default XHTML header/footer
-      header = <<EOT
-<?xml version="1.0" encoding="UTF-8"?>
-EOT
-      if @book.htmlversion == 5
-        header += <<EOT
-<!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:#{xmlns_ops_prefix}="http://www.idpf.org/2007/ops" xml:lang="#{@book.config["language"]}">
-<head>
-  <meta charset="UTF-8" />
-EOT
-      else
-        header += <<EOT
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="#{@book.config["language"]}">
-<head>
-  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-EOT
-      end
+      @error_messages = error_messages
+      @warning_messages = warning_messages
+      @title = strip_html(compile_inline(@chapter.title))
+      @body = @output.string
+      @language = @book.config['language']
+      @stylesheets = @book.config["stylesheet"]
 
-      unless @book.config["stylesheet"].nil?
-        @book.config["stylesheet"].each do |style|
-          header += <<EOT
-  <link rel="stylesheet" type="text/css" href="#{style}" />
-EOT
-        end
+      if @book.htmlversion == 5
+        htmlfilename = "layout-html5.html.erb"
+      else
+        htmlfilename = "layout-xhtml1.html.erb"
       end
-      header += <<EOT
-  <meta name="generator" content="Re:VIEW" />
-  <title>#{strip_html(compile_inline(@chapter.title))}</title>
-</head>
-<body>
-EOT
-      footer = <<EOT
-</body>
-</html>
-EOT
-      header + messages() + @output.string + footer
+      tmplfile = File.expand_path('./html/'+htmlfilename, ReVIEW::Template::TEMPLATE_DIR)
+      tmpl = ReVIEW::Template.load(tmplfile)
+      tmpl.result(binding)
     end
 
     def xmlns_ops_prefix

--- a/lib/review/template.rb
+++ b/lib/review/template.rb
@@ -1,0 +1,21 @@
+require 'erb'
+module ReVIEW
+  class Template
+    TEMPLATE_DIR = File.join(File.dirname(__FILE__), "../../templates")
+
+    def self.load(filename, mode = 1)
+      self.new(filename, mode)
+    end
+
+    def initialize(filename = nil, mode = nil)
+      if filename
+        content = File.read(filename)
+        @erb = ERB.new(content, nil, mode)
+      end
+    end
+
+    def result(bind_data = nil)
+      @erb.result(bind_data)
+    end
+  end
+end

--- a/templates/html/layout-html5.html.erb
+++ b/templates/html/layout-html5.html.erb
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="<%= @language %>">
+<head>
+  <meta charset="UTF-8" />
+<% if @stylesheets.present? %>
+<%   @stylesheets.each do |style| %>
+  <link rel="stylesheet" type="text/css" href="<%= style %>" />
+<%   end %>
+<% end%>
+  <meta name="generator" content="Re:VIEW" />
+  <title><%= @title %></title>
+</head>
+<body<%= @body_ext %>>
+<%= @body %>
+</body>
+</html>

--- a/templates/html/layout-xhtml1.html.erb
+++ b/templates/html/layout-xhtml1.html.erb
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="<%= @language %>">
+<head>
+  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+  <meta http-equiv="Content-Style-Type" content="text/css"/>
+<% if @stylesheets.present? %>
+<%   @stylesheets.each do |style| %>
+  <link rel="stylesheet" type="text/css" href="<%= style %>" />
+<%   end %>
+<% end%>
+  <meta name="generator" content="Re:VIEW"/>
+  <title><%= @title %></title>
+</head>
+<body<%= @body_ext %>>
+<% if @error_messages   %><%= @error_messages   %><% end %>
+<% if @warning_messages %><%= @warning_messages %><% end %>
+<%= @body %>
+</body>
+</html>

--- a/templates/ncx/epubv2.ncx.erb
+++ b/templates/ncx/epubv2.ncx.erb
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <head>
+    <meta name="dtb:depth" content="1"/>
+    <meta name="dtb:totalPageCount" content="0"/>
+    <meta name="dtb:maxPageNumber" content="0"/>
+<%= @ncx_isbn %>
+  </head>
+<%= @ncx_doctitle %>
+<%= @ncx_navmap %>
+</ncx>

--- a/templates/opf/epubv2.opf.erb
+++ b/templates/opf/epubv2.opf.erb
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package version="2.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookId">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+<%= @opf_metainfo %>
+<%= @opf_coverimage %>
+  </metadata>
+<%= @opf_manifest %>
+<%= @opf_toc %>
+  <guide>
+    <reference type="cover" title="<%= @producer.res.v("covertitle") %>" href="<%= @producer.params["cover"] %>"/>
+<% if @producer.params["titlepage"].present? %>
+    <reference type="title-page" title="<%= @producer.res.v("titlepagetitle") %>" href="titlepage.<%= @producer.params["htmlext"] %>"/>
+<% end %>
+<% if @producer.params["mytoc"].present? %>
+    <reference type="toc" title="<%= @producer.res.v("toctitle") %>" href="<%= @producer.params["bookname"] %>-toc.<%= @producer.params["htmlext"] %>"/>
+<% end %>
+<% if @producer.params["colophon"].present? %>
+    <reference type="colophon" title="<%= @producer.res.v("colophontitle") %>" href="colophon.<%= @producer.params["htmlext"] %>"/>
+<% end %>
+  </guide>
+</package>

--- a/templates/opf/epubv3.opf.erb
+++ b/templates/opf/epubv3.opf.erb
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookId" xml:lang="<%= @producer.params["language"] %>">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+<%= @opf_metainfo %>
+  </metadata>
+<%= @opf_manifest %>
+<%= @opf_toc %>
+  <guide>
+    <reference type="cover" title="<%= @producer.res.v("covertitle") %>" href="<%= @producer.params["cover"] %>"/>
+<% if @producer.params["titlepage"].present? %>
+    <reference type="title-page" title="<%= @producer.res.v("titlepagetitle") %>" href="titlepage.<%= @producer.params["htmlext"] %>"/>
+<% end %>
+    <reference type="toc" title="<%= @producer.res.v("toctitle") %>" href="<%= @producer.params["bookname"] %>-toc.<%= @producer.params["htmlext"] %>"/>
+<% if @producer.params["colophon"].present? %>
+    <reference type="colophon" title="<%= @producer.res.v("colophontitle") %>" href="colophon.<%= @producer.params["htmlext"] %>"/>
+<% end %>
+  </guide>
+</package>

--- a/templates/xml/container.xml.erb
+++ b/templates/xml/container.xml.erb
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<container xmlns="urn:oasis:names:tc:opendocument:xmlns:container" version="1.0">
+  <rootfiles>
+    <rootfile full-path="<%= @opf_path %>" media-type="application/oebps-package+xml" />
+  </rootfiles>
+</container>

--- a/test/assets/test.xml.erb
+++ b/test/assets/test.xml.erb
@@ -1,0 +1,3 @@
+<test>
+<name><%= @name %></name>
+</test>

--- a/test/test_template.rb
+++ b/test/test_template.rb
@@ -1,0 +1,26 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'review/template'
+
+class TemplateTest < Test::Unit::TestCase
+  include ReVIEW
+
+  def setup
+  end
+
+  def test_load
+    tmplfile = File.expand_path('./assets/test.xml.erb', File.dirname(__FILE__))
+    tmpl = ReVIEW::Template.load(tmplfile)
+    assert_equal("<test>\n<name></name>\n</test>\n",tmpl.result)
+  end
+
+  def test_open_with_value
+    tmplfile = File.expand_path('./assets/test.xml.erb', File.dirname(__FILE__))
+    tmpl = ReVIEW::Template.load(tmplfile)
+    @name = "test"
+    assert_equal("<test>\n<name>test</name>\n</test>\n",tmpl.result(binding))
+  end
+end
+
+


### PR DESCRIPTION
ソースコードとHTMLを分離するべく、ERBテンプレートを使えるようにする修正です。

* [x] OPF対応(EPUB2, EPUB3)
* [x] NCX対応(EPUB2)
* [x] XHTML対応(EPUB2)
* [x] HTML5対応(EPUB3)
* <del>[ ] partial(include)サポート</del> ←特になくても困らなさそう
