### PR TITLE
booktitleなどにも読みの指定を許可。sample.ymlにドキュメント化

### DIFF
--- a/doc/sample.yml
+++ b/doc/sample.yml
@@ -8,13 +8,16 @@
 bookname: review-sample
 
 # 書名
+# 読みを入れる例 booktitle: {name: "Re:VIEW EPUBサンプル", file-as: "リビューイーパブサンプル"}
 booktitle: Re:VIEW EPUBサンプル
 
 # 著者名。「, 」で区切って複数指定できる
+# 読みを入れる例 aut: [{name: "青木峰郎", file-as: "アオキミネロウ"}, {name: "武藤健志", file-as: "ムトウケンシ"}, {name: "高橋征義", file-as: "タカハシマサヨシ"}, {name: "角征典", file-as: "カドマサノリ"}]
 aut: ["Minero Aoki", "Kenshi Muto", "Masayoshi Takahashi", "Masanori Kado"]
 
 # 以下はオプション
 # 以下はオプション(autと同じように配列書式で複数指定可能)。
+# 読みの指定はaut:の例を参照。
 # a-が付いているものはcreator側、
 # 付いていないものはcontributor側(二次協力者)に入る
 # a-adp, adp: 異なるメディア向けに作り直した者

--- a/lib/epubmaker/epubv3.rb
+++ b/lib/epubmaker/epubv3.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # = epubv3.rb -- EPUB version 3 producer.
 #
-# Copyright (c) 2010-2015 Kenshi Muto
+# Copyright (c) 2010-2016 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -36,9 +36,23 @@ module EPUBMaker
       %w[title language date type format source description relation coverage subject rights].each do |item|
         next if @producer.params[item].nil?
         if @producer.params[item].instance_of?(Array)
-          @producer.params[item].each_with_index {|v, i|
-            s << %Q[    <dc:#{item} id="#{item}-#{i}">#{CGI.escapeHTML(v.to_s)}</dc:#{item}>\n]
-          }
+          @producer.params[item].each_with_index do |v, i|
+            if v.instance_of?(Hash)
+              s << %Q[    <dc:#{item} id="#{item}-#{i}">#{CGI.escapeHTML(v["name"])}</dc:#{item}>\n]
+              v.each_pair do |name, val|
+                next if name == "name"
+                s << %Q[    <meta refines="##{item}-#{i}" property="#{name}">#{CGI.escapeHTML(val)}</meta>\n]
+              end
+            else
+              s << %Q[    <dc:#{item} id="#{item}-#{i}">#{CGI.escapeHTML(v.to_s)}</dc:#{item}>\n]
+            end
+          end
+        elsif @producer.params[item].instance_of?(Hash)
+          s << %Q[    <dc:#{item} id="#{item}">#{CGI.escapeHTML(@producer.params[item]["name"])}</dc:#{item}>\n]
+          @producer.params[item].each_pair do |name, val|
+            next if name == "name"
+            s << %Q[    <meta refines="##{item}" property="#{name}">#{CGI.escapeHTML(val)}</meta>\n]
+          end
         else
           s << %Q[    <dc:#{item} id="#{item}">#{CGI.escapeHTML(@producer.params[item].to_s)}</dc:#{item}>\n]
         end

--- a/test/test_epub3maker.rb
+++ b/test/test_epub3maker.rb
@@ -81,6 +81,50 @@ EOT
     assert_equal expect, @output.string
   end
 
+  def test_stage1_opf_fileas
+    @producer.params["title"] = {"name" => "これは書籍です", "file-as" => "コレハショセキデス"}
+    @producer.params["aut"] = [{"name" => "著者A", "file-as" => "チョシャA"}, {"name" => "著者B", "file-as" => "チョシャB"}]
+    @producer.params["pbl"] = [{"name" => "出版社", "file-as" => "シュッパンシャ"}]
+    @producer.opf(@output)
+    expect = <<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookId" xml:lang="en">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title id="title">これは書籍です</dc:title>
+    <meta refines="#title" property="file-as">コレハショセキデス</meta>
+    <dc:language id="language">en</dc:language>
+    <dc:date id="date">2011-01-01</dc:date>
+    <meta property="dcterms:modified">2014-12-13T14:15:16Z</meta>
+    <dc:identifier id="BookId">http://example.jp/</dc:identifier>
+    <dc:creator id="aut-0">著者A</dc:creator>
+    <meta refines="#aut-0" property="role" scheme="marc:relators">aut</meta>
+    <meta refines="#aut-0" property="file-as">チョシャA</meta>
+    <dc:creator id="aut-1">著者B</dc:creator>
+    <meta refines="#aut-1" property="role" scheme="marc:relators">aut</meta>
+    <meta refines="#aut-1" property="file-as">チョシャB</meta>
+    <dc:contributor id="pbl-0">出版社</dc:contributor>
+    <meta refines="#pbl-0" property="role" scheme="marc:relators">pbl</meta>
+    <meta refines="#pbl-0" property="file-as">シュッパンシャ</meta>
+    <dc:publisher id="pub-pbl-0">出版社</dc:publisher>
+    <meta refines="#pub-pbl-0" property="role" scheme="marc:relators">pbl</meta>
+    <meta refines="#pub-pbl-0" property="file-as">シュッパンシャ</meta>
+  </metadata>
+  <manifest>
+    <item properties="nav" id="sample-toc.html" href="sample-toc.html" media-type="application/xhtml+xml"/>
+    <item id="sample" href="sample.html" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine>
+    <itemref idref="sample" linear="no"/>
+  </spine>
+  <guide>
+    <reference type="cover" title="Cover" href="sample.html"/>
+    <reference type="toc" title="Table of Contents" href="sample-toc.html"/>
+  </guide>
+</package>
+EOT
+    assert_equal expect, @output.string
+  end
+
   def test_stage1_ncx
     @producer.ncx(@output)
    expect = <<EOT


### PR DESCRIPTION
changelogをミスった気もしますが、とりあえず電書協ガイドラインのほか、今後のEPUB3.1でもrequiredになりそうなので、読み属性の適用範囲を広げました。
書式についてもsample.ymlに書いています。