### PR TITLE
use ReVIEW::Converter instead of system("review-compile ...")

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -37,6 +37,9 @@ module ReVIEW
         "debug" => nil, # debug flag
         "catalogfile" => 'catalog.yml',
         "language" => 'ja', # XXX default language should be JA??
+        "mathml" => nil, # for HTML
+        "htmlext" => "html",
+        "htmlversion" => 4,
 
         "chapter_file" => 'CHAPS',
         "part_file" => 'PART',

--- a/lib/review/converter.rb
+++ b/lib/review/converter.rb
@@ -1,0 +1,34 @@
+# encoding: utf-8
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+#
+
+module ReVIEW
+  class Converter
+    attr_accessor :target
+
+    def initialize(book, target)
+      @book = book
+      @compiler = ReVIEW::Compiler.new(load_builder(target))
+    end
+
+    def convert(file, output_path)
+      chap_name = File.basename(file, '.*')
+      chap = @book.chapter(chap_name)
+      result = @compiler.compile(chap)
+      File.open(output_path, 'w') do |f|
+        f.puts result
+      end
+    end
+
+    private
+
+    def load_builder(target)
+      require "review/#{target}builder"
+      ReVIEW.const_get("#{target.upcase}Builder").new
+    end
+  end
+end
+

--- a/lib/review/converter.rb
+++ b/lib/review/converter.rb
@@ -9,9 +9,9 @@ module ReVIEW
   class Converter
     attr_accessor :target
 
-    def initialize(book, target)
+    def initialize(book, builder)
       @book = book
-      @compiler = ReVIEW::Compiler.new(load_builder(target))
+      @compiler = ReVIEW::Compiler.new(builder)
     end
 
     def convert(file, output_path)
@@ -21,13 +21,6 @@ module ReVIEW
       File.open(output_path, 'w') do |f|
         f.puts result
       end
-    end
-
-    private
-
-    def load_builder(target)
-      require "review/#{target}builder"
-      ReVIEW.const_get("#{target.upcase}Builder").new
     end
   end
 end

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -13,6 +13,7 @@ require 'rexml/streamlistener'
 require 'epubmaker'
 require 'review/htmltoc'
 require 'review/converter'
+require 'review/htmlbuilder'
 
 module ReVIEW
  class EPUBMaker
@@ -200,7 +201,7 @@ module ReVIEW
     base_path = Pathname.new(basedir)
     book = ReVIEW::Book.load(basedir)
     book.config = @params
-    @converter = ReVIEW::Converter.new(book, "html")
+    @converter = ReVIEW::Converter.new(book, ReVIEW::HTMLBuilder.new)
     @compile_errors = nil
     book.parts.each do |part|
       htmlfile = nil

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -12,6 +12,7 @@ require 'rexml/document'
 require 'rexml/streamlistener'
 require 'epubmaker'
 require 'review/htmltoc'
+require 'review/converter'
 
 module ReVIEW
  class EPUBMaker
@@ -178,6 +179,13 @@ module ReVIEW
     end
   end
 
+  def check_compile_status
+    return unless @compile_errors
+
+    $stderr.puts "compile error, No EPUB file output."
+    exit 1
+  end
+
   def build_body(basetmpdir, yamlfile)
     @precount = 0
     @bodycount = 0
@@ -188,15 +196,17 @@ module ReVIEW
     @tocdesc = Array.new
     # toccount = 2  ## not used
 
-    basedir = Dir.pwd
+    basedir = File.dirname(yamlfile)
     base_path = Pathname.new(basedir)
     book = ReVIEW::Book.load(basedir)
-    book.load_config(yamlfile)
+    book.config = @params
+    @converter = ReVIEW::Converter.new(book, "html")
+    @compile_errors = nil
     book.parts.each do |part|
       htmlfile = nil
       if part.name.present?
         if part.file?
-          build_chap(part, base_path, basetmpdir, yamlfile, true)
+          build_chap(part, base_path, basetmpdir, true)
         else
           htmlfile = "part_#{part.number}.#{@params["htmlext"]}"
           build_part(part, basetmpdir, htmlfile)
@@ -208,10 +218,11 @@ module ReVIEW
       end
 
       part.chapters.each do |chap|
-        build_chap(chap, base_path, basetmpdir, yamlfile, nil)
+        build_chap(chap, base_path, basetmpdir, false)
       end
 
     end
+    check_compile_status()
   end
 
   def build_part(part, basetmpdir, htmlfile)
@@ -241,11 +252,11 @@ module ReVIEW
     end
   end
 
-  def build_chap(chap, base_path, basetmpdir, yamlfile, ispart=nil)
+  def build_chap(chap, base_path, basetmpdir, ispart)
     filename = ""
 
     chaptype = "body"
-    if ispart.present?
+    if ispart
       chaptype = "part"
     elsif chap.on_PREDEF?
       chaptype = "pre"
@@ -277,8 +288,6 @@ module ReVIEW
     write_buildlogtxt(basetmpdir, htmlfile, filename)
     log("Create #{htmlfile} from #{filename}.")
 
-    level = @params["secnolevel"]
-
 # TODO: It would be nice if we can modify level in PART, PREDEF, or POSTDEF.
 #        But we have to care about section number reference (@<hd>) also.
 #
@@ -289,15 +298,20 @@ module ReVIEW
 #      level = @params["post_secnolevel"] if chap.on_APPENDIX?
 #    end
 
