### PR TITLE
inheritパラメータでRe:VIEWのコードパスを$REVIEW_PATHという文字列で参照できるようにする

### DIFF
--- a/lib/review/makerhelper.rb
+++ b/lib/review/makerhelper.rb
@@ -72,11 +72,11 @@ module ReVIEW
     class << self
       private
       def __recursive_load_yaml(yaml, yamlfile, loaded_yaml={})
+        reviewpath = Pathname.new("#{Pathname.new(__FILE__).realpath.dirname}/../..").realpath
         _yaml = YAML.load_file(yamlfile)
         yaml = _yaml.merge(yaml)
         if yaml['inherit']
-          inheritfile = yaml['inherit']
-          
+          inheritfile = yaml['inherit'].sub(/\$REVIEW_PATH\//, "#{reviewpath}/")
           # Check loop
           if loaded_yaml[inheritfile]
             raise "Found cyclic YAML inheritance '#{inheritfile}' in #{yamlfile}."


### PR DESCRIPTION
#516 の対策の提案です。
<Re:VIEWコードパス>/doc/sample.yml を読み込むために、``inherit: $REVIEW_PATH/doc/sample.yml`` からYAMLロード時に実際のコードパスに置き換えるようにするものです。
