### PR TITLE
move major block notations to common.

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright (c) 2002-2014 Minero Aoki, Kenshi Muto
+# Copyright (c) 2002-2016 Minero Aoki, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -20,7 +20,7 @@ module ReVIEW
   class Builder
     include TextUtils
 
-    CAPTION_TITLES = %w(note memo tip info planning best important security caution term link notice point shoot reference practice expert)
+    CAPTION_TITLES = %w(note memo tip info warning important caution notice)
 
     def pre_paragraph
       nil

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 #
 # Copyright (c) 2002-2007 Minero Aoki
-# Copyright (c) 2009-2010 Minero Aoki, Kenshi Muto
+# Copyright (c) 2009-2016 Minero Aoki, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -152,6 +152,13 @@ module ReVIEW
     defblock :flushright, 0
     defblock :centering, 0
     defblock :note, 0..1
+    defblock :memo, 0..1
+    defblock :info, 0..1
+    defblock :important, 0..1
+    defblock :caution, 0..1
+    defblock :notice, 0..1
+    defblock :warning, 0..1
+    defblock :tip, 0..1
     defblock :box, 0..1
     defblock :comment, 0..1, true
 

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -22,15 +22,9 @@ module ReVIEW
     include HTMLUtils
 
     [:ref].each {|e| Compiler.definline(e) }
-    Compiler.defblock(:memo, 0..1)
-    Compiler.defblock(:tip, 0..1)
-    Compiler.defblock(:info, 0..1)
     Compiler.defblock(:planning, 0..1)
     Compiler.defblock(:best, 0..1)
-    Compiler.defblock(:important, 0..1)
     Compiler.defblock(:security, 0..1)
-    Compiler.defblock(:caution, 0..1)
-    Compiler.defblock(:notice, 0..1)
     Compiler.defblock(:point, 0..1)
     Compiler.defblock(:shoot, 0..1)
 
@@ -305,6 +299,10 @@ module ReVIEW
 
     def notice(lines, caption = nil)
       captionblock("notice", lines, caption)
+    end
+
+    def warning(lines, caption = nil)
+      captionblock("warning", lines, caption)
     end
 
     def point(lines, caption = nil)

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 #
 # Copyright (c) 2002-2007 Minero Aoki
-#               2008-2014 Minero Aoki, Kenshi Muto
+#               2008-2016 Minero Aoki, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -24,15 +24,9 @@ module ReVIEW
     Compiler.defsingle(:dtp, 1)
 
     Compiler.defblock(:insn, 0..1)
-    Compiler.defblock(:memo, 0..1)
-    Compiler.defblock(:tip, 0..1)
-    Compiler.defblock(:info, 0..1)
     Compiler.defblock(:planning, 0..1)
     Compiler.defblock(:best, 0..1)
-    Compiler.defblock(:important, 0..1)
     Compiler.defblock(:security, 0..1)
-    Compiler.defblock(:caution, 0..1)
-    Compiler.defblock(:notice, 0..1)
     Compiler.defblock(:point, 0..1)
     Compiler.defblock(:shoot, 0..1)
     Compiler.defblock(:reference, 0)
@@ -944,6 +938,10 @@ module ReVIEW
 
     def caution(lines, caption = nil)
       captionblock("caution", lines, caption)
+    end
+
+    def warning(lines, caption = nil)
+      captionblock("warning", lines, caption)
     end
 
     def term(lines)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2002-2007 Minero Aoki
 #               2008-2009 Minero Aoki, Kenshi Muto
-#               2010  Minero Aoki, Kenshi Muto, TAKAHASHI Masayoshi
+#               2010-2016  Minero Aoki, Kenshi Muto, TAKAHASHI Masayoshi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -25,7 +25,6 @@ module ReVIEW
       Compiler.definline(e)
     }
 
-    Compiler.defblock(:memo, 0..1)
     Compiler.defsingle(:latextsize, 1)
 
     def extname

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 #
 # Copyright (c) 2002-2006 Minero Aoki
