### PR TITLE
名前付きパラメータへのEPUBmaker/PDFmakerの対応

### DIFF
--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 # = epubcommon.rb -- super class for EPUBv2 and EPUBv3
 #
-# Copyright (c) 2010-2014 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2016 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -135,16 +135,16 @@ EOT
         end
         @body = <<-EOT
   <div id="cover-image" class="cover-image">
-    <img src="#{file}" alt="#{CGI.escapeHTML(@producer.params.name("title"))}" class="max"/>
+    <img src="#{file}" alt="#{CGI.escapeHTML(@producer.params.name_of("title"))}" class="max"/>
   </div>
         EOT
       else
         @body = <<-EOT
-<h1 class="cover-title">#{CGI.escapeHTML(@producer.params.name("title"))}</h1>
+<h1 class="cover-title">#{CGI.escapeHTML(@producer.params.name_of("title"))}</h1>
         EOT
       end
 
-      @title = CGI.escapeHTML(@producer.params.name("title"))
+      @title = CGI.escapeHTML(@producer.params.name_of("title"))
       @language = @producer.params['language']
       @stylesheets = @producer.params["stylesheet"]
       if @producer.params["htmlversion"].to_i == 5
@@ -158,7 +158,7 @@ EOT
 
     # Return title (copying) content.
     def titlepage
-      @title = CGI.escapeHTML(@producer.params.name("title"))
+      @title = CGI.escapeHTML(@producer.params.name_of("title"))
 
       @body = <<EOT
   <h1 class="tp-title">#{@title}</h1>
@@ -169,11 +169,11 @@ EOT
     <br />
     <br />
   </p>
-  <h2 class="tp-author">#{CGI.escapeHTML(join_with_separator(@producer.params.names("aut"), ReVIEW::I18n.t("names_splitter")))}</h2>
+  <h2 class="tp-author">#{CGI.escapeHTML(join_with_separator(@producer.params.names_of("aut"), ReVIEW::I18n.t("names_splitter")))}</h2>
 EOT
       end
 
-      publisher = @producer.params.names("pbl") || @producer.params.names("prt") # XXX Backward Compatiblity
+      publisher = @producer.params.names_of("pbl") || @producer.params.names_of("prt") # XXX Backward Compatiblity
       if publisher
         @body << <<EOT
   <p>
@@ -206,11 +206,11 @@ EOT
 
       if @producer.params["subtitle"].nil?
         @body << <<EOT
-    <p class="title">#{CGI.escapeHTML(@producer.params.name("title"))}</p>
+    <p class="title">#{CGI.escapeHTML(@producer.params.name_of("title"))}</p>
 EOT
       else
         @body << <<EOT
-    <p class="title">#{CGI.escapeHTML(@producer.params.name("title"))}<br /><span class="subtitle">#{CGI.escapeHTML(@producer.params.name("subtitle"))}</span></p>
+    <p class="title">#{CGI.escapeHTML(@producer.params.name_of("title"))}<br /><span class="subtitle">#{CGI.escapeHTML(@producer.params.name_of("subtitle"))}</span></p>
 EOT
       end
 
