### PR TITLE
use rubocop with rake

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -9,7 +9,16 @@ require 'rubygems'
 require 'rake/testtask'
 require 'rake/clean'
 
-task :default => [:test]
+task :default => [:test, :rubocop]
+
+task :rubocop do
+  begin
+    require 'rubocop/rake_task'
+    RuboCop::RakeTask.new
+  rescue LoadError
+    warn "rubocop not found"
+  end
+end
 
 Rake::TestTask.new("test") do |t|
   t.libs << "test"


### PR DESCRIPTION
`rake rubocop`でrubocopが実行できるようになります（インストールされていない場合は警告だけ出して無視されます）。
`rake`だとtestとrubocopの両方が実行されるようになります。