### PR TITLE
fix unclosed file

### DIFF
--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -200,7 +200,7 @@ module ReVIEW
 
         catalogfile_path = "#{basedir}/#{config["catalogfile"]}"
         if File.file? catalogfile_path
-          @catalog = Catalog.new(File.open(catalogfile_path))
+          @catalog = File.open(catalogfile_path){|f| Catalog.new(f) }
         end
 
         @catalog

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -414,7 +414,7 @@ module ReVIEW
     end
 
     def inline_include(file_name)
-      compile_inline File.open(file_name).read
+      compile_inline File.read(file_name)
     end
 
     def include(file_name)

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -300,7 +300,7 @@ module ReVIEW
         template = layout_file
       end
 
-      erb = ERB.new(File.open(template).read)
+      erb = ERB.new(File.read(template))
       values = @config # must be 'values' for legacy files
       erb.result(binding)
     end


### PR DESCRIPTION
Hi.
On Windows, Re:VIEW fails delete temporary directory because of not-explicitly-closed-file object.
I have fixed them.