### PR TITLE
tmpdirをTeXビルドパスに利用する

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -52,7 +52,7 @@ module ReVIEW
     end
 
     def build_path
-      "./#{@config["bookname"]}-pdf"
+      Dir.mktmpdir("#{@config["bookname"]}-pdf-", Dir.pwd)
     end
 
     def check_compile_status(ignore_errors)
@@ -111,88 +111,89 @@ module ReVIEW
     def generate_pdf(yamlfile)
       remove_old_file
       @path = build_path()
-      Dir.mkdir(@path)
+      begin
+        @chaps_fnames = Hash.new{|h, key| h[key] = ""}
+        @compile_errors = nil
 
-      @chaps_fnames = Hash.new{|h, key| h[key] = ""}
-      @compile_errors = nil
+        book = ReVIEW::Book.load(@basedir)
+        book.config = @config
+        @converter = ReVIEW::Converter.new(book, ReVIEW::LATEXBuilder.new)
+        book.parts.each do |part|
+          if part.name.present?
+            if part.file?
+              output_chaps(part.name, yamlfile)
+              @chaps_fnames["CHAPS"] << %Q|\\input{#{part.name}.tex}\n|
+            else
+              @chaps_fnames["CHAPS"] << %Q|\\part{#{part.name}}\n|
+            end
+          end
 
-      book = ReVIEW::Book.load(@basedir)
-      book.config = @config
-      @converter = ReVIEW::Converter.new(book, ReVIEW::LATEXBuilder.new)
-      book.parts.each do |part|
-        if part.name.present?
-          if part.file?
-            output_chaps(part.name, yamlfile)
-            @chaps_fnames["CHAPS"] << %Q|\\input{#{part.name}.tex}\n|
-          else
-            @chaps_fnames["CHAPS"] << %Q|\\part{#{part.name}}\n|
+          part.chapters.each do |chap|
+            filename = File.basename(chap.path, ".*")
+            output_chaps(filename, yamlfile)
+            @chaps_fnames["PREDEF"] << "\\input{#{filename}.tex}\n" if chap.on_PREDEF?
+            @chaps_fnames["CHAPS"] << "\\input{#{filename}.tex}\n" if chap.on_CHAPS?
+            @chaps_fnames["APPENDIX"] << "\\input{#{filename}.tex}\n" if chap.on_APPENDIX?
+            @chaps_fnames["POSTDEF"] << "\\input{#{filename}.tex}\n" if chap.on_POSTDEF?
           end
         end
 
-        part.chapters.each do |chap|
-          filename = File.basename(chap.path, ".*")
-          output_chaps(filename, yamlfile)
-          @chaps_fnames["PREDEF"] << "\\input{#{filename}.tex}\n" if chap.on_PREDEF?
-          @chaps_fnames["CHAPS"] << "\\input{#{filename}.tex}\n" if chap.on_CHAPS?
-          @chaps_fnames["APPENDIX"] << "\\input{#{filename}.tex}\n" if chap.on_APPENDIX?
-          @chaps_fnames["POSTDEF"] << "\\input{#{filename}.tex}\n" if chap.on_POSTDEF?
+        check_compile_status(@config["ignore-errors"])
+
+        @config["pre_str"] = @chaps_fnames["PREDEF"]
+        @config["chap_str"] = @chaps_fnames["CHAPS"]
+        @config["appendix_str"] = @chaps_fnames["APPENDIX"]
+        @config["post_str"] = @chaps_fnames["POSTDEF"]
+
+        @config["usepackage"] = ""
+        if @config["texstyle"]
+          @config["usepackage"] = "\\usepackage{#{@config['texstyle']}}"
         end
-      end
 
-      check_compile_status(@config["ignore-errors"])
+        copy_images("./images", File.join(@path, "images"))
+        copyStyToDir(File.join(Dir.pwd, "sty"), @path)
+        copyStyToDir(File.join(Dir.pwd, "sty"), @path, "fd")
+        copyStyToDir(File.join(Dir.pwd, "sty"), @path, "cls")
+        copyStyToDir(Dir.pwd, @path, "tex")
 
-      @config["pre_str"] = @chaps_fnames["PREDEF"]
-      @config["chap_str"] = @chaps_fnames["CHAPS"]
-      @config["appendix_str"] = @chaps_fnames["APPENDIX"]
-      @config["post_str"] = @chaps_fnames["POSTDEF"]
+        template = get_template
+        Dir.chdir(@path) do
+          File.open("./book.tex", "wb"){|f| f.write(template)}
 
-      @config["usepackage"] = ""
-      if @config["texstyle"]
-        @config["usepackage"] = "\\usepackage{#{@config['texstyle']}}"
-      end
+          call_hook("hook_beforetexcompile")
 
-      copy_images("./images", File.join(@path, "images"))
-      copyStyToDir(File.join(Dir.pwd, "sty"), @path)
-      copyStyToDir(File.join(Dir.pwd, "sty"), @path, "fd")
-      copyStyToDir(File.join(Dir.pwd, "sty"), @path, "cls")
-      copyStyToDir(Dir.pwd, @path, "tex")
+          ## do compile
+          kanji = 'utf8'
+          texcommand = "platex"
+          texoptions = "-kanji=#{kanji}"
+          dvicommand = "dvipdfmx"
+          dvioptions = "-d 5"
 
-      template = get_template
-      Dir.chdir(@path) do
-        File.open("./book.tex", "wb"){|f| f.write(template)}
+          if ENV["REVIEW_SAFE_MODE"].to_i & 4 > 0
+            warn "command configuration is prohibited in safe mode. ignored."
+          else
+            texcommand = @config["texcommand"] if @config["texcommand"]
+            dvicommand = @config["dvicommand"] if @config["dvicommand"]
+            dvioptions = @config["dvioptions"] if @config["dvioptions"]
+            texoptions = @config["texoptions"] if @config["texoptions"]
+          end
+          3.times do
+            system_or_raise("#{texcommand} #{texoptions} book.tex")
+          end
+          call_hook("hook_aftertexcompile")
 
-        call_hook("hook_beforetexcompile")
-
-        ## do compile
-        kanji = 'utf8'
-        texcommand = "platex"
-        texoptions = "-kanji=#{kanji}"
-        dvicommand = "dvipdfmx"
-        dvioptions = "-d 5"
-
-        if ENV["REVIEW_SAFE_MODE"].to_i & 4 > 0
-          warn "command configuration is prohibited in safe mode. ignored."
-        else
-          texcommand = @config["texcommand"] if @config["texcommand"]
-          dvicommand = @config["dvicommand"] if @config["dvicommand"]
-          dvioptions = @config["dvioptions"] if @config["dvioptions"]
-          texoptions = @config["texoptions"] if @config["texoptions"]
+          if File.exist?("book.dvi")
+            system_or_raise("#{dvicommand} #{dvioptions} book.dvi")
+          end
         end
-        3.times do
-          system_or_raise("#{texcommand} #{texoptions} book.tex")
+        call_hook("hook_afterdvipdf")
+
+        FileUtils.cp(File.join(@path, "book.pdf"), pdf_filepath)
+
+      ensure
+        unless @config["debug"]
+          remove_entry_secure @path
         end
-        call_hook("hook_aftertexcompile")
-
-        if File.exist?("book.dvi")
-          system_or_raise("#{dvicommand} #{dvioptions} book.dvi")
-        end
-      end
-      call_hook("hook_afterdvipdf")
-
-      FileUtils.cp(File.join(@path, "book.pdf"), pdf_filepath)
-
-      unless @config["debug"]
-        remove_entry_secure @path
       end
     end
 

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -55,7 +55,7 @@ module ReVIEW
       if @config["debug"]
         path = "#{@config["bookname"]}-pdf"
         if File.exist?(path)
-          FileUtils.rm_rf(path, secure: true)
+          FileUtils.rm_rf(path, :secure => true)
         end
         Dir.mkdir(path)
         return path

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -52,7 +52,16 @@ module ReVIEW
     end
 
     def build_path
-      Dir.mktmpdir("#{@config["bookname"]}-pdf-", Dir.pwd)
+      if @config["debug"]
+        path = "#{@config["bookname"]}-pdf"
+        if File.exist?(path)
+          FileUtils.rm_rf(path, secure: true)
+        end
+        Dir.mkdir(path)
+        return path
+      else
+        return Dir.mktmpdir("#{@config["bookname"]}-pdf-")
+      end
     end
 
     def check_compile_status(ignore_errors)

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -43,8 +43,14 @@ class PDFMakerTest < Test::Unit::TestCase
     end
   end
 
-  def test_buildpath
-    assert_equal(@maker.build_path, "./sample-pdf")
+  def test_buildpath_debug
+    @maker.config["debug"] = true
+    path = @maker.build_path
+    begin
+      assert_equal(path, "sample-pdf")
+    ensure
+      FileUtils.remove_entry_secure path
+    end
   end
 
   def test_parse_opts_help


### PR DESCRIPTION
cf. #549 
<tmpname>/book-pdf にするのもできるけれども、とりあえず <bookname>-pdf-<tmpname> で実装してみました。
begin-ensureで囲んで例外にかかわらず削除するようにしています。

取り込むにはpdfmaker_cmdのtestの削除が必要ですね。