@@ -240,7 +240,7 @@ EOT
       @body << %Q[    <table class="colophon">\n]
       @body << @producer.params["colophon_order"].map{ |role|
         if @producer.params[role]
-          %Q[      <tr><th>#{CGI.escapeHTML(@producer.res.v(role))}</th><td>#{CGI.escapeHTML(join_with_separator(@producer.params.names(role), ReVIEW::I18n.t("names_splitter")))}</td></tr>\n]
+          %Q[      <tr><th>#{CGI.escapeHTML(@producer.res.v(role))}</th><td>#{CGI.escapeHTML(join_with_separator(@producer.params.names_of(role), ReVIEW::I18n.t("names_splitter")))}</td></tr>\n]
         else
           ""
         end
@@ -251,7 +251,7 @@ EOT
       end
       @body << %Q[    </table>\n]
       if !@producer.params["rights"].nil? && @producer.params["rights"].size > 0
-        @body << %Q[    <p class="copyright">#{join_with_separator(@producer.params.names("rights").map {|m| CGI.escapeHTML(m)}, "<br />")}</p>\n]
+        @body << %Q[    <p class="copyright">#{join_with_separator(@producer.params.names_of("rights").map {|m| CGI.escapeHTML(m)}, "<br />")}</p>\n]
       end
       @body << %Q[  </div>\n]
 

--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -135,16 +135,16 @@ EOT
         end
         @body = <<-EOT
   <div id="cover-image" class="cover-image">
-    <img src="#{file}" alt="#{CGI.escapeHTML(@producer.params["title"])}" class="max"/>
+    <img src="#{file}" alt="#{CGI.escapeHTML(@producer.params.name("title"))}" class="max"/>
   </div>
         EOT
       else
         @body = <<-EOT
-<h1 class="cover-title">#{CGI.escapeHTML(@producer.params["title"])}</h1>
+<h1 class="cover-title">#{CGI.escapeHTML(@producer.params.name("title"))}</h1>
         EOT
       end
 
-      @title = CGI.escapeHTML(@producer.params['title'])
+      @title = CGI.escapeHTML(@producer.params.name("title"))
       @language = @producer.params['language']
       @stylesheets = @producer.params["stylesheet"]
       if @producer.params["htmlversion"].to_i == 5
@@ -158,7 +158,7 @@ EOT
 
     # Return title (copying) content.
     def titlepage
-      @title = CGI.escapeHTML(@producer.params["title"])
+      @title = CGI.escapeHTML(@producer.params.name("title"))
 
       @body = <<EOT
   <h1 class="tp-title">#{@title}</h1>
@@ -169,11 +169,11 @@ EOT
     <br />
     <br />
   </p>
-  <h2 class="tp-author">#{CGI.escapeHTML(join_with_separator(@producer.params["aut"], ReVIEW::I18n.t("names_splitter")))}</h2>
+  <h2 class="tp-author">#{CGI.escapeHTML(join_with_separator(@producer.params.names("aut"), ReVIEW::I18n.t("names_splitter")))}</h2>
 EOT
       end
 
-      publisher = @producer.params["pbl"] || @producer.params["prt"] # XXX Backward Compatiblity
+      publisher = @producer.params.names("pbl") || @producer.params.names("prt") # XXX Backward Compatiblity
       if publisher
         @body << <<EOT
   <p>
@@ -206,11 +206,11 @@ EOT
 
       if @producer.params["subtitle"].nil?
         @body << <<EOT
-    <p class="title">#{CGI.escapeHTML(@producer.params["title"])}</p>
+    <p class="title">#{CGI.escapeHTML(@producer.params.name("title"))}</p>
 EOT
       else
         @body << <<EOT
-    <p class="title">#{CGI.escapeHTML(@producer.params["title"])}<br /><span class="subtitle">#{CGI.escapeHTML(@producer.params["subtitle"])}</span></p>
+    <p class="title">#{CGI.escapeHTML(@producer.params.name("title"))}<br /><span class="subtitle">#{CGI.escapeHTML(@producer.params.name("subtitle"))}</span></p>
 EOT
       end
 
@@ -240,7 +240,7 @@ EOT
       @body << %Q[    <table class="colophon">\n]
       @body << @producer.params["colophon_order"].map{ |role|
         if @producer.params[role]
-          %Q[      <tr><th>#{CGI.escapeHTML(@producer.res.v(role))}</th><td>#{CGI.escapeHTML(join_with_separator(@producer.params[role], ReVIEW::I18n.t("names_splitter")))}</td></tr>\n]
+          %Q[      <tr><th>#{CGI.escapeHTML(@producer.res.v(role))}</th><td>#{CGI.escapeHTML(join_with_separator(@producer.params.names(role), ReVIEW::I18n.t("names_splitter")))}</td></tr>\n]
         else
           ""
         end
@@ -251,7 +251,7 @@ EOT
       end
       @body << %Q[    </table>\n]
       if !@producer.params["rights"].nil? && @producer.params["rights"].size > 0
-        @body << %Q[    <p class="copyright">#{join_with_separator(@producer.params["rights"].map {|m| CGI.escapeHTML(m)}, "<br />")}</p>\n]
+        @body << %Q[    <p class="copyright">#{join_with_separator(@producer.params.names("rights").map {|m| CGI.escapeHTML(m)}, "<br />")}</p>\n]
       end
       @body << %Q[  </div>\n]
 

--- a/lib/epubmaker/epubv2.rb
+++ b/lib/epubmaker/epubv2.rb
@@ -38,9 +38,9 @@ module EPUBMaker
       %w[title language date type format source description relation coverage subject rights].each do |item|
         next unless @producer.params[item]
         if @producer.params[item].kind_of?(Array)
-          s << @producer.params.names(item).map {|i| %Q[    <dc:#{item}>#{CGI.escapeHTML(i)}</dc:#{item}>\n]}.join
+          s << @producer.params.names_of(item).map {|i| %Q[    <dc:#{item}>#{CGI.escapeHTML(i)}</dc:#{item}>\n]}.join
         else
-          s << %Q[    <dc:#{item}>#{CGI.escapeHTML(@producer.params.name(item))}</dc:#{item}>\n]
+          s << %Q[    <dc:#{item}>#{CGI.escapeHTML(@producer.params.name_of(item))}</dc:#{item}>\n]
         end
       end
 
@@ -54,7 +54,7 @@ module EPUBMaker
       # creator (should be array)
       %w[aut a-adp a-ann a-arr a-art a-asn a-aqt a-aft a-aui a-ant a-bkp a-clb a-cmm a-dsr a-edt a-ill a-lyr a-mdc a-mus a-nrt a-oth a-pht a-prt a-red a-rev a-spn a-ths a-trc a-trl].each do |role|
         next unless @producer.params[role]
-        @producer.params.names(role).each do |v|
+        @producer.params.names_of(role).each do |v|
           s << %Q[    <dc:creator opf:role="#{role.sub('a-', '')}">#{CGI.escapeHTML(v)}</dc:creator>\n]
         end
       end
@@ -62,7 +62,7 @@ module EPUBMaker
       # contributor (should be array)
       %w[adp ann arr art asn aqt aft aui ant bkp clb cmm dsr edt ill lyr mdc mus nrt oth pht prt red rev spn ths trc trl].each do |role|
         next unless @producer.params[role]
-        @producer.params.names(role).each do |v|
+        @producer.params.names_of(role).each do |v|
           s << %Q[    <dc:contributor opf:role="#{role}">#{CGI.escapeHTML(v)}</dc:contributor>\n]
           if role == "prt"
             s << %Q[    <dc:publisher>#{v}</dc:publisher>\n]

--- a/lib/epubmaker/epubv2.rb
+++ b/lib/epubmaker/epubv2.rb
@@ -38,9 +38,9 @@ module EPUBMaker
       %w[title language date type format source description relation coverage subject rights].each do |item|
         next unless @producer.params[item]
         if @producer.params[item].kind_of?(Array)
-          s << @producer.params[item].map {|i| %Q[    <dc:#{item}>#{CGI.escapeHTML(i.to_s)}</dc:#{item}>\n]}.join
+          s << @producer.params.names(item).map {|i| %Q[    <dc:#{item}>#{CGI.escapeHTML(i)}</dc:#{item}>\n]}.join
         else
-          s << %Q[    <dc:#{item}>#{CGI.escapeHTML(@producer.params[item].to_s)}</dc:#{item}>\n]
+          s << %Q[    <dc:#{item}>#{CGI.escapeHTML(@producer.params.name(item))}</dc:#{item}>\n]
         end
       end
 
@@ -54,7 +54,7 @@ module EPUBMaker
       # creator (should be array)
       %w[aut a-adp a-ann a-arr a-art a-asn a-aqt a-aft a-aui a-ant a-bkp a-clb a-cmm a-dsr a-edt a-ill a-lyr a-mdc a-mus a-nrt a-oth a-pht a-prt a-red a-rev a-spn a-ths a-trc a-trl].each do |role|
         next unless @producer.params[role]
-        @producer.params[role].each do |v|
+        @producer.params.names(role).each do |v|
           s << %Q[    <dc:creator opf:role="#{role.sub('a-', '')}">#{CGI.escapeHTML(v)}</dc:creator>\n]
         end
       end
@@ -62,7 +62,7 @@ module EPUBMaker
       # contributor (should be array)
       %w[adp ann arr art asn aqt aft aui ant bkp clb cmm dsr edt ill lyr mdc mus nrt oth pht prt red rev spn ths trc trl].each do |role|
         next unless @producer.params[role]
-        @producer.params[role].each do |v|
+        @producer.params.names(role).each do |v|
           s << %Q[    <dc:contributor opf:role="#{role}">#{CGI.escapeHTML(v)}</dc:contributor>\n]
           if role == "prt"
             s << %Q[    <dc:publisher>#{v}</dc:publisher>\n]

--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -47,7 +47,7 @@ module EPUBMaker
     # +version+ takes EPUB version (default is 2).
     def initialize(params=nil, version=nil)
       @contents = []
-      @params = {}
+      @params = ReVIEW::Configure.new
       @epub = nil
       @params["epubversion"] = version unless version.nil?
       @res = ReVIEW::I18n
@@ -210,7 +210,7 @@ module EPUBMaker
     # Complement parameters.
     def complement
       @params["htmlext"] = "html" if @params["htmlext"].nil?
-      defaults = {
+      defaults = ReVIEW::Configure.new.merge({
         "cover" => "#{@params["bookname"]}.#{@params["htmlext"]}",
         "language" => "ja",
         "date" => Time.now.strftime("%Y-%m-%d"),
@@ -254,7 +254,7 @@ module EPUBMaker
         "fontdir" => "fonts",
         "image_ext" => %w(png gif jpg jpeg svg ttf woff otf),
         "font_ext" => %w(ttf woff otf),
-      }
+      })
 
       @params = defaults.deep_merge(@params)
       @params["title"] = @params["booktitle"] unless @params["title"]

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -66,7 +66,7 @@ module ReVIEW
       end
     end
 
-    def name(key)
+    def name_of(key)
       if self[key].kind_of?(Array)
         self[key].join(",") # i18n?
       elsif self[key].kind_of?(Hash)
@@ -76,7 +76,7 @@ module ReVIEW
       end
     end
 
-    def names(key)
+    def names_of(key)
       if self[key].kind_of?(Array)
         self[key].map do |a|
           if a.kind_of?(Hash)

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -65,5 +65,31 @@ module ReVIEW
         return self.fetch(@maker).fetch(key, nil)
       end
     end
+
+    def name(key)
+      if self[key].kind_of?(Array)
+        self[key].join(",") # i18n?
+      elsif self[key].kind_of?(Hash)
+        self[key]["name"]
+      else
+        self[key]
+      end
+    end
+
+    def names(key)
+      if self[key].kind_of?(Array)
+        self[key].map do |a|
+          if a.kind_of?(Hash)
+            a["name"]
+          else
+            a
+          end
+        end
+      elsif self[key].kind_of?(Hash)
+        [self[key]["name"]]
+      else
+        [self[key]]
+      end
+    end
   end
 end

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -389,15 +389,16 @@ module ReVIEW
 
   def build_titlepage(basetmpdir, htmlfile)
     # TODO: should be created via epubcommon
+    @title = CGI.escapeHTML(@params.name("booktitle"))
     File.open("#{basetmpdir}/#{htmlfile}", "w") do |f|
       @body = ""
       @body << "<div class=\"titlepage\">\n"
-      @body << "<h1 class=\"tp-title\">#{CGI.escapeHTML(@params["booktitle"])}</h1>\n"
+      @body << "<h1 class=\"tp-title\">#{CGI.escapeHTML(@params.name("booktitle"))}</h1>\n"
       if @params["aut"]
-        @body << "<h2 class=\"tp-author\">#{CGI.escapeHTML(@params["aut"].join(ReVIEW::I18n.t("names_splitter")))}</h2>\n"
+        @body << "<h2 class=\"tp-author\">#{CGI.escapeHTML(@params.names("aut").join(ReVIEW::I18n.t("names_splitter")))}</h2>\n"
       end
       if @params["prt"]
-        @body << "<h3 class=\"tp-publisher\">#{CGI.escapeHTML(@params["prt"].join(ReVIEW::I18n.t("names_splitter")))}</h3>\n"
+        @body << "<h3 class=\"tp-publisher\">#{CGI.escapeHTML(@params.names("prt").join(ReVIEW::I18n.t("names_splitter")))}</h3>\n"
       end
       @body << "</div>"
 

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -389,16 +389,16 @@ module ReVIEW
 
   def build_titlepage(basetmpdir, htmlfile)
     # TODO: should be created via epubcommon
-    @title = CGI.escapeHTML(@params.name("booktitle"))
+    @title = CGI.escapeHTML(@params.name_of("booktitle"))
     File.open("#{basetmpdir}/#{htmlfile}", "w") do |f|
       @body = ""
       @body << "<div class=\"titlepage\">\n"
-      @body << "<h1 class=\"tp-title\">#{CGI.escapeHTML(@params.name("booktitle"))}</h1>\n"
+      @body << "<h1 class=\"tp-title\">#{CGI.escapeHTML(@params.name_of("booktitle"))}</h1>\n"
       if @params["aut"]
-        @body << "<h2 class=\"tp-author\">#{CGI.escapeHTML(@params.names("aut").join(ReVIEW::I18n.t("names_splitter")))}</h2>\n"
+        @body << "<h2 class=\"tp-author\">#{CGI.escapeHTML(@params.names_of("aut").join(ReVIEW::I18n.t("names_splitter")))}</h2>\n"
       end
       if @params["prt"]
-        @body << "<h3 class=\"tp-publisher\">#{CGI.escapeHTML(@params.names("prt").join(ReVIEW::I18n.t("names_splitter")))}</h3>\n"
+        @body << "<h3 class=\"tp-publisher\">#{CGI.escapeHTML(@params.names_of("prt").join(ReVIEW::I18n.t("names_splitter")))}</h3>\n"
       end
       @body << "</div>"
 

--- a/lib/review/layout.tex.erb
+++ b/lib/review/layout.tex.erb
@@ -43,8 +43,8 @@
 \fi
 
 \usepackage[dvipdfm,bookmarks=true,bookmarksnumbered=true,colorlinks=true,%
-            pdftitle={<%= values["booktitle"] %>},%
-            pdfauthor={<%= values["aut"] %>}]{hyperref}
+            pdftitle={<%= values.name("booktitle") %>},%
+            pdfauthor={<%= values.names("aut").join(I18n.t("names_splitter")) %>}]{hyperref}
 
 <% if config["highlight"] && config["highlight"]["latex"] == "listings" %>
 <%   if config["language"] == "ja" %>
@@ -244,7 +244,7 @@
 \begin{center}%
   \mbox{} \vskip5zw
    \reviewtitlefont%
-    {\Huge <%= values["booktitle"] %> \par}%
+    {\Huge <%= values.name("booktitle") %> \par}%
     \vskip 15em%
     {\huge
       \lineskip .75em
@@ -252,7 +252,7 @@
         <%= authors %>
       \end{tabular}\par}%
     \vfill
-    {\large <%= values["date"] %> <%= I18n.t("edition")%>\hspace{2zw}<%= I18n.t("published_by", values["prt"])%>\par}%
+    {\large <%= values["date"] %> <%= I18n.t("edition")%>\hspace{2zw}<%= I18n.t("published_by", values.names("prt").join(I18n.t("names_splitter")))%>\par}%
 \vskip4zw\mbox{}
   \end{center}%
 \end{titlepage}
@@ -319,7 +319,7 @@
 
 \vspace*{\fill}
 
-{\noindent\reviewtitlefont\Large <%= values["booktitle"] %>} \\
+{\noindent\reviewtitlefont\Large <%= values.name("booktitle") %>} \\
 \rule[8pt]{14cm}{1pt} \\
 {\noindent
 <%= values["pubhistory"].to_s.gsub(/\n/){"\n\n\\noindent"} %>
@@ -330,7 +330,7 @@
 \end{tabular}
 　\\
 \rule[0pt]{14cm}{1pt} \\
-<%= values["rights"] %> \\
+<%= values.names("rights").join('\\' + '\\') %> \\
 <%   end %>
 <% end %>
 

--- a/lib/review/layout.tex.erb
+++ b/lib/review/layout.tex.erb
@@ -43,8 +43,8 @@
 \fi
 
 \usepackage[dvipdfm,bookmarks=true,bookmarksnumbered=true,colorlinks=true,%
-            pdftitle={<%= values.name("booktitle") %>},%
-            pdfauthor={<%= values.names("aut").join(I18n.t("names_splitter")) %>}]{hyperref}
+            pdftitle={<%= values.name_of("booktitle") %>},%
+            pdfauthor={<%= values.names_of("aut").join(I18n.t("names_splitter")) %>}]{hyperref}
 
 <% if config["highlight"] && config["highlight"]["latex"] == "listings" %>
 <%   if config["language"] == "ja" %>
@@ -244,7 +244,7 @@
 \begin{center}%
   \mbox{} \vskip5zw
    \reviewtitlefont%
-    {\Huge <%= values.name("booktitle") %> \par}%
+    {\Huge <%= values.name_of("booktitle") %> \par}%
     \vskip 15em%
     {\huge
       \lineskip .75em
@@ -252,7 +252,7 @@
         <%= authors %>
       \end{tabular}\par}%
     \vfill
-    {\large <%= values["date"] %> <%= I18n.t("edition")%>\hspace{2zw}<%= I18n.t("published_by", values.names("prt").join(I18n.t("names_splitter")))%>\par}%
+    {\large <%= values["date"] %> <%= I18n.t("edition")%>\hspace{2zw}<%= I18n.t("published_by", values.names_of("prt").join(I18n.t("names_splitter")))%>\par}%
 \vskip4zw\mbox{}
   \end{center}%
 \end{titlepage}
@@ -319,7 +319,7 @@
 
 \vspace*{\fill}
 
-{\noindent\reviewtitlefont\Large <%= values.name("booktitle") %>} \\
+{\noindent\reviewtitlefont\Large <%= values.name_of("booktitle") %>} \\
 \rule[8pt]{14cm}{1pt} \\
 {\noindent
 <%= values["pubhistory"].to_s.gsub(/\n/){"\n\n\\noindent"} %>
@@ -330,7 +330,7 @@
 \end{tabular}
 　\\
 \rule[0pt]{14cm}{1pt} \\
-<%= values.names("rights").join('\\' + '\\') %> \\
+<%= values.names_of("rights").join('\\' + '\\') %> \\
 <%   end %>
 <% end %>
 

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -244,7 +244,7 @@ module ReVIEW
 
     def make_colophon_role(role)
       if @config[role].present?
-        return "#{ReVIEW::I18n.t(role)} & #{escape_latex(join_with_separator(@config[role], ReVIEW::I18n.t("names_splitter")))} \\\\\n"
+        return "#{ReVIEW::I18n.t(role)} & #{escape_latex(join_with_separator(@config.names_of(role), ReVIEW::I18n.t("names_splitter")))} \\\\\n"
       else
         ""
       end
@@ -261,15 +261,15 @@ module ReVIEW
     def make_authors
       authors = ""
       if @config["aut"].present?
-        author_names = join_with_separator(@config["aut"], ReVIEW::I18n.t("names_splitter"))
+        author_names = join_with_separator(@config.names_of("aut"), ReVIEW::I18n.t("names_splitter"))
         authors = ReVIEW::I18n.t("author_with_label", author_names)
       end
       if @config["csl"].present?
-        csl_names = join_with_separator(@config["csl"], ReVIEW::I18n.t("names_splitter"))
+        csl_names = join_with_separator(@config.names_of("csl"), ReVIEW::I18n.t("names_splitter"))
         authors += " \\\\\n"+ ReVIEW::I18n.t("supervisor_with_label", csl_names)
       end
       if @config["trl"].present?
-        trl_names = join_with_separator(@config["trl"], ReVIEW::I18n.t("names_splitter"))
+        trl_names = join_with_separator(@config.names_of("trl"), ReVIEW::I18n.t("names_splitter"))
         authors += " \\\\\n"+ ReVIEW::I18n.t("translator_with_label", trl_names)
       end
       authors


### PR DESCRIPTION
#532 の名前付きパラメータへの対策です。

Configureクラスにname, namesというメソッドを加え、name:属性の値を文字列化して取得できるようにしています（本当にnameという属性名で固定になっているのかよくわからないところですが…）。ハッシュになっていなければそのまま中身を返します。namesは配列版です。

なお、PDFmakerでは値代入時にエスケープをしていないようなので、このパッチマージのあとにエスケープのロジックを入れたいところです。