### PR TITLE
add inline_comment to TOPBuilder

### DIFF
--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -503,6 +503,14 @@ module ReVIEW
       [str.to_i(16)].pack("U")
     end
 
+    def inline_comment(str)
+      if @book.config["draft"]
+        %Q[◆→DTP連絡:#{str}←◆]
+      else
+        %Q[◆→DTP連絡:#{str}←◆]
+      end
+    end
+
     def inline_m(str)
       %Q[◆→TeX式ここから←◆#{str}◆→TeX式ここまで←◆]
     end

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -507,7 +507,7 @@ module ReVIEW
       if @book.config["draft"]
         %Q[◆→DTP連絡:#{str}←◆]
       else
-        %Q[◆→DTP連絡:#{str}←◆]
+        ""
       end
     end
 

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -136,7 +136,7 @@ class TOPBuidlerTest < Test::Unit::TestCase
 
   def test_inline_comment
     actual = compile_inline("test @<comment>{コメント} test2")
-    assert_equal %Q|test ◆→DTP連絡:コメント←◆ test2|, actual
+    assert_equal %Q|test  test2|, actual
   end
 
   def test_inline_in_table

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -134,6 +134,11 @@ class TOPBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|test ① test2|, actual
   end
 
+  def test_inline_comment
+    actual = compile_inline("test @<comment>{コメント} test2")
+    assert_equal %Q|test ◆→DTP連絡:コメント←◆ test2|, actual
+  end
+
   def test_inline_in_table
     actual = compile_block("//table{\n★1☆\t▲2☆\n------------\n★3☆\t▲4☆<>&\n//}\n")
     assert_equal %Q|★★1☆☆\t★▲2☆☆\n★3☆\t▲4☆<>&\n◆→終了:表←◆\n\n|, actual


### PR DESCRIPTION
2.0.0 で出力結果が変わっていたので。

expected

```
◆→DTP連絡:コメントだよ！←◆
```

actual

```
@<comment>{コメントだよ！}
```
