### PR TITLE
use read BOM|utf-8 flag for opening files, instead of string replacing

### DIFF
--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -367,12 +367,13 @@ module ReVIEW
 
       def mkpart_from_namelistfile(path)
         chaps = []
-        File.read(path).split.each_with_index do |name, idx|
-          name.sub!(/\A\xEF\xBB\xBF/u, '') # remove BOM
-          if path =~ /PREDEF/
-            chaps << mkchap(name)
-          else
-            chaps << mkchap(name, idx + 1)
+        File.open(path, 'r:BOM|utf-8') do |f|
+          f.read.split.each_with_index do |name, idx|
+            if path =~ /PREDEF/
+              chaps << mkchap(name)
+            else
+              chaps << mkchap(name, idx + 1)
+            end
           end
         end
         mkpart(chaps)
@@ -404,9 +405,8 @@ module ReVIEW
 
       def read_FILE(filename)
         res = ""
-        File.open("#{@basedir}/#{filename}") do |f|
+        File.open("#{@basedir}/#{filename}", 'r:BOM|utf-8') do |f|
           while line = f.gets
-            line.sub!(/\A\xEF\xBB\xBF/u, '') # remove BOM
             if /\A#/ =~ line
               next
             end

--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -367,13 +367,11 @@ module ReVIEW
 
       def mkpart_from_namelistfile(path)
         chaps = []
-        File.open(path, 'r:BOM|utf-8') do |f|
-          f.read.split.each_with_index do |name, idx|
-            if path =~ /PREDEF/
-              chaps << mkchap(name)
-            else
-              chaps << mkchap(name, idx + 1)
-            end
+        File.read(path, :mode => 'r:BOM|utf-8').split.each_with_index do |name, idx|
+          if path =~ /PREDEF/
+            chaps << mkchap(name)
+          else
+            chaps << mkchap(name, idx + 1)
           end
         end
         mkpart(chaps)

--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -32,7 +32,7 @@ module ReVIEW
           @content = nil
         end
         if !@content && @path && File.exist?(@path)
-          @content = File.read(@path).sub(/\A\xEF\xBB\xBF/u, '')
+          @content = File.open(@path, 'r:BOM|utf-8').read
           @number = nil if ['nonum', 'nodisp', 'notoc'].include?(find_first_header_option)
         end
         @list_index = nil

--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -32,7 +32,7 @@ module ReVIEW
           @content = nil
         end
         if !@content && @path && File.exist?(@path)
-          @content = File.open(@path, 'r:BOM|utf-8').read
+          @content = File.read(@path, :mode => 'r:BOM|utf-8')
           @number = nil if ['nonum', 'nodisp', 'notoc'].include?(find_first_header_option)
         end
         @list_index = nil

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -2,7 +2,7 @@
 # $Id: book.rb 4315 2009-09-02 04:15:24Z kmuto $
 #
 # Copyright (c) 2002-2008 Minero Aoki
-#               2009-2014 Minero Aoki, Kenshi Muto
+#               2009-2016 Minero Aoki, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -26,7 +26,7 @@ module ReVIEW
         if io
           @content = io.read
         elsif @path && File.exist?(@path)
-          @content = File.read(@path).sub(/\A\xEF\xBB\xBF/u, '')
+          @content = File.read(@path, 'r:BOM|utf-8')
         else
           @content = nil
         end

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -26,7 +26,7 @@ module ReVIEW
         if io
           @content = io.read
         elsif @path && File.exist?(@path)
-          @content = File.read(@path, 'r:BOM|utf-8')
+          @content = File.read(@path, :mode => 'r:BOM|utf-8')
         else
           @content = nil
         end

--- a/lib/review/preprocessor.rb
+++ b/lib/review/preprocessor.rb
@@ -403,7 +403,7 @@ module ReVIEW
     end
 
     def parse_file(fname)
-      File.open(fname) {|f|
+      File.open(fname, 'r:BOM|utf-8') {|f|
         init_ErrorUtils f
         return _parse_file(f)
       }

--- a/lib/review/tocparser.rb
+++ b/lib/review/tocparser.rb
@@ -1,8 +1,6 @@
 #
-# $Id: tocparser.rb 4268 2009-05-27 04:17:08Z kmuto $
-#
 # Copyright (c) 2002-2007 Minero Aoki
-#               2008-2009 Minero Aoki, Kenshi Muto
+#               2008-2016 Minero Aoki, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -18,7 +16,7 @@ module ReVIEW
 
   class TOCParser
     def TOCParser.parse(chap)
-      f = StringIO.new(chap.content)
+      f = StringIO.new(chap.content, 'r:BOM|utf-8')
       stream = Preprocessor::Strip.new(f)
       new.parse(stream, chap).map do |root|
         root.number = chap.number
@@ -39,7 +37,6 @@ module ReVIEW
       node_stack = []
       filename = chap.path
       while line = f.gets
-        line.sub!(/\A\xEF\xBB\xBF/u, '') # remove BOM
         case line
         when /\A\#@/
           ;


### PR DESCRIPTION
Windows向けに処理。

ちょっと怖いのでドキュメントでテストが必要。