### PR TITLE
EPUBMaker: reflected colophon_order

### DIFF
--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -236,7 +236,7 @@ EOT
       end
 
       @body << %Q[    <table class="colophon">\n]
-      @body << %w[aut csl trl dsr ill edt pbl prt pht].map{ |role|
+      @body << @producer.params["colophon_order"].map{ |role|
         if @producer.params[role]
           %Q[      <tr><th>#{@producer.res.v(role)}</th><td>#{CGI.escapeHTML(@producer.params[role].join(", "))}</td></tr>\n]
         else

--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -218,6 +218,7 @@ module EPUBMaker
         "originaltitlefile" => nil,
         "profile" => nil,
         "colophon" => nil,
+        "colophon_order" => %w[aut csl trl dsr ill edt pbl prt pht],
         "epubmaker" => {
           "flattoc" => nil,
           "flattocindent" => true,


### PR DESCRIPTION
colophon_orderを`epubmaker/epubcommon.rb`の中に埋め込むのではなく、`@producer.params[]`から読んでくるようにしました。これでconfig.ymlに書けるようになるはず…。