### PR TITLE
refactor: extract HTMLToc class to read/write toc-html.txt

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -332,31 +332,15 @@ EOT
 
   def push_contents(basetmpdir)
     @htmltoc.each_item do |level, file, title, args|
-      force_include = nil
-      customid = nil
-      chaptype = nil
-      properties = nil
-      args.each do |k, v|
-        case k
-        when :id
-          customid = v
-        when :force_include
-          force_include = true
-        when :chaptype
-          chaptype = v
-        when :properties
-          properties = v
-        end
-      end
-      next if level.to_i > @params["toclevel"] && force_include.nil?
+      next if level.to_i > @params["toclevel"] && args[:force_include].nil?
       log("Push #{file} to ePUB contents.")
 
-      hash = {"file" => file, "level" => level.to_i, "title" => title, "chaptype" => chaptype}
-      if customid.present?
-        hash["id"] = customid
+      hash = {"file" => file, "level" => level.to_i, "title" => title, "chaptype" => args[:chaptype]}
+      if args[:id].present?
+        hash["id"] = args[:id]
       end
-      if properties.present?
-        hash["properties"] = properties.split(" ")
+      if args[:properties].present?
+        hash["properties"] = args[:properties].split(" ")
       end
       @producer.contents.push(Content.new(hash))
     end

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -11,6 +11,7 @@ require 'review'
 require 'rexml/document'
 require 'rexml/streamlistener'
 require 'epubmaker'
+require 'review/htmltoc'
 
 module ReVIEW
  class EPUBMaker
@@ -19,7 +20,7 @@ module ReVIEW
 
   def initialize
     @producer = nil
-    @tochtmltxt = "toc-html.txt"
+    @htmltoc = nil
     @buildlogtxt = "build-log.txt"
   end
 
@@ -51,6 +52,7 @@ module ReVIEW
 
       call_hook("hook_beforeprocess", basetmpdir)
 
+      @htmltoc = ReVIEW::HTMLToc.new(basetmpdir)
       ## copy all files into basetmpdir
       copy_stylesheet(basetmpdir)
 
@@ -200,7 +202,7 @@ module ReVIEW
           build_part(part, basetmpdir, htmlfile)
           title = ReVIEW::I18n.t("part", part.number)
           title += ReVIEW::I18n.t("chapter_postfix") + part.name.strip if part.name.strip.present?
-          write_tochtmltxt(basetmpdir, "0\t#{htmlfile}\t#{title}\tchaptype=part")
+          @htmltoc.add_item(0, htmlfile, title, {:chaptype => "part"})
           write_buildlogtxt(basetmpdir, htmlfile, "")
         end
       end
@@ -320,51 +322,43 @@ EOT
     headlines.each do |headline|
       headline["level"] = 0 if ispart.present? && headline["level"] == 1
       if first.nil?
-        write_tochtmltxt(basetmpdir, "#{headline["level"]}\t#{filename}##{headline["id"]}\t#{headline["title"]}\tchaptype=#{chaptype}")
+        @htmltoc.add_item(headline["level"], filename+"#"+headline["id"], headline["title"], {:chaptype => chaptype})
       else
-        write_tochtmltxt(basetmpdir, "#{headline["level"]}\t#{filename}\t#{headline["title"]}\tforce_include=true,chaptype=#{chaptype}#{prop_str}")
+        @htmltoc.add_item(headline["level"], filename, headline["title"], {:force_include => true, :chaptype => chaptype+prop_str})
         first = nil
       end
     end
   end
 
   def push_contents(basetmpdir)
