### PR TITLE
fix rubocop warnings

### DIFF
--- a/bin/review-vol
+++ b/bin/review-vol
@@ -66,15 +66,13 @@ def main
       puts '    --------------------'
       print_volume part.volume
     end
-    puts '============================='
-    print_volume book.volume #puts "Total #{book.volume}"
   else
     book.each_chapter do |chap|
       print_chapter_volume chap
     end
-    puts '============================='
-    print_volume book.volume #puts "Total #{book.volume}"
   end
+  puts '============================='
+  print_volume book.volume #puts "Total #{book.volume}"
 rescue ReVIEW::ApplicationError, Errno::ENOENT => err
   raise if $DEBUG
   $stderr.puts "#{File.basename($0)}: #{err.message}"

--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -37,7 +37,7 @@ module EPUBMaker
       if @producer.params["coverimage"]
         file = nil
         @producer.contents.each do |item|
-          if item.media =~ /\Aimage/ && item.file =~ /#{@producer.params["coverimage"]}\Z/
+          if item.media.start_with?('image') && item.file =~ /#{@producer.params["coverimage"]}\Z/
             s << %Q[    <meta name="cover" content="#{item.id}"/>\n]
             file = item.file
             break

--- a/lib/epubmaker/epubv3.rb
+++ b/lib/epubmaker/epubv3.rb
@@ -116,7 +116,7 @@ EOT
 
       if @producer.params["coverimage"]
         @producer.contents.each do |item|
-          if item.media =~ /\Aimage/ && File.basename(item.file) == @producer.params["coverimage"]
+          if item.media.start_with?('image') && File.basename(item.file) == @producer.params["coverimage"]
             s << %Q[    <item properties="cover-image" id="cover-#{item.id}" href="#{item.file}" media-type="#{item.media}"/>\n]
             item.id = nil
             break
@@ -203,7 +203,7 @@ EOT
 
       if @producer.params["coverimage"]
         @producer.contents.each do |item|
-          if item.media =~ /\Aimage/ && item.file =~ /#{@producer.params["coverimage"]}\Z/
+          if item.media.start_with?('image') && item.file =~ /#{@producer.params["coverimage"]}\Z/
               s << <<EOT
             <item id="#{item.id}" href="#{item.file}" media-type="#{item.media}"/>
 EOT

--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -59,7 +59,7 @@ module EPUBMaker
         return nil
       end
       @contents.each do |item|
-        if item.media =~ /\Aimage/ && item.file =~ /#{params["coverimage"]}\Z/ # /
+        if item.media.start_with?('image') && item.file =~ /#{params["coverimage"]}\Z/ # /
           return item.file
         end
       end
@@ -145,7 +145,7 @@ module EPUBMaker
       return nil unless File.exist?(path)
       allow_exts = @params["image_ext"] if allow_exts.nil?
       Dir.foreach(path) do |f|
-        next if f =~ /\A\./
+        next if f.start_with?('.')
         if f =~ /\.(#{allow_exts.join("|")})\Z/i
           path.chop! if path =~ /\/\Z/
           if base.nil?

--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -186,7 +186,7 @@ module ReVIEW
 
         catalogfile_path = "#{basedir}/#{config["catalogfile"]}"
         if File.file? catalogfile_path
-          @catalog = Catalog.new(File.open catalogfile_path)
+          @catalog = Catalog.new(File.open(catalogfile_path))
         end
 
         @catalog
@@ -327,8 +327,8 @@ module ReVIEW
         end
 
         chap = read_CHAPS()\
-          .strip.lines.map {|line| line.strip }.join("\n").split(/\n{2,}/)\
-          .map {|part_chunk|
+               .strip.lines.map {|line| line.strip }.join("\n").split(/\n{2,}/)\
+               .map {|part_chunk|
           chaps = part_chunk.split.map {|chapid|
             Chapter.new(self, (num += 1), chapid, "#{@basedir}/#{chapid}")
           }

--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -58,8 +58,8 @@ module ReVIEW
         @index.fetch(id)
       rescue
         if @index.keys.map{|i| i.split(/\|/).last }.flatten. # unfold all ids
-            reduce(Hash.new(0)){|h, i| h[i] += 1; h}. # number of occurrences
-            select{|k, v| k == id && v > 1 }.present? # detect duplicated
+           reduce(Hash.new(0)){|h, i| h[i] += 1; h}. # number of occurrences
+           select{|k, v| k == id && v > 1 }.present? # detect duplicated
           raise KeyError, "key '#{id}' is ambiguous for #{self.class}"
         end
 

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -38,7 +38,7 @@ module ReVIEW
       end
 
       def file?
-        (name.present? and path =~ /\.re\z/) ? true : false
+        (name.present? and path.end_with?('.re')) ? true : false
       end
 
       def format_number(heading = true)

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -164,7 +164,7 @@ module ReVIEW
   def recursive_copy_files(resdir, destdir, allow_exts)
     Dir.open(resdir) do |dir|
       dir.each do |fname|
-        next if fname =~ /\A\./
+        next if fname.start_with?('.')
         if FileTest.directory?("#{resdir}/#{fname}")
           recursive_copy_files("#{resdir}/#{fname}", "#{destdir}/#{fname}", allow_exts)
         else

--- a/lib/review/i18n.rb
+++ b/lib/review/i18n.rb
@@ -53,7 +53,7 @@ module ReVIEW
     end
 
     def load_default
-      load_file(File.expand_path "i18n.yml", File.dirname(__FILE__))
+      load_file(File.expand_path("i18n.yml", File.dirname(__FILE__)))
     end
 
     def load_file(path)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -489,7 +489,7 @@ module ReVIEW
         puts macro('begin', 'reviewtable', @latex_tsize)
       elsif @tsize
         cellwidth = @tsize.split(/\s*,\s*/)
-        puts macro('begin', 'reviewtable', '|'+(cellwidth.collect{|i| "p{#{i}mm}"}.join('|'))+'|')
+        puts macro('begin', 'reviewtable', '|'+cellwidth.collect{|i| "p{#{i}mm}"}.join('|')+'|')
       else
         puts macro('begin', 'reviewtable', (['|'] * (ncols + 1)).join('l'))
       end

--- a/lib/review/preprocessor.rb
+++ b/lib/review/preprocessor.rb
@@ -161,8 +161,6 @@ module ReVIEW
       end
     end
 
-    private
-
     KNOWN_DIRECTIVES = %w( require provide warn ok )
 
     def known_directive?(op)
@@ -406,7 +404,7 @@ module ReVIEW
     end
 
     def git?(fname)
-      fname =~ /\Agit\|/
+      fname.start_with?('git|')
     end
 
     def parse_git_blob(g_obj)


### PR DESCRIPTION
どうもrubocopのデフォルトが変わったようで、警告がばんばん出るので`rubocop -a`で修正してみました。