### PR TITLE
review-index: refine TOCParser and TOCPrinter

### DIFF
--- a/bin/review-index
+++ b/bin/review-index
@@ -91,7 +91,12 @@ def _main
   end
 
   begin
-    printer_class.new(upper, param).print_book source
+    printer = printer_class.new(upper, param)
+    if source.kind_of?(ReVIEW::Book::Part)
+      printer.print_part source
+    else
+      printer.print_book source
+    end
   rescue ReVIEW::Error, Errno::ENOENT => err
     raise if $DEBUG
     error_exit err.message

--- a/bin/review-index
+++ b/bin/review-index
@@ -41,11 +41,7 @@ def _main
   opts = OptionParser.new
   opts.version = ReVIEW::VERSION
   opts.on('-a', '--all', 'print all chapters.') {
-    begin
-      source = book
-    rescue ReVIEW::Error => err
-      error_exit err.message
-    end
+    source = book
   }
   opts.on('-p', '--part N', 'list only part N.') {|n|
     source = book.part(Integer(n)) or

--- a/bin/review-index
+++ b/bin/review-index
@@ -67,9 +67,6 @@ def _main
   opts.on('--html', 'output in HTML (deprecated)') {
     printer_class = ReVIEW::HTMLTOCPrinter
   }
-  opts.on('--idg', 'output in InDesign XML') {
-    printer_class = ReVIEW::IDGTOCPrinter
-  }
   opts.on('--help', 'print this message and quit.') {
     puts opts.help
     exit 0

--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -34,6 +34,7 @@ module ReVIEW
         @indepimage_index = nil
         @headline_index = nil
         @column_index = nil
+        @volume = nil
       end
 
       def inspect

--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -380,7 +380,7 @@ module ReVIEW
         seq = 1
         src.each do |line|
           if m = COLUMN_PATTERN.match(line)
-            level = m[1] ## not use it yet
+            _level = m[1] ## not use it yet
             id = m[2]
             caption = m[3].strip
             if !id || id == ""

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -21,6 +21,7 @@ module ReVIEW
         @chapters = chapters
         @path = name
         @name = name ? File.basename(name, '.re') : nil
+        @volume = nil
       end
 
       attr_reader :number

--- a/lib/review/extentions/string.rb
+++ b/lib/review/extentions/string.rb
@@ -1,4 +1,5 @@
-if defined?(Encoding) && Encoding.respond_to?("default_external")
+if defined?(Encoding) && Encoding.respond_to?("default_external") &&
+   Encoding.default_external != Encoding::UTF_8
   Encoding.default_external = "UTF-8"
 end
 

--- a/lib/review/preprocessor.rb
+++ b/lib/review/preprocessor.rb
@@ -304,7 +304,7 @@ module ReVIEW
     end
 
     def spawn
-      pid, status = *Process.waitpid2(fork { yield })
+      _pid, status = *Process.waitpid2(fork { yield }) ## pid not used
       status
     end
 

--- a/lib/review/tocparser.rb
+++ b/lib/review/tocparser.rb
@@ -27,6 +27,14 @@ module ReVIEW
       end
     end
 
+    def TOCParser.chapter_node(chap)
+      toc = TOCParser.parse(chap)
+      unless toc.size == 1
+        $stderr.puts "warning: chapter #{toc.join} contains more than 1 chapter"
+      end
+      toc.first
+    end
+
     def parse(f, chap)
       roots = [] ## list of chapters
       node_stack = []
@@ -285,55 +293,5 @@ module ReVIEW
     end
 
   end
-
-
-  module TOCRoot
-    def level
-      0
-    end
-
-    def chapter?
-      false
-    end
-
-    def each_section_with_index
-      idx = -1
-      each_section do |node|
-        yield node, (idx += 1)
-      end
-    end
-
-    def each_section(&block)
-      each_chapter do |chap|
-        yield chap.toc
-      end
-    end
-
-    def section_size
-      chapters.size
-    end
-
-    def estimated_lines
-      chapters.inject(0) {|sum, chap| sum + chap.toc.estimated_lines }
-    end
-  end
-
-  class Book::Base # reopen
-    include TOCRoot
-  end
-
-  class Book::Part
-    include TOCRoot
-  end
-
-  class Book::Chapter # reopen
-    def toc
-      @toc ||= TOCParser.parse(self)
-      unless @toc.size == 1
-        $stderr.puts "warning: chapter #{@toc.join} contains more than 1 chapter"
-      end
-      @toc.first
-    end
-  end
-
 end
+

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -187,7 +187,6 @@ module ReVIEW
 
     def print_node(seq, node)
       if node.chapter?
-        vol = node.volume
         printf "<li aid:pstyle='ul-part'>%s</li>\n",
                "#{chapnumstr(node.number)}#{node.label}"
       else

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -36,12 +36,20 @@ module ReVIEW
   class TextTOCPrinter < TOCPrinter
     def print_book(book)
       book.each_part do |part|
-        part.each_chapter do |chap|
-          chap_node = TOCParser.chapter_node(chap)
-          print_node 1, chap_node
-          print_children chap_node
-        end
+        print_part(part)
       end
+    end
+
+    def print_part(part)
+      part.each_chapter do |chap|
+        print_chapter(chap)
+      end
+    end
+
+    def print_chapter(chap)
+      chap_node = TOCParser.chapter_node(chap)
+      print_node 1, chap_node
+      print_children chap_node
     end
 
     private
@@ -178,13 +186,21 @@ module ReVIEW
       puts %Q(<title aid:pstyle="h0">1　パート1</title><?dtp level="0" section="第1部　パート1"?>) # FIXME: 部タイトルを取るには？ & 部ごとに結果を分けるには？
       puts %Q(<ul aid:pstyle='ul-partblock'>)
       book.each_part do |part|
-        part.each_chapter do |chap|
-          chap_node = TOCParser.chapter_node(chap)
-          print_node 1, chap_node
-          print_children chap_node
-        end
+        print_part(part)
       end
       puts %Q(</ul></doc>)
+    end
+
+    def print_part(part)
+      part.each_chapter do |chap|
+        print_chapter(chap)
+      end
+    end
+
+    def print_chapter(chap)
+      chap_node = TOCParser.chapter_node(chap)
+      print_node 1, chap_node
+      print_children chap_node
     end
 
     private

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -27,13 +27,6 @@ module ReVIEW
       @config = param
     end
 
-    def print?(level)
-      level <= @print_upper
-    end
-  end
-
-
-  class TextTOCPrinter < TOCPrinter
     def print_book(book)
       book.each_part do |part|
         print_part(part)
@@ -51,6 +44,14 @@ module ReVIEW
       print_node 1, chap_node
       print_children chap_node
     end
+
+    def print?(level)
+      level <= @print_upper
+    end
+  end
+
+
+  class TextTOCPrinter < TOCPrinter
 
     private
 
@@ -95,17 +96,9 @@ module ReVIEW
 
     include HTMLUtils
 
-    def print_book(book)
-      book.each_part do |part|
-        print_part(part)
-      end
-    end
-
     def print_part(part)
       puts h1(part.name) if part.name
-      part.each_chapter do |chap|
-        print_chapter(chap)
-      end
+      super
     end
 
     def print_chapter(chap)
@@ -176,27 +169,16 @@ module ReVIEW
   end
 
   class IDGTOCPrinter < TOCPrinter
+
+    LABEL_LEN = 54
+
     def print_book(book)
       puts %Q(<?xml version="1.0" encoding="UTF-8"?>)
       puts %Q(<doc xmlns:aid='http://ns.adobe.com/AdobeInDesign/4.0/'>)
       puts %Q(<title aid:pstyle="h0">1　パート1</title><?dtp level="0" section="第1部　パート1"?>) # FIXME: 部タイトルを取るには？ & 部ごとに結果を分けるには？
       puts %Q(<ul aid:pstyle='ul-partblock'>)
-      book.each_part do |part|
-        print_part(part)
-      end
+      super
       puts %Q(</ul></doc>)
-    end
-
-    def print_part(part)
-      part.each_chapter do |chap|
-        print_chapter(chap)
-      end
-    end
-
-    def print_chapter(chap)
-      chap_node = TOCParser.chapter_node(chap)
-      print_node 1, chap_node
-      print_children chap_node
     end
 
     private
@@ -208,8 +190,6 @@ module ReVIEW
         print_children sec
       end
     end
-
-    LABEL_LEN = 54
 
     def print_node(seq, node)
       if node.chapter?

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -35,7 +35,13 @@ module ReVIEW
 
   class TextTOCPrinter < TOCPrinter
     def print_book(book)
-      print_children book
+      book.each_part do |part|
+        part.each_chapter do |chap|
+          chap_node = TOCParser.chapter_node(chap)
+          print_node 1, chap_node
+          print_children chap_node
+        end
+      end
     end
 
     private
@@ -86,20 +92,21 @@ module ReVIEW
       html = ""
       book.each_part do |part|
         html << h1(part.name) if part.name
-        part.each_section do |chap|
-          if chap.number
-            name = "chap#{chap.number}"
-            label = "第#{chap.number}章 #{chap.label}"
+        part.each_chapter do |chap|
+          chap_node = TOCParser.chapter_node(chap)
+          if chap_node.number
+            name = "chap#{chap_node.number}"
+            label = "第#{chap_node.number}章 #{chap_node.label}"
             html << h2(a_name(escape_html(name), escape_html(label)))
           else
-            label = "#{chap.label}"
+            label = "#{chap_node.label}"
             html << h2(escape_html(label))
           end
           return unless print?(2)
           if print?(3)
-            html << chap_sections_to_s(chap)
+            html << chap_sections_to_s(chap_node)
           else
-            html << chapter_to_s(chap)
+            html << chapter_to_s(chap_node)
           end
         end
       end
@@ -167,9 +174,16 @@ module ReVIEW
   class IDGTOCPrinter < TOCPrinter
     def print_book(book)
       puts %Q(<?xml version="1.0" encoding="UTF-8"?>)
-      puts %Q(<doc xmlns:aid='http://ns.adobe.com/AdobeInDesign/4.0/'><title aid:pstyle="h0">1　パート1</title><?dtp level="0" section="第1部　パート1"?>) # FIXME: 部タイトルを取るには？ & 部ごとに結果を分けるには？
+      puts %Q(<doc xmlns:aid='http://ns.adobe.com/AdobeInDesign/4.0/'>)
+      puts %Q(<title aid:pstyle="h0">1　パート1</title><?dtp level="0" section="第1部　パート1"?>) # FIXME: 部タイトルを取るには？ & 部ごとに結果を分けるには？
       puts %Q(<ul aid:pstyle='ul-partblock'>)
-      print_children book
+      book.each_part do |part|
+        part.each_chapter do |chap|
+          chap_node = TOCParser.chapter_node(chap)
+          print_node 1, chap_node
+          print_children chap_node
+        end
+      end
       puts %Q(</ul></doc>)
     end
 

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -115,11 +115,10 @@ module ReVIEW
       if chap_node.number
         name = "chap#{chap_node.number}"
         label = "#{chap.number} #{chap.title}"
-        puts li(a_name(path, escape_html(label)))
       else
         label = chap.title
-        puts li(a_name(path, escape_html(label)))
       end
+      puts li(a_name(path, escape_html(label)))
       return unless print?(2)
       if print?(3)
         puts chap_sections_to_s(chap_node)

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -96,37 +96,33 @@ module ReVIEW
     include HTMLUtils
 
     def print_book(book)
-      return unless print?(1)
-      html = ""
       book.each_part do |part|
-        html << h1(part.name) if part.name
-        part.each_chapter do |chap|
-          chap_node = TOCParser.chapter_node(chap)
-          if chap_node.number
-            name = "chap#{chap_node.number}"
-            label = "第#{chap_node.number}章 #{chap_node.label}"
-            html << h2(a_name(escape_html(name), escape_html(label)))
-          else
-            label = "#{chap_node.label}"
-            html << h2(escape_html(label))
-          end
-          return unless print?(2)
-          if print?(3)
-            html << chap_sections_to_s(chap_node)
-          else
-            html << chapter_to_s(chap_node)
-          end
-        end
+        print_part(part)
       end
-      layout_file = File.join(book.basedir, "layouts", "layout.html.erb")
-      unless File.exist?(layout_file) # backward compatibility
-        layout_file = File.join(book.basedir, "layouts", "layout.erb")
+    end
+
+    def print_part(part)
+      puts h1(part.name) if part.name
+      part.each_chapter do |chap|
+        print_chapter(chap)
       end
-      if File.exist?(layout_file)
-        puts HTMLLayout.new(
-               {'body' => html, 'title' => "目次"}, layout_file).result
+    end
+
+    def print_chapter(chap)
+      chap_node = TOCParser.chapter_node(chap)
+      if chap_node.number
+        name = "chap#{chap_node.number}"
+        label = "第#{chap_node.number}章 #{chap_node.label}"
+        puts h2(a_name(escape_html(name), escape_html(label)))
       else
-        puts html
+        label = "#{chap_node.label}"
+        puts h2(escape_html(label))
+      end
+      return unless print?(2)
+      if print?(3)
+        puts chap_sections_to_s(chap_node)
+      else
+        puts chapter_to_s(chap_node)
       end
     end
 

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -168,47 +168,4 @@ module ReVIEW
 
   end
 
-  class IDGTOCPrinter < TOCPrinter
-
-    LABEL_LEN = 54
-
-    def print_book(book)
-      puts %Q(<?xml version="1.0" encoding="UTF-8"?>)
-      puts %Q(<doc xmlns:aid='http://ns.adobe.com/AdobeInDesign/4.0/'>)
-      puts %Q(<title aid:pstyle="h0">1　パート1</title><?dtp level="0" section="第1部　パート1"?>) # FIXME: 部タイトルを取るには？ & 部ごとに結果を分けるには？
-      puts %Q(<ul aid:pstyle='ul-partblock'>)
-      super
-      puts %Q(</ul></doc>)
-    end
-
-    private
-
-    def print_children(node)
-      return unless print?(node.level + 1)
-      node.each_section_with_index do |sec, idx|
-        print_node idx+1, sec
-        print_children sec
-      end
-    end
-
-    def print_node(seq, node)
-      if node.chapter?
-        printf "<li aid:pstyle='ul-part'>%s</li>\n",
-               "#{chapnumstr(node.number)}#{node.label}"
-      else
-        printf "<li>%-#{LABEL_LEN}s\n",
-               "  #{'   ' * (node.level - 1)}#{seq}　#{node.label}</li>"
-      end
-    end
-
-    def chapnumstr(n)
-      n ? sprintf('第%d章　', n) : ''
-    end
-
-    def volume_columns(level, volstr)
-      cols = ["", "", "", nil]
-      cols[level - 1] = volstr
-      cols[0, 3]
-    end
-  end
 end


### PR DESCRIPTION
目次周りを何とかするべく、TOCParserを大工事しています。

* TOCRoot を廃止して、既存のReVIEW::Book::* のクラスに後からincludeする形の修正をなくし、TOCParserで定義しているクラス郡とは完全に別扱いするようになっています。
    * 現状はTOCParserをrequireするとReVIEW::Book::*にeach_sectionとかを追加して、上手い感じに扱えるようなハックが入っているのですが、ちょっとハック過ぎるというか、同じ物として扱おうとするのは筋が悪そうです。少なくともTOCParser::ChapterとReVIEW::Book::Chapterの両方がある時点でやばそう
* TOCPrinter側も、TEXT/HTML/IDGで別々のロジックになっていたところを統一しています。
    * というかHTMLがまともに動いてなかった。たぶん`--html`オプションは誰も使ってない。
    * `-a`で文書全体、`-p`で部単位、`-c`で章単位に出力するところを、print_book, print_part, print_chapterのメソッドに切り分けて、各メソッドの実装もこれらのメソッドを使うようにしています。
* `ruby -w`をつけて警告が出るところを一部修正しています。

今のところTOCParserはreview-indexコマンドでしか使っていないはずですが、本体でも使うようにする予定です。