### PR TITLE
add instruction to column headline for toc on IDGXMLBuilder.

### DIFF
--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -811,7 +811,7 @@ module ReVIEW
       @column += 1
       a_id = %Q[id="column-#{@column}"]
       print "<#{type}column #{a_id}>"
-      puts %Q[<title aid:pstyle="#{type}column-title">#{compile_inline(caption)}</title>]
+      puts %Q[<title aid:pstyle="#{type}column-title">#{compile_inline(caption)}</title><?dtp level="9" section="#{escape_html(compile_inline(caption))}"?>]
     end
 
     def common_column_end(type)

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -412,7 +412,7 @@ inside column
 ===[/column]
 EOS
     expected =<<-EOS.chomp
-<column id="column-1"><title aid:pstyle="column-title">prev column</title><p>inside prev column</p></column><column id="column-2"><title aid:pstyle="column-title">test</title><p>inside column</p></column>
+<column id="column-1"><title aid:pstyle="column-title">prev column</title><?dtp level="9" section="prev column"?><p>inside prev column</p></column><column id="column-2"><title aid:pstyle="column-title">test</title><?dtp level="9" section="test"?><p>inside column</p></column>
 EOS
     assert_equal expected, column_helper(review)
   end
@@ -426,7 +426,7 @@ inside column
 === next level
 EOS
     expected =<<-EOS.chomp
-<column id="column-1"><title aid:pstyle="column-title">test</title><p>inside column</p></column><title aid:pstyle=\"h3\">next level</title><?dtp level="3" section="next level"?>
+<column id="column-1"><title aid:pstyle="column-title">test</title><?dtp level="9" section="test"?><p>inside column</p></column><title aid:pstyle=\"h3\">next level</title><?dtp level="3" section="next level"?>
 EOS
 
     assert_equal expected, column_helper(review)


### PR DESCRIPTION
IDGXMLにおいてコラムの埋め込み目次情報を入れていなかったので、ほかのheadlineと同じくXMLインストラクションを入れるようにしました。