-#               2008-2010 Minero Aoki, Kenshi Muto
+#               2008-2016 Minero Aoki, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -23,20 +23,16 @@ module ReVIEW
     Compiler.defsingle(:dtp, 1)
 
     Compiler.defblock(:insn, 1)
-    Compiler.defblock(:memo, 0..1)
-    Compiler.defblock(:tip, 0..1)
-    Compiler.defblock(:info, 0..1)
     Compiler.defblock(:planning, 0..1)
     Compiler.defblock(:best, 0..1)
-    Compiler.defblock(:important, 0..1)
     Compiler.defblock(:securty, 0..1)
-    Compiler.defblock(:caution, 0..1)
-    Compiler.defblock(:notice, 0..1)
     Compiler.defblock(:point, 0..1)
     Compiler.defblock(:reference, 0)
     Compiler.defblock(:term, 0)
     Compiler.defblock(:practice, 0)
     Compiler.defblock(:expert, 0)
+    Compiler.defblock(:link, 0..1)
+    Compiler.defblock(:shoot, 0..1)
 
     def pre_paragraph
       ''
@@ -72,6 +68,7 @@ module ReVIEW
         "term" => "用語解説",
         "notice" => "注意",
         "caution" => "警告",
+        "warning" => "危険",
         "point" => "ここがポイント",
         "reference" => "参考",
         "link" => "リンク",
@@ -674,6 +671,10 @@ module ReVIEW
 
     def insn(lines, caption = nil)
       base_block "insn", lines, caption
+    end
+
+    def warning(lines, caption = nil)
+      base_parablock "warning", lines, caption
     end
 
     alias_method :box, :insn

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1136,4 +1136,39 @@ EOS
     expected = %Q|<div id="sampleimg" class="imgtable image">\n<p class="caption">表1.1: test for imgtable</p>\n<img src="images/chap1-sampleimg.png" alt="test for imgtable" />\n</div>\n|
     assert_equal expected, actual
   end
