### PR TITLE
Fix link to format document

### DIFF
--- a/doc/quickstart.ja.md
+++ b/doc/quickstart.ja.md
@@ -161,7 +161,7 @@ sample.re を HTML に変換すると、次のようになります。
 </html>
 ```
 
-Re:VIEW フォーマットについての詳細は、 [format.rdoc](https://github.com/kmuto/review/blob/master/doc/format.rdoc) を参照してください。
+Re:VIEW フォーマットについての詳細は、 [format.ja.md](https://github.com/kmuto/review/blob/master/doc/format.ja.md) を参照してください。
 
 review-compile を含め、ほとんどのコマンドは `--help` オプションを付けるとオプションについてのヘルプが表示されます。`review-compile` には多数のオプションがあるので確認してください。
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -191,7 +191,7 @@ You can get HTML file as follows:
 </html>
 ```
 
-For more information about Re:VIEW format, see [format.rdoc](https://github.com/kmuto/review/blob/master/doc/format.rdoc).
+For more information about Re:VIEW format, see [format.md](https://github.com/kmuto/review/blob/master/doc/format.md).
 
 review-compile and other commands in Re:VIEW has `--help` option to output help.  `review-compile` has many options, so you may see them.
 


### PR DESCRIPTION
フォーマットガイドへのリンクが古くなってしまっているようでしたので、修正いたしました。