### PR TITLE
review-init: fix to suport epub2 and epub3

### DIFF
--- a/bin/review-init
+++ b/bin/review-init
@@ -31,6 +31,9 @@ def main
   opts.on('-l', '--locale', 'generate locale.yml file.') {
     @locale = true
   }
+  opts.on('', '--epub-version VERSION', 'define EPUB version') { |version|
+    @epub_version = version
+  }
   begin
     opts.parse!
   rescue OptionParser::ParseError => err
@@ -80,23 +83,10 @@ end
 
 def generate_layout(dir)
   FileUtils.mkdir_p dir + '/layouts'
-  File.open("#{dir}/layouts/layout.html.erb", "w") do |file|
-    file.write <<-EOS
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="ja">
-<head>
-  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8" />
-  <meta http-equiv="Content-Style-Type" content="text/css" />
-  <link rel="stylesheet" type="text/css" href="style.css" />
-  <meta name="generator" content="Re:VIEW" />
-  <title><%= title %></title>
-</head>
-<body>
-<%= body %>
-</body>
-</html>
-EOS
+  if @epub_version.to_i == 2
+    FileUtils.cp @review_dir + "/templates/html/layout-xhtml1.html.erb", dir + '/layouts/layout.html.erb'
+  else
+    FileUtils.cp @review_dir + "/templates/html/layout-html5.html.erb", dir + '/layouts/layout.html.erb'
   end
 end
 
@@ -125,7 +115,11 @@ def generate_cover_image(dir)
 end
 
 def generate_config(dir)
-  FileUtils.cp @review_dir + "/test/sample-book/src/config.yml", dir
+  if @epub_version.to_i == 2
+    FileUtils.cp @review_dir + "/test/sample-book/src/config-epub2.yml", File.join(dir, "config.yml")
+  else
+    FileUtils.cp @review_dir + "/test/sample-book/src/config.yml", dir
+  end
 end
 
 def generate_style(dir)

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -71,6 +71,8 @@ module ReVIEW
           warn "user's layout is prohibited in safe mode. ignored."
         else
           title = strip_html(compile_inline(@chapter.title))
+          language = @book.config['language']
+          stylesheets = @book.config["stylesheet"]
 
           toc = ""
           toc_level = 0
@@ -94,6 +96,8 @@ module ReVIEW
             HTMLLayout.new(
             {'body' => @output.string, 'title' => title, 'toc' => toc,
              'builder' => self,
+             'language' => language,
+             'stylesheets' => stylesheets,
              'next' => @chapter.next_chapter,
              'prev' => @chapter.prev_chapter},
             layout_file).result

--- a/lib/review/htmllayout.rb
+++ b/lib/review/htmllayout.rb
@@ -11,6 +11,8 @@ class HTMLLayout
     @next = params['next']
     @prev = params['prev']
     @builder = params['builder']
+    @language = params['language']
+    @stylesheets = params['stylesheets']
     @template = template
   end
   attr_reader :body, :title, :toc

--- a/test/sample-book/src/config-epub2.yml
+++ b/test/sample-book/src/config-epub2.yml
@@ -67,14 +67,13 @@ rights: (C) 2011 Masayoshi Takahashi
 # coverage: 内容の範囲や領域
 
 # htmlext: HTMLファイルの拡張子(省略した場合はhtml)
-htmlext: xhtml
 # CSSファイル(配列で複数指定可、yamlファイルおよびRe:VIEWファイルを置いたディレクトリにあること)
 stylesheet: ["style.css"]
 
 # ePUBのバージョン (2か3) 省略した場合は2
-epubversion: 3
+epubversion: 2
 # HTMLのバージョン (4か5。epubversionを3にしたときには5にする)
-# htmlversion: 5
+htmlversion: 4
 
 # 目次を作成するか。省略した場合はnull（作成しない）
 # toc: true


### PR DESCRIPTION
#456 の対応についてちょっと悩んだ結果、review-initに`--epub-version`オプションをつけて、EPUB2用とEPUB3用で別々のファイルを出せるようにしてみました。

オプションをつけない場合はEPUB3です。EPUB3版は拡張子を`.xhtml`にしています。
