### PR TITLE
refactor: extract EPUBCommon#colophon_history method

### DIFF
--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -215,26 +215,7 @@ EOT
       end
 
       if @producer.params["date"] || @producer.params["history"]
-        @body << %Q[    <div class="pubhistory">\n]
-        if @producer.params["history"]
-          @producer.params["history"].each_with_index do |items, edit|
-            items.each_with_index do |item, rev|
-              editstr = (edit == 0) ? ReVIEW::I18n.t("first_edition") : ReVIEW::I18n.t("nth_edition","#{edit+1}")
-              revstr = ReVIEW::I18n.t("nth_impression", "#{rev+1}")
-              if item =~ /\A\d+\-\d+\-\d+\Z/
-                @body << %Q[      <p>#{ReVIEW::I18n.t("published_by1", [date_to_s(item), editstr+revstr])}</p>\n]
-              else
-                # custom date with string
-                item.match(/\A(\d+\-\d+\-\d+)[\s　](.+)/) do |m|
-                  @body << %Q[      <p>#{ReVIEW::I18n.t("published_by3", [date_to_s(m[1]), m[2]])}</p>\n]
-                end
-              end
-            end
-          end
-        else
-          @body << %Q[      <p>#{ReVIEW::I18n.t("published_by2", date_to_s(@producer.params["date"]))}</p>\n]
-        end
-        @body << %Q[    </div>\n]
+        @body << colophon_history
       end
 
       @body << %Q[    <table class="colophon">\n]
@@ -264,6 +245,31 @@ EOT
       end
       tmpl = ReVIEW::Template.load(tmplfile)
       tmpl.result(binding)
+    end
+
+    def colophon_history
+      buf = ""
+      buf << %Q[    <div class="pubhistory">\n]
+      if @producer.params["history"]
+        @producer.params["history"].each_with_index do |items, edit|
+          items.each_with_index do |item, rev|
+            editstr = (edit == 0) ? ReVIEW::I18n.t("first_edition") : ReVIEW::I18n.t("nth_edition","#{edit+1}")
+            revstr = ReVIEW::I18n.t("nth_impression", "#{rev+1}")
+            if item =~ /\A\d+\-\d+\-\d+\Z/
+              buf << %Q[      <p>#{ReVIEW::I18n.t("published_by1", [date_to_s(item), editstr+revstr])}</p>\n]
+            else
+              # custom date with string
+              item.match(/\A(\d+\-\d+\-\d+)[\s　](.+)/) do |m|
+                buf << %Q[      <p>#{ReVIEW::I18n.t("published_by3", [date_to_s(m[1]), m[2]])}</p>\n]
+              end
+            end
+          end
+        end
+      else
+        buf << %Q[      <p>#{ReVIEW::I18n.t("published_by2", date_to_s(@producer.params["date"]))}</p>\n]
+      end
+      buf << %Q[    </div>\n]
+      buf
     end
 
     def date_to_s(date)

--- a/test/test_epub3maker.rb
+++ b/test/test_epub3maker.rb
@@ -539,6 +539,84 @@ EOT
     assert_equal expect, @output.string
   end
 
+  def test_colophon_history
+    @producer.params["aut"] = ["Mr.Smith"]
+    @producer.params["pbl"] = ["BLUEPRINT"]
+    @producer.params["pht"] = ["Mrs.Smith"]
+    @producer.merge_params({"language" => "ja"})
+    history = @producer.instance_eval{ @epub.colophon_history }
+    expect = <<EOT
+    <div class="pubhistory">
+      <p>2011年1月1日　発行</p>
+    </div>
+EOT
+    assert_equal expect, history
+  end
+
+  def test_colophon_history_2
+    @producer.params["aut"] = ["Mr.Smith"]
+    @producer.params["pbl"] = ["BLUEPRINT"]
+    @producer.params["pht"] = ["Mrs.Smith"]
+    @producer.merge_params({"language" => "ja",
+                            "history" => [[
+                                            "2011-08-03 v1.0.0版発行",
+                                            "2012-02-15 v1.1.0版発行",
+                                          ]] })
+    history = @producer.instance_eval{ @epub.colophon_history }
+    expect = <<EOT
+    <div class="pubhistory">
+      <p>2011年8月3日　v1.0.0版発行</p>
+      <p>2012年2月15日　v1.1.0版発行</p>
+    </div>
+EOT
+    assert_equal expect, history
+  end
+
+  def test_colophon_history_date
+    @producer.params["aut"] = ["Mr.Smith"]
+    @producer.params["pbl"] = ["BLUEPRINT"]
+    @producer.params["pht"] = ["Mrs.Smith"]
+    @producer.merge_params({"language" => "ja",
+                            "history" => [[
+                                            "2011-08-03",
+                                            "2012-02-15",
+                                          ]] })
+    history = @producer.instance_eval{ @epub.colophon_history }
+    expect = <<EOT
+    <div class="pubhistory">
+      <p>2011年8月3日　初版第1刷　発行</p>
+      <p>2012年2月15日　初版第2刷　発行</p>
+    </div>
+EOT
+    assert_equal expect, history
+  end
+
+  def test_colophon_history_date2
+    @producer.params["aut"] = ["Mr.Smith"]
+    @producer.params["pbl"] = ["BLUEPRINT"]
+    @producer.params["pht"] = ["Mrs.Smith"]
+    @producer.merge_params({"language" => "ja",
+                            "history" => [[
+                                            "2011-08-03",
+                                            "2012-02-15",
+                                          ],[
+                                            "2012-10-01",
+                                          ],[
+                                            "2013-03-01",
+                                          ]] })
+    history = @producer.instance_eval{ @epub.colophon_history }
+    expect = <<EOT
+    <div class="pubhistory">
+      <p>2011年8月3日　初版第1刷　発行</p>
+      <p>2012年2月15日　初版第2刷　発行</p>
+      <p>2012年10月1日　第2版第1刷　発行</p>
+      <p>2013年3月1日　第3版第1刷　発行</p>
+    </div>
+EOT
+    assert_equal expect, history
+  end
+
+
 #  def test_duplicate_id
 #    stage3
 #    assert_raise(Error) do


### PR DESCRIPTION
奥付の発行日をテストするため `EPUBCommon#colophon_history` を独立したメソッドに切り出してみました。