### PR TITLE
support AI, EPS, and TIFF on pdfmaker correctly

### DIFF
--- a/lib/review/makerhelper.rb
+++ b/lib/review/makerhelper.rb
@@ -53,7 +53,7 @@ module ReVIEW
               image_files << "#{from_dir}/#{fname}.#{conv_type}"
             end
 
-            exts = options[:exts] || %w(png gif jpg jpeg svg pdf eps)
+            exts = options[:exts] || %w(png gif jpg jpeg svg pdf eps ai tif)
             exts_str = exts.join('|')
             if !is_converted && fname =~ /\.(#{exts_str})$/i
               FileUtils.cp "#{from_dir}/#{fname}", to_dir

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -228,7 +228,7 @@ module ReVIEW
         ReVIEW::MakerHelper.copy_images_to_dir(from, to)
         Dir.chdir(to) do
           images = Dir.glob("**/*").find_all{|f|
-            File.file?(f) and f =~ /\.(jpg|jpeg|png|pdf)\z/
+            File.file?(f) and f =~ /\.(jpg|jpeg|png|pdf|ai|eps|tif)\z/
           }
           break if images.empty?
           system("extractbb", *images)
@@ -395,7 +395,7 @@ module ReVIEW
         if ENV["REVIEW_SAFE_MODE"].to_i & 1 > 0
           warn "hook configuration is prohibited in safe mode. ignored."
         else
-          system_or_raise("#{hook} #{Dir.pwd} #{@basedir}")
+          system_or_raise("#{hook} #{Dir.pwd} #{@basehookdir}")
         end
       end
     end


### PR DESCRIPTION
.ai, .eps, .tifのファイルについてコピーなどがうまくできていなかったのを修正。
フックでbasehookdir（絶対パス）を渡すように修正。