### PR TITLE
refactoring, escaping and i18ning.

### DIFF
--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -64,7 +64,7 @@ module EPUBMaker
     <text>#{CGI.escapeHTML(@producer.params["title"])}</text>
   </docTitle>
   <docAuthor>
-    <text>#{@producer.params["aut"].nil? ? "" : CGI.escapeHTML(join_with_separator(@producer.params["aut"], ", "))}</text>
+    <text>#{@producer.params["aut"].nil? ? "" : CGI.escapeHTML(join_with_separator(@producer.params["aut"], ReVIEW::I18n.t("names_splitter")))}</text>
   </docAuthor>
 EOT
     end
@@ -86,7 +86,7 @@ EOT
         s << <<EOT
     <navPoint id="toc" playOrder="#{nav_count}">
       <navLabel>
-        <text>#{@producer.res.v("toctitle")}</text>
+        <text>#{CGI.escapeHTML(@producer.res.v("toctitle"))}</text>
       </navLabel>
       <content src="#{@producer.params["bookname"]}-toc.#{@producer.params["htmlext"]}"/>
     </navPoint>
@@ -144,7 +144,7 @@ EOT
         EOT
       end
 
-      @title = @producer.params['title']
+      @title = CGI.escapeHTML(@producer.params['title'])
       @language = @producer.params['language']
       @stylesheets = @producer.params["stylesheet"]
       if @producer.params["htmlversion"].to_i == 5
@@ -158,10 +158,10 @@ EOT
 
     # Return title (copying) content.
     def titlepage
-      @title = @producer.params["title"]
+      @title = CGI.escapeHTML(@producer.params["title"])
 
       @body = <<EOT
-  <h1 class="tp-title">#{CGI.escapeHTML(@title)}</h1>
+  <h1 class="tp-title">#{@title}</h1>
 EOT
       if @producer.params["aut"]
         @body << <<EOT
@@ -169,7 +169,7 @@ EOT
     <br />
     <br />
   </p>
-  <h2 class="tp-author">#{CGI.escapeHTML(join_with_separator(@producer.params["aut"], ", "))}</h2>
+  <h2 class="tp-author">#{CGI.escapeHTML(join_with_separator(@producer.params["aut"], ReVIEW::I18n.t("names_splitter")))}</h2>
 EOT
       end
 
@@ -182,7 +182,7 @@ EOT
     <br />
     <br />
   </p>
-  <h3 class="tp-publisher">#{CGI.escapeHTML(join_with_separator(publisher, ", "))}</h3>
+  <h3 class="tp-publisher">#{CGI.escapeHTML(join_with_separator(publisher, ReVIEW::I18n.t("names_splitter")))}</h3>
 EOT
       end
 
@@ -199,7 +199,7 @@ EOT
 
     # Return colophon content.
     def colophon
-      @title = @producer.res.v("colophontitle")
+      @title = CGI.escapeHTML(@producer.res.v("colophontitle"))
       @body = <<EOT
   <div class="colophon">
 EOT
