### PR TITLE
note about opf_prefix and opf_meta

### DIFF
--- a/doc/sample.yml
+++ b/doc/sample.yml
@@ -174,6 +174,12 @@ secnolevel: 2
 # ページ送りの送り方向、page-progression-directionの値("ltr"|"rtl"|"default")
 # direction: "ltr"
 
+# EPUBのOPFへの固有の追加ルール
+# <package>要素に追加する名前空間
+# opf_prefix: {ebpaj: "http://www.ebpaj.jp/"}
+# 追加する<meta>要素のプロパティとその値
+# opf_meta: {"ebpaj:guide-version": "1.1.3"}
+
 # 以下のパラメータを有効にするときには、
 # epubmaker:
 #    パラメータ: 値


### PR DESCRIPTION
opf_prefix, opf_metaのとりあえずのコメントをsample.ymlに追加。
本当はepubmaker:の下にしたい（#515 絡み）が、とりあえずこれでマージ。
