### PR TITLE
fix missing default dc:identifier value.

### DIFF
--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -11,7 +11,6 @@
 require 'tmpdir'
 require 'fileutils'
 require 'review/yamlloader'
-require 'securerandom'
 require 'epubmaker/content'
 require 'epubmaker/epubv2'
 require 'epubmaker/epubv3'
@@ -215,7 +214,6 @@ module EPUBMaker
         "language" => "ja",
         "date" => Time.now.strftime("%Y-%m-%d"),
         "modified" => Time.now.strftime("%Y-%02m-%02dT%02H:%02M:%02SZ"),
-        "urnid" => "urn:uid:#{SecureRandom.uuid}",
         "isbn" => nil,
         "toclevel" => 2,
         "stylesheet" => [],

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+require 'securerandom'
+
 module ReVIEW
   class Configure < Hash
 
@@ -23,7 +25,7 @@ module ReVIEW
         "date" => nil, # publishing date
         "rights" => nil, # Copyright messages
         "description" => nil, # Description
-        "urnid" => nil, # Identifier (nil makes random uuid)
+        "urnid" => "urn:uid:#{SecureRandom.uuid}", # Identifier
         "stylesheet" => "stylesheet.css", # stylesheet file
         "coverfile" => nil, # content file of body of cover page
         "mytoc" => nil, # whether make own table of contents or not


### PR DESCRIPTION
「ReVIEW::Configure側で上書き」するため、urnidがUUIDではなくnilになってしまっていました。
config.ymlで明示的な設定をしていない場合に壊れたEPUBを作ってしまうことになります。

Configure側にUUID作成の設定を移動しました（設定が別々にあるのがそもそもいかん、ちゅー話ですね）。