@@ -240,7 +240,7 @@ EOT
       @body << %Q[    <table class="colophon">\n]
       @body << @producer.params["colophon_order"].map{ |role|
         if @producer.params[role]
-          %Q[      <tr><th>#{@producer.res.v(role)}</th><td>#{CGI.escapeHTML(join_with_separator(@producer.params[role], ", "))}</td></tr>\n]
+          %Q[      <tr><th>#{CGI.escapeHTML(@producer.res.v(role))}</th><td>#{CGI.escapeHTML(join_with_separator(@producer.params[role], ReVIEW::I18n.t("names_splitter")))}</td></tr>\n]
         else
           ""
         end
@@ -251,7 +251,7 @@ EOT
       end
       @body << %Q[    </table>\n]
       if !@producer.params["rights"].nil? && @producer.params["rights"].size > 0
-        @body << %Q[    <p class="copyright">#{join_with_separator(@producer.params["rights"], "<br />")}</p>]
+        @body << %Q[    <p class="copyright">#{join_with_separator(@producer.params["rights"].map {|m| CGI.escapeHTML(m)}, "<br />")}</p>\n]
       end
       @body << %Q[  </div>\n]
 
@@ -274,9 +274,9 @@ EOT
 
     # Return own toc content.
     def mytoc
-      @title = @producer.res.v("toctitle")
+      @title = CGI.escapeHTML(@producer.res.v("toctitle"))
 
-      @body = %Q[  <h1 class="toc-title">#{@producer.res.v("toctitle")}</h1>\n]
+      @body = %Q[  <h1 class="toc-title">#{CGI.escapeHTML(@producer.res.v("toctitle"))}</h1>\n]
       if @producer.params["epubmaker"]["flattoc"].nil?
         @body << hierarchy_ncx("ul")
       else

--- a/lib/epubmaker/epubv2.rb
+++ b/lib/epubmaker/epubv2.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # = epubv2.rb -- EPUB version 2 producer.
 #
-# Copyright (c) 2010-2015 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2016 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -36,8 +36,8 @@ module EPUBMaker
     def opf_metainfo
       s = ""
       %w[title language date type format source description relation coverage subject rights].each do |item|
-        next if @producer.params[item].nil?
-        if @producer.params[item].instance_of?(Array)
+        next unless @producer.params[item]
+        if @producer.params[item].kind_of?(Array)
           s << @producer.params[item].map {|i| %Q[    <dc:#{item}>#{CGI.escapeHTML(i.to_s)}</dc:#{item}>\n]}.join
         else
           s << %Q[    <dc:#{item}>#{CGI.escapeHTML(@producer.params[item].to_s)}</dc:#{item}>\n]
@@ -53,7 +53,7 @@ module EPUBMaker
 
       # creator (should be array)
       %w[aut a-adp a-ann a-arr a-art a-asn a-aqt a-aft a-aui a-ant a-bkp a-clb a-cmm a-dsr a-edt a-ill a-lyr a-mdc a-mus a-nrt a-oth a-pht a-prt a-red a-rev a-spn a-ths a-trc a-trl].each do |role|
-        next if @producer.params[role].nil?
+        next unless @producer.params[role]
         @producer.params[role].each do |v|
           s << %Q[    <dc:creator opf:role="#{role.sub('a-', '')}">#{CGI.escapeHTML(v)}</dc:creator>\n]
         end
@@ -61,7 +61,7 @@ module EPUBMaker
 
       # contributor (should be array)
       %w[adp ann arr art asn aqt aft aui ant bkp clb cmm dsr edt ill lyr mdc mus nrt oth pht prt red rev spn ths trc trl].each do |role|
-        next if @producer.params[role].nil?
+        next unless @producer.params[role]
         @producer.params[role].each do |v|
           s << %Q[    <dc:contributor opf:role="#{role}">#{CGI.escapeHTML(v)}</dc:contributor>\n]
           if role == "prt"

--- a/lib/epubmaker/epubv3.rb
+++ b/lib/epubmaker/epubv3.rb
@@ -46,10 +46,10 @@ module EPUBMaker
     def opf_metainfo
       s = ""
       %w[title language date type format source description relation coverage subject rights].each do |item|
-        next if @producer.params[item].nil?
-        if @producer.params[item].instance_of?(Array)
+        next unless @producer.params[item]
+        if @producer.params[item].kind_of?(Array)
           @producer.params[item].each_with_index do |v, i|
-            if v.instance_of?(Hash)
+            if v.kind_of?(Hash)
               s << %Q[    <dc:#{item} id="#{item}-#{i}">#{CGI.escapeHTML(v["name"])}</dc:#{item}>\n]
               v.each_pair do |name, val|
                 next if name == "name"
@@ -59,7 +59,7 @@ module EPUBMaker
               s << %Q[    <dc:#{item} id="#{item}-#{i}">#{CGI.escapeHTML(v.to_s)}</dc:#{item}>\n]
             end
           end
-        elsif @producer.params[item].instance_of?(Hash)
+        elsif @producer.params[item].kind_of?(Hash)
           s << %Q[    <dc:#{item} id="#{item}">#{CGI.escapeHTML(@producer.params[item]["name"])}</dc:#{item}>\n]
           @producer.params[item].each_pair do |name, val|
             next if name == "name"
@@ -81,9 +81,9 @@ module EPUBMaker
 
       # creator (should be array)
       %w[a-adp a-ann a-arr a-art a-asn a-aqt a-aft a-aui a-ant a-bkp a-clb a-cmm a-csl a-dsr a-edt a-ill a-lyr a-mdc a-mus a-nrt a-oth a-pht a-prt a-red a-rev a-spn a-ths a-trc a-trl aut].each do |role|
-        next if @producer.params[role].nil?
+        next unless @producer.params[role]
         @producer.params[role].each_with_index do |v, i|
-          if v.instance_of?(Hash)
+          if v.kind_of?(Hash)
             s << %Q[    <dc:creator id="#{role}-#{i}">#{CGI.escapeHTML(v["name"])}</dc:creator>\n]
             s << %Q[    <meta refines="##{role}-#{i}" property="role" scheme="marc:relators">#{role.sub('a-', '')}</meta>\n]
             v.each_pair do |name, val|
@@ -99,9 +99,9 @@ module EPUBMaker
 
       # contributor (should be array)
       %w[adp ann arr art asn aqt aft aui ant bkp clb cmm csl dsr edt ill lyr mdc mus nrt oth pbd pbl pht prt red rev spn ths trc trl].each do |role|
-        next if @producer.params[role].nil?
+        next unless @producer.params[role]
         @producer.params[role].each_with_index do |v, i|
-          if v.instance_of?(Hash)
+          if v.kind_of?(Hash)
             s << %Q[    <dc:contributor id="#{role}-#{i}">#{CGI.escapeHTML(v["name"])}</dc:contributor>\n]
             s << %Q[    <meta refines="##{role}-#{i}" property="role" scheme="marc:relators">#{role}</meta>\n]
             v.each_pair do |name, val|
@@ -114,7 +114,7 @@ module EPUBMaker
           end
 
           if role == "prt" || role == "pbl"
-            if v.instance_of?(Hash)
+            if v.kind_of?(Hash)
               s << %Q[    <dc:publisher id="pub-#{role}-#{i}">#{CGI.escapeHTML(v["name"])}</dc:publisher>\n]
               s << %Q[    <meta refines="#pub-#{role}-#{i}" property="role" scheme="marc:relators">#{role}</meta>\n]
               v.each_pair do |name, val|
@@ -204,11 +204,11 @@ EOT
 
       @body = <<EOT
   <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
-  <h1 class="toc-title">#{@producer.res.v("toctitle")}</h1>
+  <h1 class="toc-title">#{CGI.escapeHTML(@producer.res.v("toctitle"))}</h1>
 #{ncx_main}  </nav>
 EOT
 
-      @title = @producer.res.v("toctitle")
+      @title = CGI.escapeHTML(@producer.res.v("toctitle"))
       @language = @producer.params['language']
       @stylesheets = @producer.params["stylesheet"]
       tmplfile = File.expand_path('./html/layout-html5.html.erb', ReVIEW::Template::TEMPLATE_DIR)

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -229,9 +229,9 @@ module ReVIEW
     File.open("#{basetmpdir}/#{htmlfile}", "w") do |f|
       @body = ""
       @body << "<div class=\"part\">\n"
-      @body << "<h1 class=\"part-number\">#{ReVIEW::I18n.t("part", part.number)}</h1>\n"
+      @body << "<h1 class=\"part-number\">#{CGI.escapeHTML(ReVIEW::I18n.t("part", part.number))}</h1>\n"
       if part.name.strip.present?
-        @body << "<h2 class=\"part-title\">#{part.name.strip}</h2>\n"
+        @body << "<h2 class=\"part-title\">#{CGI.escapeHTML(part.name.strip)}</h2>\n"
       end
       @body << "</div>\n"
 
@@ -286,16 +286,6 @@ module ReVIEW
     htmlfile = "#{id}.#{@params["htmlext"]}"
     write_buildlogtxt(basetmpdir, htmlfile, filename)
     log("Create #{htmlfile} from #{filename}.")
-
-# TODO: It would be nice if we can modify level in PART, PREDEF, or POSTDEF.
-#        But we have to care about section number reference (@<hd>) also.
-#
-#    if !ispart.nil?
-#      level = @params["part_secnolevel"]
-#    else
-#      level = @params["pre_secnolevel"] if chap.on_PREDEF?
-#      level = @params["post_secnolevel"] if chap.on_APPENDIX?
-#    end
 
     if @params["params"].present?
       warn "'params:' in config.yml is obsoleted."
@@ -398,15 +388,16 @@ module ReVIEW
   end
 
   def build_titlepage(basetmpdir, htmlfile)
+    # TODO: should be created via epubcommon
     File.open("#{basetmpdir}/#{htmlfile}", "w") do |f|
       @body = ""
-      @body << "<div class=\"titlepage\">"
-      @body << "<h1 class=\"tp-title\">#{CGI.escapeHTML(@params["booktitle"])}</h1>"
+      @body << "<div class=\"titlepage\">\n"
+      @body << "<h1 class=\"tp-title\">#{CGI.escapeHTML(@params["booktitle"])}</h1>\n"
       if @params["aut"]
-        @body << "<h2 class=\"tp-author\">#{@params["aut"].join(", ")}</h2>"
+        @body << "<h2 class=\"tp-author\">#{CGI.escapeHTML(@params["aut"].join(ReVIEW::I18n.t("names_splitter")))}</h2>\n"
       end
       if @params["prt"]
-        @body << "<h3 class=\"tp-publisher\">#{@params["prt"].join(", ")}</h3>"
+        @body << "<h3 class=\"tp-publisher\">#{CGI.escapeHTML(@params["prt"].join(ReVIEW::I18n.t("names_splitter")))}</h3>\n"
       end
       @body << "</div>"
 
@@ -430,7 +421,7 @@ module ReVIEW
     end
 
     if @params["colophon"]
-      if @params["colophon"].instance_of?(String) # FIXME:このやり方はやめる？
+      if @params["colophon"].kind_of?(String) # FIXME:このやり方はやめる？
         FileUtils.cp(@params["colophon"], "#{basetmpdir}/colophon.#{@params["htmlext"]}")
       else
         File.open("#{basetmpdir}/colophon.#{@params["htmlext"]}", "w") {|f| @producer.colophon(f) }

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -77,6 +77,33 @@ EOT
     assert_equal expect, @output.string
   end
 
+  def test_stage1_opf_escape
+    @producer.params["title"] = "Sample<>Book"
+    @producer.opf(@output)
+    expect = <<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<package version="2.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookId">
+  <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
+    <dc:title>Sample&lt;&gt;Book</dc:title>
+    <dc:language>en</dc:language>
+    <dc:date>2011-01-01</dc:date>
+    <dc:identifier id="BookId">http://example.jp/</dc:identifier>
+  </metadata>
+  <manifest>
+    <item id="ncx" href="sample.ncx" media-type="application/x-dtbncx+xml"/>
+    <item id="sample" href="sample.html" media-type="application/xhtml+xml"/>
+  </manifest>
+  <spine toc="ncx">
+    <itemref idref="sample" linear="no"/>
+  </spine>
+  <guide>
+    <reference type="cover" title="Cover" href="sample.html"/>
+  </guide>
+</package>
+EOT
+    assert_equal expect, @output.string
+  end
+
   def test_stage1_ncx
     @producer.ncx(@output)
    expect = <<EOT
@@ -98,6 +125,37 @@ EOT
     <navPoint id="top" playOrder="1">
       <navLabel>
         <text>Sample Book</text>
+      </navLabel>
+      <content src="sample.html"/>
+    </navPoint>
+  </navMap>
+</ncx>
+EOT
+    assert_equal expect, @output.string
+  end
+
+  def test_stage1_ncx_escape
+    @producer.params["title"] = "Sample<>Book"
+    @producer.ncx(@output)
+   expect = <<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<ncx xmlns="http://www.daisy.org/z3986/2005/ncx/" version="2005-1">
+  <head>
+    <meta name="dtb:depth" content="1"/>
+    <meta name="dtb:totalPageCount" content="0"/>
+    <meta name="dtb:maxPageNumber" content="0"/>
+    <meta name="dtb:uid" content="http://example.jp/"/>
+  </head>
+  <docTitle>
+    <text>Sample&lt;&gt;Book</text>
+  </docTitle>
+  <docAuthor>
+    <text></text>
+  </docAuthor>
+  <navMap>
+    <navPoint id="top" playOrder="1">
+      <navLabel>
+        <text>Sample&lt;&gt;Book</text>
       </navLabel>
       <content src="sample.html"/>
     </navPoint>
@@ -471,6 +529,28 @@ EOT
     assert_equal expect, @output.string
   end
 
+  def test_stage3_cover_escape
+    stage3
+    @producer.params["title"] = "Sample<>Book"
+    @producer.cover(@output)
+    expect = <<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+  <meta http-equiv="Content-Style-Type" content="text/css"/>
+  <meta name="generator" content="Re:VIEW"/>
+  <title>Sample&lt;&gt;Book</title>
+</head>
+<body>
+<h1 class="cover-title">Sample&lt;&gt;Book</h1>
+</body>
+</html>
+EOT
+    assert_equal expect, @output.string
+  end
+
   def test_stage3_cover_with_image
     stage3
     @producer.params["coverimage"] = "sample.png"
@@ -488,6 +568,31 @@ EOT
 <body>
   <div id="cover-image" class="cover-image">
     <img src="sample.png" alt="Sample Book" class="max"/>
+  </div>
+</body>
+</html>
+EOT
+    assert_equal expect, @output.string
+  end
+
+  def test_stage3_cover_with_image_escape
+    stage3
+    @producer.params["title"] = "Sample<>Book"
+    @producer.params["coverimage"] = "sample.png"
+    @producer.cover(@output)
+    expect = <<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+  <meta http-equiv="Content-Style-Type" content="text/css"/>
+  <meta name="generator" content="Re:VIEW"/>
+  <title>Sample&lt;&gt;Book</title>
+</head>
+<body>
+  <div id="cover-image" class="cover-image">
+    <img src="sample.png" alt="Sample&lt;&gt;Book" class="max"/>
   </div>
 </body>
 </html>
@@ -521,6 +626,43 @@ EOT
       <tr><th>Publisher</th><td>BLUEPRINT</td></tr>
       <tr><th>ISBN</th><td>978-4-79737-227-4</td></tr>
     </table>
+  </div>
+</body>
+</html>
+EOT
+    assert_equal expect, @output.string
+  end
+
+  def test_colophon_default_escape_and_multiple
+    @producer.params["title"] = "<&Sample Book>"
+    @producer.params["subtitle"] = "Sample<>Subtitle"
+    @producer.params["aut"] = ["Mr.Smith", "Mr.&Anderson"]
+    @producer.params["pbl"] = ["BLUEPRINT", "COPY<>EDIT"]
+    @producer.params["isbn"] = "9784797372274"
+    @producer.params["rights"] = ["COPYRIGHT 2016 <>", "& REVIEW"]
+    @producer.colophon(@output)
+    expect = <<EOT
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="en">
+<head>
+  <meta http-equiv="Content-Type" content="text/html;charset=UTF-8"/>
+  <meta http-equiv="Content-Style-Type" content="text/css"/>
+  <meta name="generator" content="Re:VIEW"/>
+  <title>Colophon</title>
+</head>
+<body>
+  <div class="colophon">
+    <p class="title">&lt;&amp;Sample Book&gt;<br /><span class="subtitle">Sample&lt;&gt;Subtitle</span></p>
+    <div class="pubhistory">
+      <p>published by Jan.  1, 2011</p>
+    </div>
+    <table class="colophon">
+      <tr><th>Author</th><td>Mr.Smith, Mr.&amp;Anderson</td></tr>
+      <tr><th>Publisher</th><td>BLUEPRINT, COPY&lt;&gt;EDIT</td></tr>
+      <tr><th>ISBN</th><td>978-4-79737-227-4</td></tr>
+    </table>
+    <p class="copyright">COPYRIGHT 2016 &lt;&gt;<br />&amp; REVIEW</p>
   </div>
 </body>
 </html>


### PR DESCRIPTION
EPUBMakerまわりの修正です。
名前の区切りに”,"を直接文字列で指定していた箇所をi18n.ymlのnamed_splitterの文字列に。
i18n文字列をそのままテンプレートに入れていた箇所をCGI.escapeHTMLするように。
そのほかif→unless、instance_of→kind_of、マージ時のdeep_merge利用です。

 - use i18n'd names_splitter string for splitting names (such as
   authors or contributors) in titlepage and colophon.
 - escape HTML tag of toctitle in toc file.
 - escape HTML tag of colophontitle and rights string in colophon file.
 - escape HTML tag of title in cover and titlepage.
 - use kind_of instead of instance_of.
 - use 'unless X' instead of 'if X.nil?' of one liner.
 - use deep_merge to merge epubmaker's default preset.
 - escape HTML tag of i18n'd part name.
 - add tests for HTML escaping.