### PR TITLE
supress rubocop warning

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,6 +61,12 @@ Performance/RedundantMerge:
 Style/ZeroLengthPredicate:
   Enabled: false
 
+Style/NumericPredicate:
+  Enabled: false
+
+Style/TernaryParentheses:
+  Enabled: false
+
 ##################### Metrics ##################################
 
 Metrics/ClassLength:

--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -239,28 +239,6 @@ module ReVIEW
       end
     end
 
-    class FormatRef
-      def initialize(locale, index)
-        @locale = locale
-        @index = index
-      end
-
-      def title(id)
-        sprintf(@locale["#{@index.item_type}_caption_format".to_sym],
-          @index.title(id))
-      end
-
-      def number(id)
-        sprintf(@locale["#{@index.item_type}_number_format".to_sym],
-          @index.number(id))
-      end
-
-      def method_missing(mid, *args, &block)
-        super unless @index.respond_to?(mid)
-        @index.__send__(mid, *args, &block)
-      end
-    end
-
     class BibpaperIndex < Index
       Item = Struct.new(:id, :number, :caption)
 


### PR DESCRIPTION
* add config option
* remove ReVIEW::Book::FormatRef class; this class seems to be never called