### PR TITLE
fix: surpress rubocop 0.41.0

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -198,11 +198,6 @@ Style/CommentIndentation:
 Style/ConstantName:
   Enabled: false
 
-# Offense count: 4
-# Cop supports --auto-correct.
-Style/DeprecatedHashMethods:
-  Enabled: false
-
 # Offense count: 105
 Style/Documentation:
   Enabled: false

--- a/lib/review/book/compilable.rb
+++ b/lib/review/book/compilable.rb
@@ -109,9 +109,9 @@ module ReVIEW
       end
 
       def image(id)
-        return image_index()[id] if image_index().has_key?(id)
-        return icon_index()[id] if icon_index().has_key?(id)
-        return numberless_image_index()[id] if numberless_image_index().has_key?(id)
+        return image_index()[id] if image_index().key?(id)
+        return icon_index()[id] if icon_index().key?(id)
+        return numberless_image_index()[id] if numberless_image_index().key?(id)
         indepimage_index()[id]
       end
 

--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -79,9 +79,10 @@ module ReVIEW
         @items.each(&block)
       end
 
-      def has_key?(id)
-        return @index.has_key?(id)
+      def key?(id)
+        return @index.key?(id)
       end
+      alias_method :has_key?, :key?
     end
 
 

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -54,7 +54,7 @@ module ReVIEW
         "page_metric" => ReVIEW::Book::PageMetric::A5,
         "ext" => '.re',
         "image_dir" => 'images',
-        "image_types" => %w( .ai .psd .eps .pdf .tif .tiff .png .bmp .jpg .jpeg .gif .svg ),
+        "image_types" => %w(.ai .psd .eps .pdf .tif .tiff .png .bmp .jpg .jpeg .gif .svg),
         "image_scale2width" => true, # for LaTeX
         "bib_file" => "bib.re",
         "colophon_order" => %w(aut csl trl dsr ill cov edt pbl contact prt),

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -50,7 +50,7 @@ module ReVIEW
     def builder_init_file
       @warns = []
       @errors = []
-      @chapter.book.image_types = %w( .png .jpg .jpeg .gif .svg )
+      @chapter.book.image_types = %w(.png .jpg .jpeg .gif .svg)
       @column = 0
       @sec_counter = SecCounter.new(5, @chapter)
       @nonum_counter = 0

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -18,7 +18,7 @@ module ReVIEW
     def builder_init_file
       @blank_seen = nil
       @ul_indent = 0
-      @chapter.book.image_types = %w( .png .jpg .jpeg .gif .svg )
+      @chapter.book.image_types = %w(.png .jpg .jpeg .gif .svg)
     end
     private :builder_init_file
 

--- a/lib/review/preprocessor.rb
+++ b/lib/review/preprocessor.rb
@@ -107,7 +107,7 @@ module ReVIEW
 
     private
 
-    TYPES = %w( file range )
+    TYPES = %w(file range)
 
     def preproc(f)
       init_vars
@@ -161,7 +161,7 @@ module ReVIEW
       end
     end
 
-    KNOWN_DIRECTIVES = %w( require provide warn ok )
+    KNOWN_DIRECTIVES = %w(require provide warn ok)
 
     def known_directive?(op)
       KNOWN_DIRECTIVES.index(op)

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -28,6 +28,16 @@ class IndexTest < Test::Unit::TestCase
     assert_equal 'bar\\a\\$buz', item.content
   end
 
+  def test_footnote_index_key?
+    fn = Book::FootnoteIndex.parse(['//footnote[foo][bar]'])
+    assert_equal true, fn.key?('foo')
+
+    ## for compatibility
+    # rubocop:disable Style/PreferredHashMethods
+    assert_equal true, fn.has_key?('foo')
+    # rubocop:enable Style/PreferredHashMethods
+  end
+
   def test_HeadelineIndex
     src = <<-EOB
 = chap1


### PR DESCRIPTION
* Style/PreferredHashMethods: Use Hash#key? instead of Hash#has_key?
* Style/SpaceInsidePercentLiteralDelimiters: Do not use spaces inside percent literal delimiters