### PR TITLE
check caption by using present? instead of nil? on IDGXMLBuilder.

### DIFF
--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -392,7 +392,7 @@ module ReVIEW
 
     def quotedlist(lines, css_class, caption)
       print %Q[<list type='#{css_class}'>]
-      puts "<caption aid:pstyle='#{css_class}-title'>#{compile_inline(caption)}</caption>" unless caption.nil?
+      puts "<caption aid:pstyle='#{css_class}-title'>#{compile_inline(caption)}</caption>" if caption.present?
       print %Q[<pre>]
       no = 1
       lines.each do |line|


### PR DESCRIPTION
IDGXMLBuilderで//emlist[][highlight-lang]としたときに、「空文字の」captionができてしまっていました。HTMLBuilderと同様に、unless nil?をやめてif present?で有効な文字列があることを調査するようにします。