### PR TITLE
LATEXBuilder: fix to use keywords in locale.yml

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -348,6 +348,17 @@ module ReVIEW
         @coverimageoption = "width=\\textwidth,height=\\textheight,keepaspectratio"
       end
 
+      @locale_latex = Hash.new
+      part_tuple = I18n.get("part").split(/\%[A-Za-z]{1,3}/, 2)
+      chapter_tuple = I18n.get("chapter").split(/\%[A-Za-z]{1,3}/, 2)
+      appendix_tuple = I18n.get("appendix").split(/\%[A-Za-z]{1,3}/, 2)
+      @locale_latex["prepartname"] = part_tuple[0]
+      @locale_latex["postpartname"] = part_tuple[1]
+      @locale_latex["prechaptername"] = chapter_tuple[0]
+      @locale_latex["postchaptername"] = chapter_tuple[1]
+      @locale_latex["preappendixname"] = appendix_tuple[0]
+      @locale_latex["postappendixname"] = appendix_tuple[1]
+
       template = File.expand_path('./latex/layout.tex.erb', ReVIEW::Template::TEMPLATE_DIR)
       layout_file = File.join(@basedir, "layouts", "layout.tex.erb")
       if File.exist?(layout_file)

--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -171,9 +171,9 @@
   {\large <%= I18n.t("memo_head")%>: #1}\\}
 
 <%- if @config["toctitle"].present? -%>
-\renewcommand{\contentsname}{<%= @config["toctitle"]%>}
+\renewcommand{\contentsname}{<%= escape_latex(@config["toctitle"]) %>}
 <%- elsif I18n.t("toctitle") -%>
-\renewcommand{\contentsname}{<%= I18n.t("toctitle")%>}
+\renewcommand{\contentsname}{<%= escape_latex(I18n.t("toctitle")) %>}
 <%- end -%>
 
 \newenvironment{reviewminicolumn}{%
@@ -201,13 +201,13 @@
 \newcommand{\reviewcolophon}[0]{\clearpage}
 \newcommand{\reviewappendix}[0]{\appendix}
 
-\newcommand{\reviewprepartname}{<%= @locale_latex["prepartname"] %>}
-\newcommand{\reviewpostpartname}{<%= @locale_latex["postpartname"] %>}
-\newcommand{\reviewprechaptername}{<%= @locale_latex["prechaptername"] %>}
-\newcommand{\reviewpostchaptername}{<%= @locale_latex["postchaptername"] %>}
-\newcommand{\reviewfigurename}{<%= I18n.t("image")%>}
-\newcommand{\reviewtablename}{<%= I18n.t("table")%>}
-\newcommand{\reviewappendixname}{<%= @locale_latex["preappendixname"] %>}
+\newcommand{\reviewprepartname}{<%= escape_latex(@locale_latex["prepartname"]) %>}
+\newcommand{\reviewpostpartname}{<%= escape_latex(@locale_latex["postpartname"]) %>}
+\newcommand{\reviewprechaptername}{<%= escape_latex(@locale_latex["prechaptername"]) %>}
+\newcommand{\reviewpostchaptername}{<%= escape_latex(@locale_latex["postchaptername"]) %>}
+\newcommand{\reviewfigurename}{<%= escape_latex(I18n.t("image")) %>}
+\newcommand{\reviewtablename}{<%= escape_latex(I18n.t("table")) %>}
+\newcommand{\reviewappendixname}{<%= escape_latex(@locale_latex["preappendixname"]) %>}
 
 \ifdefined\prepartname
   \renewcommand{\prepartname}{\reviewprepartname}

--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -172,6 +172,8 @@
 
 <%- if @config["toctitle"].present? -%>
 \renewcommand{\contentsname}{<%= @config["toctitle"]%>}
+<%- elsif I18n.t("toctitle") -%>
+\renewcommand{\contentsname}{<%= I18n.t("toctitle")%>}
 <%- end -%>
 
 \newenvironment{reviewminicolumn}{%
@@ -198,6 +200,37 @@
 \newcommand{\reviewmainfont}[0]{}
 \newcommand{\reviewcolophon}[0]{\clearpage}
 \newcommand{\reviewappendix}[0]{\appendix}
+
+\newcommand{\reviewprepartname}{<%= @locale_latex["prepartname"] %>}
+\newcommand{\reviewpostpartname}{<%= @locale_latex["postpartname"] %>}
+\newcommand{\reviewprechaptername}{<%= @locale_latex["prechaptername"] %>}
+\newcommand{\reviewpostchaptername}{<%= @locale_latex["postchaptername"] %>}
+\newcommand{\reviewfigurename}{<%= I18n.t("image")%>}
+\newcommand{\reviewtablename}{<%= I18n.t("table")%>}
+\newcommand{\reviewappendixname}{<%= @locale_latex["preappendixname"] %>}
+
+\ifdefined\prepartname
+  \renewcommand{\prepartname}{\reviewprepartname}
+\fi
+\ifdefined\postpartname
+  \renewcommand{\postpartname}{\reviewpostpartname}
+\fi
+\ifdefined\prechaptername
+  \renewcommand{\prechaptername}{\reviewprechaptername}
+\fi
+\ifdefined\postchaptername
+  \renewcommand{\postchaptername}{\reviewpostchaptername}
+\fi
+\ifdefined\figurename
+  \renewcommand{\figurename}{\reviewfigurename}
+\fi
+\ifdefined\tablename
+  \renewcommand{\tablename}{\reviewtablename}
+\fi
+\ifdefined\appendixname
+  \renewcommand{\appendixname}{\reviewappendixname}
+\fi
+
 
 \makeatletter
 %% maxwidth is the original width if it is less than linewidth

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -115,6 +115,7 @@
 \newcommand{\reviewminicolumntitle}[1]{%
   {\large ■メモ: #1}\\}
 
+\renewcommand{\contentsname}{目次}
 
 \newenvironment{reviewminicolumn}{%
   \vspace{1.5zw}\begin{screen}}{%
@@ -140,6 +141,37 @@
 \newcommand{\reviewmainfont}[0]{}
 \newcommand{\reviewcolophon}[0]{\clearpage}
 \newcommand{\reviewappendix}[0]{\appendix}
+
+\newcommand{\reviewprepartname}{第}
+\newcommand{\reviewpostpartname}{部}
+\newcommand{\reviewprechaptername}{第}
+\newcommand{\reviewpostchaptername}{章}
+\newcommand{\reviewfigurename}{図}
+\newcommand{\reviewtablename}{表}
+\newcommand{\reviewappendixname}{付録}
+
+\ifdefined\prepartname
+  \renewcommand{\prepartname}{\reviewprepartname}
+\fi
+\ifdefined\postpartname
+  \renewcommand{\postpartname}{\reviewpostpartname}
+\fi
+\ifdefined\prechaptername
+  \renewcommand{\prechaptername}{\reviewprechaptername}
+\fi
+\ifdefined\postchaptername
+  \renewcommand{\postchaptername}{\reviewpostchaptername}
+\fi
+\ifdefined\figurename
+  \renewcommand{\figurename}{\reviewfigurename}
+\fi
+\ifdefined\tablename
+  \renewcommand{\tablename}{\reviewtablename}
+\fi
+\ifdefined\appendixname
+  \renewcommand{\appendixname}{\reviewappendixname}
+\fi
+
 
 \makeatletter
 %% maxwidth is the original width if it is less than linewidth

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -19,6 +19,7 @@ class PDFMakerTest < Test::Unit::TestCase
                      "texcommand" => "uplatex",
                    })
     @maker.config = @config
+    @maker.initialize_metachars(@config["texcommand"])
     @output = StringIO.new
     I18n.setup(@config["language"])
   end


### PR DESCRIPTION
`locale.yml`で`chapter`や`image`を再設定してもLATEXBuilderに反映されなかったのを修正します。

* `locale.yml`で設定した文字列を、`\reviewfigurename`などのコントロールシーケンスで参照できるようにします
* chapter, part, appendixは、`%XXX`で２分割した前後をそれぞれ`\reviewprepartname`,`\reviewpostpartname`等で参照できるようにします。
* jsbook、utbookの場合は`\prepartname`、`\figurename`等を`\renewcommand`するので何もしなくても反映されます。`\prepartname`を使っていないスタイルファイルを使っている場合は、自力で`\reviewprepartname`等を使って再設定してください。