### PR TITLE
hookに相対パスで指定したときにうまく動かない問題の解決

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -120,7 +120,7 @@ module ReVIEW
       # YAML configs will be overridden by command line options.
       @config.merge!(cmd_config)
       I18n.setup(@config["language"])
-      @basedir = File.dirname(yamlfile)
+      @basedir = File.absolute_path(File.dirname(yamlfile))
 
       begin
         @config.check_version(ReVIEW::VERSION)


### PR DESCRIPTION
File.dirname(yamlfile)だけだと「.」になってしまい、フックの場所が見つけられなくなる。
absolute_pathを使うように変更。