-    File.open("#{basetmpdir}/#{@tochtmltxt}") do |f|
-      f.each_line do |l|
-        force_include = nil
-        customid = nil
-        chaptype = nil
-        properties = nil
-        level, file, title, custom = l.chomp.split("\t")
-        if custom.present?
-          # custom setting
-          vars = custom.split(/,\s*/)
-          vars.each do |var|
-            k, v = var.split("=")
-            case k
-            when "id"
-              customid = v
-            when "force_include"
-              force_include = true
-            when "chaptype"
-              chaptype = v
-            when "properties"
-              properties = v
-            end
-          end
+    @htmltoc.each_item do |level, file, title, args|
+      force_include = nil
+      customid = nil
+      chaptype = nil
+      properties = nil
+      args.each do |k, v|
+        case k
+        when :id
+          customid = v
+        when :force_include
+          force_include = true
+        when :chaptype
+          chaptype = v
+        when :properties
+          properties = v
         end
-        next if level.to_i > @params["toclevel"] && force_include.nil?
-        log("Push #{file} to ePUB contents.")
-
-        hash = {"file" => file, "level" => level.to_i, "title" => title, "chaptype" => chaptype}
-        if customid.present?
-          hash["id"] = customid
-        end
-        if properties.present?
-          hash["properties"] = properties.split(" ")
-        end
-        @producer.contents.push(Content.new(hash))
       end
+      next if level.to_i > @params["toclevel"] && force_include.nil?
+      log("Push #{file} to ePUB contents.")
+
+      hash = {"file" => file, "level" => level.to_i, "title" => title, "chaptype" => chaptype}
+      if customid.present?
+        hash["id"] = customid
+      end
+      if properties.present?
+        hash["properties"] = properties.split(" ")
+      end
+      @producer.contents.push(Content.new(hash))
     end
   end
 
@@ -386,17 +380,17 @@ EOT
       else
         FileUtils.cp(@params["titlefile"], "#{basetmpdir}/titlepage.#{@params["htmlext"]}")
       end
-      write_tochtmltxt(basetmpdir, "1\ttitlepage.#{@params["htmlext"]}\t#{@producer.res.v("titlepagetitle")}\tchaptype=pre")
+      @htmltoc.add_item(1, "titlepage.#{@params['htmlext']}", @producer.res.v("titlepagetitle"), {:chaptype => "pre"})
     end
 
     if @params["originaltitlefile"].present? && File.exist?(@params["originaltitlefile"])
       FileUtils.cp(@params["originaltitlefile"], "#{basetmpdir}/#{File.basename(@params["originaltitlefile"])}")
-      write_tochtmltxt(basetmpdir, "1\t#{File.basename(@params["originaltitlefile"])}\t#{@producer.res.v("originaltitle")}\tchaptype=pre")
+      @htmltoc.add_item(1, File.basename(@params["originaltitlefile"]), @producer.res.v("originaltitle"), {:chaptype => "pre"})
     end
 
     if @params["creditfile"].present? && File.exist?(@params["creditfile"])
       FileUtils.cp(@params["creditfile"], "#{basetmpdir}/#{File.basename(@params["creditfile"])}")
-      write_tochtmltxt(basetmpdir, "1\t#{File.basename(@params["creditfile"])}\t#{@producer.res.v("credittitle")}\tchaptype=pre")
+      @htmltoc.add_item(1, File.basename(@params["creditfile"]), @producer.res.v("credittitle"), {:chaptype => "pre"})
     end
   end
 
@@ -429,12 +423,12 @@ EOT
   def copy_backmatter(basetmpdir)
     if @params["profile"]
       FileUtils.cp(@params["profile"], "#{basetmpdir}/#{File.basename(@params["profile"])}")
-      write_tochtmltxt(basetmpdir, "1\t#{File.basename(@params["profile"])}\t#{@producer.res.v("profiletitle")}\tchaptype=post")
+      @htmltoc.add_item(1, File.basename(@params["profile"]), @producer.res.v("profiletitle"), {:chaptype => "post"})
     end
 
     if @params["advfile"]
       FileUtils.cp(@params["advfile"], "#{basetmpdir}/#{File.basename(@params["advfile"])}")
-      write_tochtmltxt(basetmpdir, "1\t#{File.basename(@params["advfile"])}\t#{@producer.res.v("advtitle")}\tchaptype=post")
+      @htmltoc.add_item(1, File.basename(@params["advfile"]), @producer.res.v("advtitle"), {:chaptype => "post"})
     end
 
     if @params["colophon"]
