### PR TITLE
accept multiple YAML files for configuration.

### DIFF
--- a/bin/review-compile
+++ b/bin/review-compile
@@ -66,7 +66,7 @@ def _main
   opts = OptionParser.new
   opts.version = ReVIEW::VERSION
   opts.banner = "Usage: #{File.basename($0)} [--target=FMT]"
-  opts.on('--yaml=YAML', 'Read configurations from YAML file.') {|yaml| config["yaml"] = yaml}
+  opts.on('--yaml=YAML[,YAML,...]', 'Read configurations from YAML file.') {|yaml| config["yaml"] = yaml}
   opts.on('-c', '--check', 'Check manuscript') { check_only = true }
   opts.on('--level=LVL', 'Section level to append number.') {|lvl| config["secnolevel"] = lvl.to_i }
   opts.on('--toclevel=LVL', 'Section level to append number.') {|lvl| config["toclevel"] = lvl.to_i }
@@ -138,14 +138,14 @@ def _main
 
   begin
     if config["yaml"]
-      config = config.merge(YAML.load_file(config["yaml"]))
+      config["yaml"].split(",").each do |yamlfile|
+        config.merge!(YAML.load_file(yamlfile))
+      end
     else
       if File.exist?(DEFAULT_CONFIG_FILENAME)
         config = config.merge(YAML.load_file(DEFAULT_CONFIG_FILENAME))
       end
     end
-
-
 
     config["builder"] = target
     ReVIEW::I18n.setup(config["language"])

--- a/bin/review-epubmaker
+++ b/bin/review-epubmaker
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
 #
-# Copyright (c) 2010-2013 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2016 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -33,12 +33,23 @@ rescue OptionParser::ParseError => err
   exit 1
 end
 
-
-if ARGV.size < 1 || !File.exist?(ARGV[0])
+if ARGV.size < 1
   puts opts.help
   exit 1
 end
 
-yaml_file = ARGV[0]
-bookname = ARGV[1]
-rv.produce(yaml_file, bookname)
+yamlfiles = []
+bookname = nil
+
+ARGV.each_with_index do |arg, i|
+  if arg =~ /\.ya?ml\Z/i
+    yamlfiles.push(arg)
+  elsif ARGV.size == i - 1
+    bookname = arg
+  else
+    puts opts.help
+    exit 1
+  end
+end
+
+rv.produce(yamlfiles, bookname)

--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # = producer.rb -- EPUB producer.
 #
-# Copyright (c) 2010-2015 Kenshi Muto
+# Copyright (c) 2010-2016 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -27,16 +27,22 @@ module EPUBMaker
     # Message resource object.
     attr_reader :res
 
-    # Take YAML +file+ and return parameter hash.
-    def Producer.load(file)
-      raise "Can't open #{yamlfile}." if file.nil? || !File.exist?(file)
-      return YAML.load_file(file)
+    # Take YAML +files+ and return parameter hash.
+    def Producer.load(files)
+      params = {}
+      files.each do |file|
+        raise "Can't open #{file}." if file.nil? || !File.exist?(file)
+        params.merge!(YAML.load_file(file))
+      end
+      params
     end
 
-    # Take YAML +file+ and update parameter hash.
-    def load(file)
-      raise "Can't open #{yamlfile}." if file.nil? || !File.exist?(file)
-      merge_params(@params.merge(YAML.load_file(file)))
+    # Take YAML +files+ and update parameter hash.
+    def load(files)
+      files.each do |file|
+        raise "Can't open #{file}." if file.nil? || !File.exist?(file)
+        merge_params(@params.merge(YAML.load_file(file)))
+      end
     end
 
     # Construct producer object.

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -61,9 +61,9 @@ class PDFMakerTest < Test::Unit::TestCase
 
   def test_parse_opts_ignore_errors
     io = StringIO.new
-    conf, yml = @maker.parse_opts(["--ignore-errors", "hoge.yml"])
+    conf, ymls = @maker.parse_opts(["--ignore-errors", "hoge.yml", "foo.yml"])
     assert_equal conf["ignore-errors"], true
-    assert_equal yml, "hoge.yml"
+    assert_equal ymls, ["hoge.yml", "foo.yml"]
   end
 
   def test_make_custom_page


### PR DESCRIPTION
#503 の実装手段として、「複数のymlファイルを指定して順に上書きできる」ように*-makerおよびreview-compileに手を入れてみました。