### PR TITLE
rubocop: add more rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,7 @@ AllCops:
   Exclude:
     - lib/lineinput.rb
     - lib/uuid.rb
+  DisplayCopNames: true
 
 inherit_from: .rubocop_todo.yml
 
@@ -64,3 +65,26 @@ Style/ZeroLengthPredicate:
 
 Metrics/ClassLength:
   Max: 1500
+
+Metrics/LineLength:
+  Max: 256
+  Exclude:
+    - "test/**/*"
+
+### should be < 50
+Metrics/MethodLength:
+  Max: 100
+  Exclude:
+    - "bin/review-*"
+    - "test/**/*"
+
+### should be < 20
+Metrics/CyclomaticComplexity:
+  Max: 32
+
+### should be < 60
+Metrics/AbcSize:
+  Max: 120
+  Exclude:
+    - "bin/review-*"
+    - "test/**/*"

--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -297,7 +297,12 @@ module EPUBMaker
         raise "Key #{k} must have a value. Abort." unless @params[k]
       end
       # array
-      %w[subject aut a-adp a-ann a-arr a-art a-asn a-aqt a-aft a-aui a-ant a-bkp a-clb a-cmm a-dsr a-edt a-ill a-lyr a-mdc a-mus a-nrt a-oth a-pht a-prt a-red a-rev a-spn a-ths a-trc a-trl adp ann arr art asn aut aqt aft aui ant bkp clb cmm dsr edt ill lyr mdc mus nrt oth pht pbl prt red rev spn ths trc trl stylesheet rights].each do |item|
+      %w[subject aut
+         a-adp a-ann a-arr a-art a-asn a-aqt a-aft a-aui a-ant a-bkp a-clb a-cmm a-dsr a-edt
+         a-ill a-lyr a-mdc a-mus a-nrt a-oth a-pht a-prt a-red a-rev a-spn a-ths a-trc a-trl
+         adp ann arr art asn aut aqt aft aui ant bkp clb cmm dsr edt
+         ill lyr mdc mus nrt oth pht pbl prt red rev spn ths trc trl
+         stylesheet rights].each do |item|
         next unless @params[item]
         @params[item] = [@params[item]] if @params[item].kind_of?(String)
       end


### PR DESCRIPTION
add `Metrics/MethodLength` rule and fix long Array in EPUBMaker::Producer.