### PR TITLE
md2inaobuilderの追加とrubyのサポート

### DIFF
--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -5,11 +5,13 @@
 
 require 'review/builder'
 require 'review/textutils'
+require 'review/htmlutils'
 
 module ReVIEW
 
   class MARKDOWNBuilder < Builder
     include TextUtils
+    include HTMLUtils
 
     def extname
       '.md'
@@ -290,6 +292,15 @@ module ReVIEW
     def nofunc_text(str)
       str
     end
+
+    def compile_ruby(base, ruby)
+      if @book.htmlversion == 5
+        %Q[<ruby>#{escape_html(base)}<rp>#{I18n.t("ruby_prefix")}</rp><rt>#{escape_html(ruby)}</rt><rp>#{I18n.t("ruby_postfix")}</rp></ruby>]
+      else
+        %Q[<ruby><rb>#{escape_html(base)}</rb><rp>#{I18n.t("ruby_prefix")}</rp><rt>#{ruby}</rt><rp>#{I18n.t("ruby_postfix")}</rp></ruby>]
+      end
+    end
+
   end
 
 end # module ReVIEW

--- a/lib/review/md2inaobuilder.rb
+++ b/lib/review/md2inaobuilder.rb
@@ -3,7 +3,7 @@
 # You can distribute or modify this program under the terms of
 # the GNU LGPL, Lesser General Public License version 2.1.
 
-require 'review/builder'
+require 'review/markdownbuilder'
 
 module ReVIEW
 

--- a/lib/review/md2inaobuilder.rb
+++ b/lib/review/md2inaobuilder.rb
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'review/builder'
+
+module ReVIEW
+
+  class MD2INAOBuilder < MARKDOWNBuilder
+    def paragraph(lines)
+      puts "　" + lines.join
+      puts "\n"
+    end
+
+    def list_header(id, caption, lang)
+      lang ||= ""
+      puts "```#{lang}"
+      print %Q[●リスト#{@chapter.list(id).number}::#{compile_inline(caption)}\n\n]
+    end
+
+    def cmd(lines)
+      # WEB+DB では使っていないらしいけど
+      puts "!!! cmd"
+      lines.each do |line|
+        puts detab(line)
+      end
+      puts ""
+    end
+
+    def dl_begin
+      puts '<dl>'
+    end
+
+    def dt(line)
+      puts "<dt>#{line}</dt>"
+    end
+
+    def dd(lines)
+      puts "<dd>#{lines.join}</dd>"
+    end
+
+    def dl_end
+      puts '</dl>'
+    end
+
+    def comment(lines, comment = nil)
+      lines ||= []
+      lines.unshift comment unless comment.blank?
+      str = lines.join("\n")
+      puts '<span class="red">'
+      puts str
+      puts '</span>'
+    end
+  end
+
+end # module ReVIEW

--- a/lib/review/md2inaobuilder.rb
+++ b/lib/review/md2inaobuilder.rb
@@ -52,6 +52,15 @@ module ReVIEW
       puts str
       puts '</span>'
     end
+
+    def compile_ruby(base, ruby)
+      if base.length == 1
+        %Q[<span class='monoruby'>#{escape_html(base)}(#{escape_html(ruby)})</span>]
+      else
+        %Q[<span class='groupruby'>#{escape_html(base)}(#{escape_html(ruby)})</span>]
+      end
+    end
+
   end
 
 end # module ReVIEW

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -139,4 +139,10 @@ BBB
     actual = compile_block("//table{\ntestA\ttestB\n------------\ncontentA\tcontentB\n//}\n")
     assert_equal "|testA|testB|\n|:--|:--|\n|contentA|contentB|\n\n", actual
   end
+
+  def test_ruby
+    actual = compile_block("@<ruby>{謳,うた}い文句")
+    assert_equal "<ruby><rb>謳</rb><rp>（</rp><rt>うた</rt><rp>）</rp></ruby>い文句\n\n", actual
+  end
+
 end

--- a/test/test_md2inaobuilder.rb
+++ b/test/test_md2inaobuilder.rb
@@ -61,4 +61,15 @@ BBB
     actual = compile_block("//comment{\nHello, world!\n//}\n")
     assert_equal "<span class=\"red\">\nHello, world!\n</span>\n", actual
   end
+
+  def test_ruby_mono
+    actual = compile_block("@<ruby>{謳,うた}い文句")
+    assert_equal "　<span class='monoruby'>謳(うた)</span>い文句\n\n", actual
+  end
+
+  def test_ruby_group
+    actual = compile_block("@<ruby>{欠伸,あくび}が出る")
+    assert_equal "　<span class='groupruby'>欠伸(あくび)</span>が出る\n\n", actual
+  end
+
 end

--- a/test/test_md2inaobuilder.rb
+++ b/test/test_md2inaobuilder.rb
@@ -1,0 +1,64 @@
+# encoding: utf-8
+
+require 'test_helper'
+require 'review/compiler'
+require 'review/book'
+require 'review/md2inaobuilder'
+require 'review/i18n'
+
+class MD2INAOBuilderTest < Test::Unit::TestCase
+  include ReVIEW
+
+  def setup
+    @builder = MD2INAOBuilder.new()
+    @config = {
+      "secnolevel" => 2, # for IDGXMLBuilder, HTMLBuilder
+      "stylesheet" => nil, # for HTMLBuilder
+    }
+    @book = Book::Base.new(".")
+    @book.config = @config
+    @compiler = ReVIEW::Compiler.new(@builder)
+    @chapter = Book::Chapter.new(@book, 1, '-', nil, StringIO.new)
+    location = Location.new(nil, nil)
+    @builder.bind(@compiler, @chapter, location)
+    I18n.setup("ja")
+  end
+
+  def test_paragraph
+    actual = compile_block("Hello, world!")
+    assert_equal "　Hello, world!\n\n", actual
+  end
+
+  def test_cmd
+    actual = compile_block("//cmd{\nlineA\nlineB\n//}\n")
+    assert_equal "!!! cmd\nlineA\nlineB\n\n", actual
+  end
+
+  def test_dlist
+    actual = compile_block(": foo\n  foo.\n  bar.\n")
+    assert_equal "<dl>\n<dt>foo</dt>\n<dd>foo.bar.</dd>\n</dl>\n", actual
+  end
+
+  def test_list
+    actual = compile_block(<<-EOS)
+//list[name][caption]{
+AAA
+BBB
+//}
+    EOS
+
+    assert_equal <<-EOS, actual
+```
+●リスト1::caption
+
+AAA
+BBB
+```
+    EOS
+  end
+
+  def test_comment
+    actual = compile_block("//comment{\nHello, world!\n//}\n")
+    assert_equal "<span class=\"red\">\nHello, world!\n</span>\n", actual
+  end
+end


### PR DESCRIPTION
https://github.com/naoya/md2inao 用Markdown出力を行うビルダです。
技評さんのWEB+DB用原稿書きに使っていて、2回分くらい回してみて @murashitas さんからフォーマットについて注文が来なかったので多分よかろ！と思ってPRにしました。