@@ -443,18 +437,12 @@ EOT
       else
         File.open("#{basetmpdir}/colophon.#{@params["htmlext"]}", "w") {|f| @producer.colophon(f) }
       end
-      write_tochtmltxt(basetmpdir, "1\tcolophon.#{@params["htmlext"]}\t#{@producer.res.v("colophontitle")}\tchaptype=post")
+      @htmltoc.add_item(1, "colophon.#{@params["htmlext"]}", @producer.res.v("colophontitle"), {:chaptype => "post"})
     end
 
     if @params["backcover"]
       FileUtils.cp(@params["backcover"], "#{basetmpdir}/#{File.basename(@params["backcover"])}")
-      write_tochtmltxt(basetmpdir, "1\t#{File.basename(@params["backcover"])}\t#{@producer.res.v("backcovertitle")}\tchaptype=post")
-    end
-  end
-
-  def write_tochtmltxt(basetmpdir, s)
-    File.open("#{basetmpdir}/#{@tochtmltxt}", "a") do |f|
-      f.puts s
+      @htmltoc.add_item(1, File.basename(@params["backcover"]), @producer.res.v("backcovertitle"), {:chaptype => "post"})
     end
   end
 

--- a/lib/review/htmltoc.rb
+++ b/lib/review/htmltoc.rb
@@ -1,0 +1,45 @@
+require 'review'
+module ReVIEW
+  class HTMLToc
+    def initialize(basedir)
+      @tochtmltxt = "toc-html.txt"
+      @basedir = basedir
+    end
+
+    def add_item(level, filename, title, args)
+      args_str = encode_args(args)
+      line = [level, filename, title, args_str].join("\t")
+      File.open(tocfilename, "a") do |f|
+        f.write "#{line}\n"
+      end
+    end
+
+    def each_item
+      File.open(tocfilename) do |f|
+        f.each_line do |line|
+          level, file, title, args_str = line.chomp.split("\t")
+          args = decode_args(args_str)
+          yield level, file, title, args
+        end
+      end
+    end
+
+    def tocfilename
+      File.join(@basedir, @tochtmltxt)
+    end
+
+    def decode_args(args_str)
+      args = Hash.new
+      args_str.split(/,\s*/).each do |pair|
+        key, val = pair.split("=")
+        args[key.to_sym] = val
+      end
+      args
+    end
+
+    def encode_args(args)
+      args.map{|k,v| "#{k}=#{v}"}.join(",")
+    end
+  end
+end
+

--- a/test/test_htmltoc.rb
+++ b/test/test_htmltoc.rb
@@ -1,0 +1,32 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'review/htmltoc'
+
+class HTMLTocTest < Test::Unit::TestCase
+
+  def setup
+  end
+
+  def teardown
+  end
+
+  def test_tocfilename
+    toc = HTMLToc.new("/var/tmp")
+    assert_equal "/var/tmp/toc-html.txt", toc.tocfilename
+  end
+
+  def test_encode_args
+    toc = HTMLToc.new("/var/tmp")
+    assert_equal "chaptype=pre", toc.encode_args({:chaptype => "pre"})
+    assert_equal "force_include=true,chaptype=body,properties=foo", toc.encode_args({:force_include => true, :chaptype => "body", "properties"=>"foo"})
+  end
+
+  def test_decode_args
+    toc = HTMLToc.new("/var/tmp")
+    assert_equal({:chaptype => "pre"}, toc.decode_args("chaptype=pre"))
+    assert_equal({:force_include => "true", :chaptype => "body",:properties=>"foo"}, toc.decode_args("force_include=true,chaptype=body,properties=foo"))
+  end
+
+end
+


### PR DESCRIPTION
toc-html.txtを読み書きする部分が何をやっているのかよく分からなかった（テストもなかった）のでReVIEW::HTMLTocクラスに切り出してみました。