### PR TITLE
Breaking Change: fix LaTeX templates

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -350,8 +350,7 @@ module ReVIEW
 
       texcompiler = File.basename(@config["texcommand"], ".*")
 
-      erb = ERB.new(File.read(template), nil, '-')
-      values = @config # must be 'values' for legacy files
+      erb = ReVIEW::Template.load(template, '-')
       erb.result(binding)
     end
 

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -28,6 +28,7 @@ module ReVIEW
 
     def initialize
       @basedir = nil
+      @input_files = Hash.new{|h, key| h[key] = ""}
     end
 
     def system_or_raise(*args)
@@ -127,7 +128,6 @@ module ReVIEW
       remove_old_file
       @path = build_path()
       begin
-        @input_files = Hash.new{|h, key| h[key] = ""}
         @compile_errors = nil
 
         book = ReVIEW::Book.load(@basedir)
@@ -337,9 +337,9 @@ module ReVIEW
         @config["pubhistory"] = make_history_list.join("\n")
       end
       if @documentclass == "ubook" || @documentclass == "utbook"
-        @coverimageoption = "width=\textheight,height=\textwidth,keepaspectratio,angle=90"
+        @coverimageoption = "width=\\textheight,height=\\textwidth,keepaspectratio,angle=90"
       else
-        @coverimageoption = "width=\textheight,height=\textwidth,keepaspectratio"
+        @coverimageoption = "width=\\textheight,height=\\textwidth,keepaspectratio"
       end
 
       template = File.expand_path('./latex/layout.tex.erb', ReVIEW::Template::TEMPLATE_DIR)

--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -1,4 +1,4 @@
-\documentclass[<%= documentclassoption %>]{<%= documentclass %>}
+\documentclass[<%= @documentclassoption %>]{<%= @documentclass %>}
 <%- if texcompiler == "uplatex" -%>
 \usepackage[deluxe,uplatex]{otf}
 <%- else -%>
@@ -28,7 +28,7 @@
   \MakeFramed {\FrameRestore}}%
  {\endMakeFramed}
 
-<%- unless ["utbook", "tbook"].include?(values["texdocumentclass"][0])  -%>
+<%- unless ["utbook", "tbook"].include?(@documentclass)  -%>
 \usepackage[top=10zw,bottom=12zw,left=10zw,right=10zw]{geometry}
 %\usepackage[top=5zw,bottom=5zw,left=1zw,right=1zw]{geometry}
 <%- end -%>
@@ -38,8 +38,8 @@
 
 <%- if texcompiler == "uplatex" -%>
 \usepackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true,colorlinks=true,%
-            pdftitle={<%= values.name_of("booktitle") %>},%
-            pdfauthor={<%= values.names_of("aut").join(I18n.t("names_splitter")) %>}]{hyperref}
+            pdftitle={<%= @config.name_of("booktitle") %>},%
+            pdfauthor={<%= @config.names_of("aut").join(I18n.t("names_splitter")) %>}]{hyperref}
 % uplatexでのBookmarkの文字化け対策（日本語向け）
 \usepackage[dvipdfmx]{pxjahyper}
 <%- else -%>
@@ -55,12 +55,11 @@
 \fi
 
 \usepackage[dvipdfm,bookmarks=true,bookmarksnumbered=true,colorlinks=true,%
-             pdftitle={<%= values.name_of("booktitle") %>},%
-             pdfauthor={<%= values.names_of("aut").join(I18n.t("names_splitter")
-) %>}]{hyperref}
+     pdftitle={<%= @config.name_of("booktitle") %>},%
+     pdfauthor={<%= @config.names_of("aut").join(I18n.t("names_splitter")) %>}]{hyperref}
 <%- end -%>
 
-<%- if ["utbook", "tbook"].include?(values["texdocumentclass"][0])  -%>
+<%- if ["utbook", "tbook"].include?(@documentclass)  -%>
 \newcommand{\headfont}{\gtfamily\sffamily\bfseries}
 \usepackage{plext}
 <%- end -%>
@@ -86,20 +85,12 @@
   stringstyle=\color{reviewred},%
   keywordstyle=\bfseries\color{reviewdarkred},%
 }