+
+  def test_major_blocks
+    actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
+    expected = %Q(<div class="note">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="note">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
+    expected = %Q(<div class="memo">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="memo">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
+    expected = %Q(<div class="info">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="info">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
+    expected = %Q(<div class="important">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="important">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
+    expected = %Q(<div class="caution">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="caution">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
+    expected = %Q(<div class="notice">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="notice">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
+    expected = %Q(<div class="warning">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="warning">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
+    expected = %Q(<div class="tip">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="tip">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    assert_equal expected, actual
+  end
+
 end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -189,29 +189,44 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|<quote><p>foobar</p><p>buz</p></quote>|, actual
   end
 
-  def test_note
-    actual = compile_block("//note[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q|<note><title aid:pstyle='note-title'>this is <b>test</b>&lt;&amp;&gt;_</title><p>test1test1.5</p><p>test<i>2</i></p></note>|, actual
-  end
+  def test_major_blocks
+    actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
+    expected = %Q(<note><p>A</p><p>B</p></note><note><title aid:pstyle='note-title'>caption</title><p>A</p></note>)
+    assert_equal expected, actual
 
-  def test_memo
-    actual = compile_block("//memo[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q|<memo><title aid:pstyle='memo-title'>this is <b>test</b>&lt;&amp;&gt;_</title><p>test1test1.5</p><p>test<i>2</i></p></memo>|, actual
+    actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
+    expected = %Q(<memo><p>A</p><p>B</p></memo><memo><title aid:pstyle='memo-title'>caption</title><p>A</p></memo>)
+    assert_equal expected, actual
+
+    actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
+    expected = %Q(<info><p>A</p><p>B</p></info><info><title aid:pstyle='info-title'>caption</title><p>A</p></info>)
+    assert_equal expected, actual
+
+    actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
+    expected = %Q(<important><p>A</p><p>B</p></important><important><title aid:pstyle='important-title'>caption</title><p>A</p></important>)
+    assert_equal expected, actual
+
+    actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
+    expected = %Q(<caution><p>A</p><p>B</p></caution><caution><title aid:pstyle='caution-title'>caption</title><p>A</p></caution>)
+    assert_equal expected, actual
+
+    # notice uses special tag notice-t if it includes caption
+    actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
+    expected = %Q(<notice><p>A</p><p>B</p></notice><notice-t><title aid:pstyle='notice-title'>caption</title><p>A</p></notice-t>)
+    assert_equal expected, actual
+
+    actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
+    expected = %Q(<warning><p>A</p><p>B</p></warning><warning><title aid:pstyle='warning-title'>caption</title><p>A</p></warning>)
+    assert_equal expected, actual
+
+    actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
+    expected = %Q(<tip><p>A</p><p>B</p></tip><tip><title aid:pstyle='tip-title'>caption</title><p>A</p></tip>)
+    assert_equal expected, actual
   end
 
   def test_term
     actual = compile_block("//term{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
     assert_equal %Q|<term><p>test1test1.5</p><p>test<i>2</i></p></term>|, actual
-  end
-
-  def test_notice
-    actual = compile_block("//notice[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q|<notice-t><title aid:pstyle='notice-title'>this is <b>test</b>&lt;&amp;&gt;_</title><p>test1test1.5</p><p>test<i>2</i></p></notice-t>|, actual
-  end
-
-  def test_notice_without_caption
-    actual = compile_block("//notice{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q|<notice><p>test1test1.5</p><p>test<i>2</i></p></notice>|, actual
   end
 
   def test_point

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -732,6 +732,40 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_major_blocks
+    actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
+    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
+    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
+    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
+    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
+    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
+    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
+    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
+    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    assert_equal expected, actual
+  end
+
   def test_inline_raw0
     assert_equal "normal", compile_inline("@<raw>{normal}")
   end

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -180,6 +180,40 @@ class TOPBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|◆→開始:インラインリスト←◆\n■this is ★test☆<&>_\n 1: foo\n 2: bar\n◆→終了:インラインリスト←◆\n\n|, actual
   end
 
+  def test_major_blocks
+    actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
+    expected = %Q(◆→開始:ノート←◆\nA\nB\n◆→終了:ノート←◆\n\n◆→開始:ノート←◆\n■caption\nA\n◆→終了:ノート←◆\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
+    expected = %Q(◆→開始:メモ←◆\nA\nB\n◆→終了:メモ←◆\n\n◆→開始:メモ←◆\n■caption\nA\n◆→終了:メモ←◆\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
+    expected = %Q(◆→開始:情報←◆\nA\nB\n◆→終了:情報←◆\n\n◆→開始:情報←◆\n■caption\nA\n◆→終了:情報←◆\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
+    expected = %Q(◆→開始:重要←◆\nA\nB\n◆→終了:重要←◆\n\n◆→開始:重要←◆\n■caption\nA\n◆→終了:重要←◆\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
+    expected = %Q(◆→開始:警告←◆\nA\nB\n◆→終了:警告←◆\n\n◆→開始:警告←◆\n■caption\nA\n◆→終了:警告←◆\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
+    expected = %Q(◆→開始:注意←◆\nA\nB\n◆→終了:注意←◆\n\n◆→開始:注意←◆\n■caption\nA\n◆→終了:注意←◆\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
+    expected = %Q(◆→開始:危険←◆\nA\nB\n◆→終了:危険←◆\n\n◆→開始:危険←◆\n■caption\nA\n◆→終了:危険←◆\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
+    expected = %Q(◆→開始:TIP←◆\nA\nB\n◆→終了:TIP←◆\n\n◆→開始:TIP←◆\n■caption\nA\n◆→終了:TIP←◆\n\n)
+    assert_equal expected, actual
+  end
+
   def test_image
     def @chapter.image(id)
       item = Book::ImageIndex::Item.new("sampleimg",1)


### PR DESCRIPTION
cf #396 

memo, tip, info, important, caution, notice, warning(新設) をcommonなブロックにします。
いずれもキャプションをオプションでとり、空行区切りの複数の段落を格納します。

LaTeXにおいては、今のところcaptionblockにしか実装がないので、すべてreviewminicolumnになります。
