### PR TITLE
allow to use shortcut key of config

### DIFF
--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -69,7 +69,7 @@ module EPUBMaker
 
     # Update parameters by merging from new parameter hash +params+.
     def merge_params(params)
-      @params = @params.deep_merge(params)
+      @params.deep_merge!(params)
       complement
 
       unless @params["epubversion"].nil?

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -58,11 +58,12 @@ module ReVIEW
     end
 
     def [](key)
+      maker = self.maker
+      if maker && self.key?(maker) && self.fetch(maker).key?(key)
+        return self.fetch(maker).fetch(key, nil)
+      end
       if self.key?(key)
         return self.fetch(key)
-      end
-      if @maker && self.key?(@maker)
-        return self.fetch(@maker).fetch(key, nil)
       end
     end
 

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -33,7 +33,7 @@ module ReVIEW
     @producer = Producer.new(@params)
     @producer.load(yamlfile)
     @params = @producer.params
-    @params.maker = "pdfmaker"
+    @params.maker = "epubmaker"
   end
 
   def produce(yamlfile, bookname=nil)

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -33,6 +33,7 @@ module ReVIEW
     @producer = Producer.new(@params)
     @producer.load(yamlfile)
     @params = @producer.params
+    @params.maker = "pdfmaker"
   end
 
   def produce(yamlfile, bookname=nil)

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -97,6 +97,7 @@ module ReVIEW
 
     def execute(*args)
       @config = ReVIEW::Configure.values
+      @config.maker = "pdfmaker"
       cmd_config, yamlfile = parse_opts(args)
       loader = YAMLLoader.new
       @config.deep_merge!(loader.load_file(yamlfile))

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -16,7 +16,8 @@ class ConfigureTest < Test::Unit::TestCase
                      "urnid" => "http://example.jp/",
                      "date" => "2011-01-01",
                      "language" => "ja",
-                     "epubmaker" => {"flattocindent" => true},
+                     "epubmaker" => {"flattocindent" => true,
+                                     "title" => "Sample Book(EPUB)"},
                    })
     @output = StringIO.new
     I18n.setup(@config["language"])
@@ -39,6 +40,13 @@ class ConfigureTest < Test::Unit::TestCase
     @config.maker = "epubmaker"
     assert_equal true, @config["flattocindent"]
     assert_equal true, @config["epubmaker"]["flattocindent"]
+  end
+
+  def test_configure_with_maker_override
+    @config.maker = "epubmaker"
+    assert_equal "Sample Book(EPUB)", @config["title"]
+    @config.maker = "pdfmaker"
+    assert_equal "Sample Book", @config["title"]
   end
 
   def test_configure_with_invalidmaker


### PR DESCRIPTION
* enable to use `@config["foo"]` instead of `@config["epubmaker"]["foo"]` when using epubmaker

cf. #515 