### PR TITLE
I18n.t: fix format_number_header

### DIFF
--- a/lib/review/i18n.rb
+++ b/lib/review/i18n.rb
@@ -119,40 +119,46 @@ module ReVIEW
         end
       end
 
-      percents = frmt.scan(/%\w{1,3}/)
+      percents = frmt.scan(/%[A-Za-z]{1,3}/)
+      remove_args = []
       percents.each_with_index do |i, idx|
         case i
         when "%pA"
           frmt.sub!(i, ALPHA_U[args[idx]])
-          args.delete idx
+          remove_args << idx
         when "%pa"
           frmt.sub!(i, ALPHA_L[args[idx]])
-          args.delete idx
+          remove_args << idx
         when "%pAW"
           frmt.sub!(i, ALPHA_UW[args[idx]])
-          args.delete idx
+          remove_args << idx
         when "%paW"
           frmt.sub!(i, ALPHA_LW[args[idx]])
-          args.delete idx
+          remove_args << idx
         when "%pR"
           frmt.sub!(i, ROMAN_U[args[idx]])
-          args.delete idx
+          remove_args << idx
         when "%pr"
           frmt.sub!(i, ROMAN_L[args[idx]])
-          args.delete idx
+          remove_args << idx
         when "%pRW"
           frmt.sub!(i, ROMAN_UW[args[idx]])
-          args.delete idx
+          remove_args << idx
         when "%pJ"
           frmt.sub!(i, JAPAN[args[idx]])
-          args.delete idx
+          remove_args << idx
         when "%pdW"
           frmt.sub!(i, ARABIC_LW[args[idx]])
-          args.delete idx
+          remove_args << idx
         when "%pDW"
           frmt.sub!(i, ARABIC_UW[args[idx]])
-          args.delete idx
+          remove_args << idx
+        else
+          # noop
         end
+      end
+      remove_args.reverse_each do |idx|
+        args.delete_at idx
       end
       args_matched = (frmt.count("%") == args.size)
       frmt.gsub!('##', '%%')

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -153,6 +153,34 @@ class I18nTest < Test::Unit::TestCase
     end
   end
 
+  def test_custom_format_numbers
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        file = File.join(dir, "locale.yml")
+
+        File.open(file, "w"){|f| f.write %Q|locale: ja\nformat_number_header: "%s-%pA:"| }
+        I18n.setup("ja")
+        assert_equal "1-B:", I18n.t("format_number_header", [1, 2])
+
+        File.open(file, "w"){|f| f.write %Q|locale: ja\nformat_number_header: "%s.%pa:"| }
+        I18n.setup("ja")
+        assert_equal "2.c:", I18n.t("format_number_header", [2, 3])
+
+        File.open(file, "w"){|f| f.write %Q|locale: ja\nformat_number_header: "%pA,%pAW:"| }
+        I18n.setup("ja")
+        assert_equal "C,Ｄ:", I18n.t("format_number_header", [3, 4])
+
+        File.open(file, "w"){|f| f.write %Q|locale: ja\nformat_number_header: "%pJ・%pJ:"| }
+        I18n.setup("ja")
+        assert_equal "十二・二十六:", I18n.t("format_number_header", [12, 26])
+
+        File.open(file, "w"){|f| f.write %Q|locale: ja\nformat_number_header: "%pdW―%pdW:"| }
+        I18n.setup("ja")
+        assert_equal "３―12:", I18n.t("format_number_header", [3, 12])
+      end
+    end
+  end
+
   def test_ja
     I18n.setup("ja")
     assert_equal "図", I18n.t("image")


### PR DESCRIPTION
`format_number_header`で`%pJ`を正しく使えないようなので修正しました。

`percents.each_with_index`の中で、`args`をインデックスアクセスに使っているのに`args.delete`で破壊的に変更しているので、`%pXX`が複数あると正常に動かなかったようです。`args`の変更はループの外で行うようにしました。