### PR TITLE
nonumの見出しも目次に追加

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -58,6 +58,7 @@ module ReVIEW
       @chapter.book.image_types = %w( .png .jpg .jpeg .gif .svg )
       @column = 0
       @sec_counter = SecCounter.new(5, @chapter)
+      @nonum_counter = 0
     end
     private :builder_init_file
 
@@ -194,10 +195,12 @@ module ReVIEW
     end
 
     def nonum_begin(level, label, caption)
+      @nonum_counter += 1
       puts '' if level > 1
       unless caption.empty?
         if label.nil?
-          puts %Q[<h#{level}>#{compile_inline(caption)}</h#{level}>]
+          id = normalize_id("#{@chapter.name}_nonum#{@nonum_counter}")
+          puts %Q[<h#{level} id="#{id}">#{compile_inline(caption)}</h#{level}>]
         else
           puts %Q[<h#{level} id="#{normalize_id(label)}">#{compile_inline(caption)}</h#{level}>]
         end

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -101,6 +101,7 @@ module ReVIEW
     def nonum_begin(level, label, caption)
       blank unless @output.pos == 0
       puts macro(HEADLINE[level]+"*", compile_inline(caption))
+      puts macro('addcontentsline', 'toc', HEADLINE[level], compile_inline(caption))
     end
 
     def nonum_end(level)


### PR DESCRIPTION
nodispにするつもりで使っていた、というケースはどのくらいあるだろうか。
たくさんあるなら互換性のflagが必要。

cf. #506 