-\lstnewenvironment{reviewemlistlst}[1][]{%
-  \lstset{#1}}{}
 
-\lstnewenvironment{reviewemlistnumlst}[1][]{%
-  \lstset{numbers=left, #1}}{}
-
-\lstnewenvironment{reviewlistlst}[1][]{%
-  \lstset{#1}}{}
-
-\lstnewenvironment{reviewlistnumlst}[1][]{%
-  \lstset{numbers=left, #1}}{}
-
-\lstnewenvironment{reviewcmdlst}[1][]{%
-  \lstset{backgroundcolor=\color{white}, frameround=tttt, frame=trbl, #1}}{}
+\lstnewenvironment{reviewemlistlst}[1][]{\lstset{#1}}{}
+\lstnewenvironment{reviewemlistnumlst}[1][]{\lstset{numbers=left, #1}}{}
+\lstnewenvironment{reviewlistlst}[1][]{\lstset{#1}}{}
+\lstnewenvironment{reviewlistnumlst}[1][]{\lstset{numbers=left, #1}}{}
+\lstnewenvironment{reviewcmdlst}[1][]{\lstset{backgroundcolor=\color{white}, frameround=tttt, frame=trbl, #1}}{}
 <%- end -%>
 
 \newenvironment{reviewimage}{%
@@ -138,8 +129,8 @@
 
 \newenvironment{reviewcolumn}{%
      \begin{framed}
-   }{%
-      \end{framed}
+  }{%
+     \end{framed}
   \vspace{2zw}}
 
 \newcommand{\reviewcolumnhead}[2]{%
@@ -169,42 +160,28 @@
 \newcommand{\reviewboxcaption}[1]{%
   \medskip{\small\noindent #1}\vspace*{-1.3zw}}
 
-\newcommand{\reviewimageref}[2]{%
-  <%= I18n.t("image")%> #1}
-\newcommand{\reviewtableref}[2]{%
-  <%= I18n.t("table")%> #1}
-\newcommand{\reviewlistref}[1]{%
-  <%= I18n.t("list")%> #1}
-\newcommand{\reviewbibref}[2]{%
-  #1}
-\newcommand{\reviewcolumnref}[2]{%
-  <%= I18n.t("columnname")%> #1}
-\newcommand{\reviewsecref}[2]{%
-  #1}
+\newcommand{\reviewimageref}[2]{<%= I18n.t("image")%> #1}
+\newcommand{\reviewtableref}[2]{<%= I18n.t("table")%> #1}
+\newcommand{\reviewlistref}[1]{<%= I18n.t("list")%> #1}
+\newcommand{\reviewbibref}[2]{#1}
+\newcommand{\reviewcolumnref}[2]{<%= I18n.t("columnname")%> #1}
+\newcommand{\reviewsecref}[2]{#1}
 
 \newcommand{\reviewminicolumntitle}[1]{%
   {\large <%= I18n.t("memo_head")%>: #1}\\}
 
-<%- if values["toctitle"].present? -%>
-\renewcommand{\contentsname}{<%= values["toctitle"]%>}
+<%- if @config["toctitle"].present? -%>
+\renewcommand{\contentsname}{<%= @config["toctitle"]%>}
 <%- end -%>
 
 \newenvironment{reviewminicolumn}{%
   \vspace{1.5zw}\begin{screen}}{%
   \end{screen}\vspace{2zw}}
 
-\newcommand{\reviewkw}[1]{%
-  \textbf{\textgt{#1}}}
-
-\newcommand{\reviewami}[1]{%
-  \mask{#1}{A}}
-
-\newcommand{\reviewem}[1]{%
-  \textbf{#1}}
-
-\newcommand{\reviewstrong}[1]{%
-  \textbf{#1}}
-
+\newcommand{\reviewkw}[1]{\textbf{\textgt{#1}}}
+\newcommand{\reviewami}[1]{\mask{#1}{A}}
+\newcommand{\reviewem}[1]{\textbf{#1}}
+\newcommand{\reviewstrong}[1]{\textbf{#1}}
 \newcommand{\reviewunderline}{\Underline}
 
 %% @<del> is ignored in LaTeX with default style
@@ -216,19 +193,11 @@
 %%%% for jumoline.sty:
 %%\renewcommand{\reviewstrike}[1]{\Middleline{#1}}
 
-\newcommand{\reviewth}[1]{%
-  \textgt{#1}}
-
-\newcommand{\reviewtitlefont}[0]{%
-  \usefont{T1}{phv}{b}{n}\gtfamily}
-
-\newcommand{\reviewmainfont}[0]{%
- }
-
-\newcommand{\reviewcolophon}[0]{%
-  \clearpage}
-\newcommand{\reviewappendix}[0]{%
-  \appendix}
+\newcommand{\reviewth}[1]{\textgt{#1}}
+\newcommand{\reviewtitlefont}[0]{\usefont{T1}{phv}{b}{n}\gtfamily}
+\newcommand{\reviewmainfont}[0]{}
+\newcommand{\reviewcolophon}[0]{\clearpage}
+\newcommand{\reviewappendix}[0]{\appendix}
 
 \makeatletter
 %% maxwidth is the original width if it is less than linewidth
@@ -242,8 +211,8 @@
 }
 \makeatother
 
-<%- if values["usepackage"] -%>
-<%= values["usepackage"] %>
+<%- if @config["usepackage"] -%>
+<%= @config["usepackage"] %>
 <%- end -%>
 
 \usepackage[T1]{fontenc}
@@ -252,36 +221,22 @@
 
 \reviewmainfont
 
-<%- if values["titlepage"] -%>
+<%- if @config["titlepage"] -%>
 <%-   if custom_titlepage -%>
 <%= custom_titlepage %>
 <%-   else -%>
-<%-     unless ["utbook", "tbook"].include?(values["texdocumentclass"][0])  -%>
 \begin{titlepage}
-<%-       if values["coverimage"] -%>
+<%-     if @config["coverimage"] -%>
   \begin{center}
-    %%%\mbox{}\vskip5zw%
-    \includegraphics[width=\textwidth,height=\textheight,keepaspectratio]{./images/<%= values["coverimage"] %>}
+    \includegraphics[<%= @coverimageoption%>]{./images/<%= @config["coverimage"] %>}
   \end{center}
   \clearpage
-<%-       end -%>
-<%-     else -%>
-% 縦書きの表紙
-\begin{titlepage}
-<%-       if values["coverimage"] -%>
-  \begin{center}
-    %%%\mbox{}\vskip5zw%
-    \includegraphics[width=\textheight,height=\textwidth,keepaspectratio,angle=90]{./images/<%= values["coverimage"] %>}
-  \end{center}
-  \clearpage
-<%-      end -%>
-<%-    end -%>
-<%-  end -%>
+<%-     end -%>
 \thispagestyle{empty}
 \begin{center}%
   \mbox{} \vskip5zw
    \reviewtitlefont%
-    {\Huge <%= values.name_of("booktitle") %> \par}%
+    {\Huge <%= @config.name_of("booktitle") %> \par}%
     \vskip 15em%
     {\huge
       \lineskip .75em
@@ -289,61 +244,62 @@
         <%= authors %>
       \end{tabular}\par}%
     \vfill
-    {\large <%= values["date"] %> <%= I18n.t("edition")%>\hspace{2zw}<%= I18n.t("published_by", values.names_of("prt").join(I18n.t("names_splitter")))%>\par}%
+    {\large <%= @config["date"] %> <%= I18n.t("edition")%>\hspace{2zw}<%= I18n.t("published_by", @config.names_of("prt").join(I18n.t("names_splitter")))%>\par}%
 \vskip4zw\mbox{}
   \end{center}%
 \end{titlepage}
+<%-   end -%>
 <%- end -%>
 
 \renewcommand{\chaptermark}[1]{{}}
 \frontmatter
 
 %%% originaltitle
-<%- if values["originaltitlefile"] -%>
+<%- if @config["originaltitlefile"] -%>
 <%= custom_originaltitlepage %>
 <%- end -%>
 
 %%% credit
-<%- if values["creditfile"] -%>
+<%- if @config["creditfile"] -%>
 <%= custom_creditpage %>
 <%- end -%>
 
 %% preface
-<%= values["pre_str"] %>
+<%= @input_files["PREDEF"] %>
 
-<%- if values["toc"] -%>
-\setcounter{tocdepth}{<%= values["toclevel"] %>}
+<%- if @config["toc"] -%>
+\setcounter{tocdepth}{<%= @config["toclevel"] %>}
 \tableofcontents
 <%- end -%>
 
 \renewcommand{\chaptermark}[1]{\markboth{\prechaptername\thechapter\postchaptername~#1}{}}
 \mainmatter
-<%= values["chap_str"] %>
+<%= @input_files["CHAPS"] %>
 \renewcommand{\chaptermark}[1]{\markboth{\appendixname\thechapter~#1}{}}
 \reviewappendix
-<%= values["appendix_str"] %>
+<%= @input_files["APPENDIX"] %>
 
 %% backmatter begins
-<%- if values["post_str"] or values["colophon"] -%>
+<%- if @input_files["POSTDEF"] or @config["colophon"] -%>
 \backmatter
 <%- end -%>
 
-<%- if values["post_str"] -%>
-<%= values["post_str"] %>
+<%- if @input_files["POSTDEF"] -%>
+<%= @input_files["POSTDEF"] %>
 <%- end -%>
 
 %%% profile
-<%- if values["profile"] -%>
+<%- if @config["profile"] -%>
 <%= custom_profilepage %>
 <%- end -%>
 
 %%% advfile
-<%- if values["advfile"] -%>
+<%- if @config["advfile"] -%>
 <%= custom_advfilepage %>
 <%- end -%>
 
 %%% colophon
-<%- if values["colophon"] -%>
+<%- if @config["colophon"] -%>
 <%-   if custom_colophonpage -%>
 <%= custom_colophonpage %>
 <%-   else -%>
@@ -353,10 +309,10 @@
 
 \vspace*{\fill}
 
-{\noindent\reviewtitlefont\Large <%= values.name_of("booktitle") %>} \\
+{\noindent\reviewtitlefont\Large <%= @config.name_of("booktitle") %>} \\
 \rule[8pt]{14cm}{1pt} \\
 {\noindent
-<%= values["pubhistory"].to_s.gsub(/\n/){"\n\n\\noindent"} %>
+<%= @config["pubhistory"].to_s.gsub(/\n/){"\n\n\\noindent"} %>
 }
 
 \begin{tabular}{ll}
@@ -364,12 +320,12 @@
 \end{tabular}
 　\\
 \rule[0pt]{14cm}{1pt} \\
-<%= values.names_of("rights").join('\\' + '\\') %> \\
+<%= @config.names_of("rights").join('\\' + '\\') %> \\
 <%-   end -%>
 <%- end -%>
 
 %%% backcover
-<%- if values["backcover"] -%>
+<%- if @config["backcover"] -%>
 <%= custom_backcoverpage %>
 <%- end -%>
 

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -74,8 +74,8 @@
 
 \newenvironment{reviewcolumn}{%
      \begin{framed}
-   }{%
-      \end{framed}
+  }{%
+     \end{framed}
   \vspace{2zw}}
 
 \newcommand{\reviewcolumnhead}[2]{%
@@ -105,18 +105,12 @@
 \newcommand{\reviewboxcaption}[1]{%
   \medskip{\small\noindent #1}\vspace*{-1.3zw}}
 
-\newcommand{\reviewimageref}[2]{%
-  図 #1}
-\newcommand{\reviewtableref}[2]{%
-  表 #1}
-\newcommand{\reviewlistref}[1]{%
-  リスト #1}
-\newcommand{\reviewbibref}[2]{%
-  #1}
-\newcommand{\reviewcolumnref}[2]{%
-  コラム #1}
-\newcommand{\reviewsecref}[2]{%
-  #1}
+\newcommand{\reviewimageref}[2]{図 #1}
+\newcommand{\reviewtableref}[2]{表 #1}
+\newcommand{\reviewlistref}[1]{リスト #1}
+\newcommand{\reviewbibref}[2]{#1}
+\newcommand{\reviewcolumnref}[2]{コラム #1}
+\newcommand{\reviewsecref}[2]{#1}
 
 \newcommand{\reviewminicolumntitle}[1]{%
   {\large ■メモ: #1}\\}
@@ -126,18 +120,10 @@
   \vspace{1.5zw}\begin{screen}}{%
   \end{screen}\vspace{2zw}}
 
-\newcommand{\reviewkw}[1]{%
-  \textbf{\textgt{#1}}}
-
-\newcommand{\reviewami}[1]{%
-  \mask{#1}{A}}
-
-\newcommand{\reviewem}[1]{%
-  \textbf{#1}}
-
-\newcommand{\reviewstrong}[1]{%
-  \textbf{#1}}
-
+\newcommand{\reviewkw}[1]{\textbf{\textgt{#1}}}
+\newcommand{\reviewami}[1]{\mask{#1}{A}}
+\newcommand{\reviewem}[1]{\textbf{#1}}
+\newcommand{\reviewstrong}[1]{\textbf{#1}}
 \newcommand{\reviewunderline}{\Underline}
 
 %% @<del> is ignored in LaTeX with default style
@@ -149,19 +135,11 @@
 %%%% for jumoline.sty:
 %%\renewcommand{\reviewstrike}[1]{\Middleline{#1}}
 
-\newcommand{\reviewth}[1]{%
-  \textgt{#1}}
-
-\newcommand{\reviewtitlefont}[0]{%
-  \usefont{T1}{phv}{b}{n}\gtfamily}
-
-\newcommand{\reviewmainfont}[0]{%
- }
-
-\newcommand{\reviewcolophon}[0]{%
-  \clearpage}
-\newcommand{\reviewappendix}[0]{%
-  \appendix}
+\newcommand{\reviewth}[1]{\textgt{#1}}
+\newcommand{\reviewtitlefont}[0]{\usefont{T1}{phv}{b}{n}\gtfamily}
+\newcommand{\reviewmainfont}[0]{}
+\newcommand{\reviewcolophon}[0]{\clearpage}
+\newcommand{\reviewappendix}[0]{\appendix}
 
 \makeatletter
 %% maxwidth is the original width if it is less than linewidth
@@ -219,6 +197,8 @@
 
 
 %% backmatter begins
+\backmatter
+
 
 
 %%% profile

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -1,3 +1,5 @@
+\backmatter
+
 
 
 %%% profile


### PR DESCRIPTION
* use instance variables instead of `values`
    * `@config` for Configure
    * `@documentclass` and `@documentclassoption` for \documentclass
    * `@coverimageoption` for \includegraphics of cover
    * `@input_files` to including CHAPS, PREDEF, ...
* remove newline and/or spaces (cosmetic changes)
* use ReVIEW::Template instead of ERB directly