### PR TITLE
TOPBuilder: add a test for `@<comment>{}` in draft mode

### DIFF
--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -139,6 +139,12 @@ class TOPBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|test  test2|, actual
   end
 
+  def test_inline_comment_for_draft
+    @config["draft"] = true
+    actual = compile_inline("test @<comment>{コメント} test2")
+    assert_equal %Q|test ◆→DTP連絡:コメント←◆ test2|, actual
+  end
+
   def test_inline_in_table
     actual = compile_block("//table{\n★1☆\t▲2☆\n------------\n★3☆\t▲4☆<>&\n//}\n")
     assert_equal %Q|★★1☆☆\t★▲2☆☆\n★3☆\t▲4☆<>&\n◆→終了:表←◆\n\n|, actual


### PR DESCRIPTION
cf. #625 