-    stylesheet = ""
-    if @params["stylesheet"].size > 0
-      stylesheet = "--stylesheet=#{@params["stylesheet"].join(",")}"
+    if @params["params"].present?
+      warn "'params:' in config.yml is obsoleted."
+      if @params["params"] =~ /stylesheet=/
+        warn "stylesheets should be defined in 'stylesheet:', not in 'params:'"
+      end
     end
-
-    ENV["REVIEWFNAME"] = filename
-    system("#{ReVIEW::MakerHelper.bindir}/review-compile --yaml=#{yamlfile} --target=html --level=#{level} --htmlversion=#{@params["htmlversion"]} --epubversion=#{@params["epubversion"]} #{stylesheet} #{@params["params"]} #{filename} > \"#{basetmpdir}/#{htmlfile}\"")
-
-    write_info_body(basetmpdir, id, htmlfile, ispart, chaptype)
+    begin
+      @converter.convert(filename, File.join(basetmpdir, htmlfile))
+      write_info_body(basetmpdir, id, htmlfile, ispart, chaptype)
+    rescue => e
+      @compile_errors = true
+      warn "compile error in #{filename} (#{e.class})"
+      warn e.message
+    end
   end
 
   def detect_properties(path)

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -15,6 +15,7 @@ require 'erb'
 require 'review'
 require 'review/i18n'
 require 'review/converter'
+require 'review/latexbuilder'
 
 
 module ReVIEW
@@ -116,7 +117,7 @@ module ReVIEW
 
       book = ReVIEW::Book.load(@basedir)
       book.config = @config
-      @converter = ReVIEW::Converter.new(book, "latex")
+      @converter = ReVIEW::Converter.new(book, ReVIEW::LATEXBuilder.new)
       book.parts.each do |part|
         if part.name.present?
           if part.file?

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -14,6 +14,7 @@ require 'erb'
 
 require 'review'
 require 'review/i18n'
+require 'review/converter'
 
 
 module ReVIEW
@@ -25,7 +26,7 @@ module ReVIEW
     attr_accessor :config, :basedir
 
     def initialize
-      @basedir = Dir.pwd
+      @basedir = nil
     end
 
     def system_or_raise(*args)
@@ -101,6 +102,7 @@ module ReVIEW
       # YAML configs will be overridden by command line options.
       @config.merge!(cmd_config)
       I18n.setup(@config["language"])
+      @basedir = File.dirname(yamlfile)
       generate_pdf(yamlfile)
     end
 
@@ -114,6 +116,7 @@ module ReVIEW
 
       book = ReVIEW::Book.load(@basedir)
       book.config = @config
+      @converter = ReVIEW::Converter.new(book, "latex")
       book.parts.each do |part|
         if part.name.present?
           if part.file?
@@ -193,12 +196,12 @@ module ReVIEW
 
     def output_chaps(filename, yamlfile)
       $stderr.puts "compiling #{filename}.tex"
-      cmd = "#{ReVIEW::MakerHelper.bindir}/review-compile --yaml=#{yamlfile} --target=latex --level=#{@config["secnolevel"]} --toclevel=#{@config["toclevel"]} #{@config["params"]} #{filename}.re > #{@path}/#{filename}.tex"
-      if system cmd
-        # OK
-      else
+      begin
+        @converter.convert(filename+".re", File.join(@path, filename+".tex"))
+      rescue => e
         @compile_errors = true
-        warn cmd
+        warn "compile error in #{filename}.tex (#{e.class})"
+        warn e.message
       end
     end
 

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -37,6 +37,7 @@ class PDFMakerTest < Test::Unit::TestCase
   def test_check_book_none
     Dir.mktmpdir do |dir|
       assert_nothing_raised do
+        @maker.basedir = Dir.pwd
         @maker.remove_old_file
       end
     end
@@ -132,6 +133,7 @@ class PDFMakerTest < Test::Unit::TestCase
 
   def test_gettemplate
     Dir.mktmpdir do |dir|
+      @maker.basedir = Dir.pwd
       tmpl = @maker.get_template
       expect = File.read(File.join(assets_dir,"test_template.tex"))
       assert_equal(expect, tmpl)
@@ -159,6 +161,7 @@ class PDFMakerTest < Test::Unit::TestCase
 
         expect = File.read(File.join(assets_dir,"test_template_backmatter.tex"))
 
+        @maker.basedir = Dir.pwd
         tmpl = @maker.get_template
         tmpl.gsub!(/\A.*%% backmatter begins\n/m,"")
         assert_equal(expect, tmpl)


### PR DESCRIPTION
* `ReVIEW::Configure`: add some default values
* `ReVIEW::EPUBMaker`, `ReVIEW::PDFMaker`: basedir should be same as yamlfile
* `ReVIEW::EPUBMaker`: stop building when error occured in compile *.re files.

review-epubmakerとreview-pdfmakerで、内部的にreview-compileを呼ぶのを止めて、compile用のReVIEW::Converterクラスを使うようにするものです。
review-epubmakerは5倍くらいは速くなりそうです(review-pdfmakerはLaTeX側処理が圧倒的に時間がかかっているのであんまり変わらない)。
ただし、review-compileは別コマンドを呼ぶことによってBookオブジェクト等が共有されていなかったのですが、ReVIEW::Converterでは積極的に共有する形にしているので、思わぬ結果になる可能性があります。