### PR TITLE
ReVIEW::Chapter and ReVIEW::Part: do not use lazy loading

### DIFF
--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -24,7 +24,16 @@ module ReVIEW
         @path = path
         @io = io
         @title = nil
-        @content = nil
+        if @io
+          begin
+            @content = @io.read
+          rescue
+            @content = nil
+          end
+        end
+        if !@content && @path && File.exist?(@path)
+          @content = File.read(@path)
+        end
         @list_index = nil
         @table_index = nil
         @footnote_index = nil

--- a/lib/review/book/compilable.rb
+++ b/lib/review/book/compilable.rb
@@ -42,19 +42,17 @@ module ReVIEW
         return @title if @title
 
         @title = ''
-        open {|f|
-          f.each_line {|l|
-            if l =~ /\A=+/
-              @title = l.sub(/\A=+(\[.+?\])?(\{.+?\})?/, '').strip
-              break
-            end
-          }
-        }
+        content.each_line do |line|
+          if line =~ /\A=+/
+            @title = line.sub(/\A=+(\[.+?\])?(\{.+?\})?/, '').strip
+            break
+          end
+        end
         @title
       end
 
       def size
-        File.size(path())
+        content.size
       end
 
       def volume
@@ -65,16 +63,15 @@ module ReVIEW
         @volume
       end
 
+      # deprecated; use content()
       def open(&block)
         return (block_given?() ? yield(@io) : @io) if @io
-        File.open(path(), &block)
+        StringIO.new(content)
       end
 
       attr_writer :content
 
       def content
-        @content = File.read(path())
-      rescue
         @content
       end
 

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -20,6 +20,9 @@ module ReVIEW
         @number = number
         @chapters = chapters
         @path = name
+        if @path && File.exist?(@path)
+          @content = File.read(@path)
+        end
         @name = name ? File.basename(name, '.re') : nil
         @volume = nil
       end

--- a/lib/review/tocparser.rb
+++ b/lib/review/tocparser.rb
@@ -18,12 +18,11 @@ module ReVIEW
 
   class TOCParser
     def TOCParser.parse(chap)
-      chap.open do |f|
-        stream = Preprocessor::Strip.new(f)
-        new.parse(stream, chap).map do |root|
-          root.number = chap.number
-          root
-        end
+      f = StringIO.new(chap.content)
+      stream = Preprocessor::Strip.new(f)
+      new.parse(stream, chap).map do |root|
+        root.number = chap.number
+        root
       end
     end
 

--- a/test/test_book_chapter.rb
+++ b/test/test_book_chapter.rb
@@ -40,10 +40,6 @@ class ChapterTest < Test::Unit::TestCase
     ch = Book::Chapter.new(nil, nil, nil, __FILE__, :io)
     assert_equal :io, ch.open
     assert_equal [:io], ch.open {|io| [io] }
-
-    ch = Book::Chapter.new(nil, nil, nil, __FILE__)
-    assert_equal __FILE__, ch.open.path
-    assert_equal [__FILE__], ch.open {|io| [io.path] }
   end
 
   def test_size
@@ -52,9 +48,7 @@ class ChapterTest < Test::Unit::TestCase
 
     File.open(__FILE__, 'r') do |i|
       ch = Book::Chapter.new(nil, nil, nil, nil, i)
-      assert_raises(TypeError) do # XXX: OK?
-        ch.size
-      end
+      assert_equal File.size(__FILE__), ch.size
     end
   end
 


### PR DESCRIPTION
*.re ファイルについて、それに対応するオブジェクトの初期化時に中身を読み込むようにして、それ以降読み込み直さないようにするものです。

また、どうせ読み込んでしまうので、Chapter#open（*.reの中身をIOオブジェクトとして返す）はdeprecatedにして、Chapter#content(*.reの中身をStringオブジェクトとして返す)を使うようにしたいです（IOが必要な場合はStringIOでラップする）。

* Chapter.new and Part.new: read file and set @content immediately
* Compilable#title: use @content instead of self.open
* Compilable#size: use @content instead of load file.
* Compilable#open: do not use File.open
* TOCParser.parse: use Chapter#content instead of Chapter#open