### PR TITLE
LATEXBuilder: fix //source

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -305,7 +305,7 @@ module ReVIEW
 
     def common_code_block(id, lines, command, caption, lang)
       if caption
-        if command =~ /emlist/ || command =~ /cmd/
+        if command =~ /emlist/ || command =~ /cmd/ || command =~ /source/
           puts macro(command + 'caption', "#{compile_inline(caption)}")
         else
           begin
@@ -346,15 +346,11 @@ module ReVIEW
 
     def source(lines, caption, lang = nil)
       if highlight_listings?
-        common_code_block_lst(nil, lines, 'reviewlistlst', 'title', caption, lang)
+        common_code_block_lst(nil, lines, 'reviewsourcelst', 'title', caption, lang)
       else
-        puts '\begin{reviewlist}'
-        puts macro('reviewlistcaption', compile_inline(caption))
-        lines.each do |line|
-          puts detab(line)
+        common_code_block(nil, lines, 'reviewsource', caption, lang) do |line, idx|
+          detab(line) + "\n"
         end
-        puts '\end{reviewlist}'
-        puts ""
       end
     end
 

--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -79,6 +79,8 @@
 \lstnewenvironment{reviewemlistnumlst}[1][]{\lstset{numbers=left, #1}}{}
 \lstnewenvironment{reviewlistlst}[1][]{\lstset{#1}}{}
 \lstnewenvironment{reviewlistnumlst}[1][]{\lstset{numbers=left, #1}}{}
+\lstnewenvironment{reviewsourcelst}[1][]{\lstset{#1}}{}
+\lstnewenvironment{reviewsourcenumlst}[1][]{\lstset{numbers=left, #1}}{}
 \lstnewenvironment{reviewcmdlst}[1][]{\lstset{backgroundcolor=\color{white}, frameround=tttt, frame=trbl, #1}}{}
 <%- end -%>
 
@@ -99,6 +101,10 @@
   \end{alltt}\end{shaded}}
 
 \newenvironment{reviewlist}{%
+  \begin{shaded}\small\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
+  \end{alltt}\end{shaded}\par\vspace*{0.5zw}}
+
+\newenvironment{reviewsource}{%
   \begin{shaded}\small\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
   \end{alltt}\end{shaded}\par\vspace*{0.5zw}}
 
@@ -138,6 +144,9 @@
   \medskip{\small\noindent #1}\vspace*{-1.3zw}}
 
 \newcommand{\reviewemlistcaption}[1]{%
+  \medskip{\small\noindent #1}\vspace*{-1.3zw}}
+
+\newcommand{\reviewsourcecaption}[1]{%
   \medskip{\small\noindent #1}\vspace*{-1.3zw}}
 
 \newcommand{\reviewcmdcaption}[1]{%

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -64,6 +64,10 @@
   \begin{shaded}\small\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
   \end{alltt}\end{shaded}\par\vspace*{0.5zw}}
 
+\newenvironment{reviewsource}{%
+  \begin{shaded}\small\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
+  \end{alltt}\end{shaded}\par\vspace*{0.5zw}}
+
 \newenvironment{reviewcmd}{%
   \color{white}\medskip\small\begin{shadedb}\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
   \end{alltt}\end{shadedb}}
@@ -100,6 +104,9 @@
   \medskip{\small\noindent #1}\vspace*{-1.3zw}}
 
 \newcommand{\reviewemlistcaption}[1]{%
+  \medskip{\small\noindent #1}\vspace*{-1.3zw}}
+
+\newcommand{\reviewsourcecaption}[1]{%
   \medskip{\small\noindent #1}\vspace*{-1.3zw}}
 
 \newcommand{\reviewcmdcaption}[1]{%

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -320,14 +320,14 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def test_source
     actual = compile_block("//source[foo/bar/test.rb]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q|\\begin{reviewlist}\n\\reviewlistcaption{foo/bar/test.rb}\nfoo\nbar\n\nbuz\n\\end{reviewlist}\n\n|, actual
+    assert_equal %Q|\\reviewsourcecaption{foo/bar/test.rb}\n\\begin{reviewsource}\nfoo\nbar\n\nbuz\n\\end{reviewsource}\n|, actual
   end
 
   def test_source_lst
     @book.config["highlight"] = {}
     @book.config["highlight"]["latex"] = "listings"
     actual = compile_block("//source[foo/bar/test.rb]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q|\\begin{reviewlistlst}[title={foo/bar/test.rb},language={}]\nfoo\nbar\n\nbuz\n\\end{reviewlistlst}\n|, actual
+    assert_equal %Q|\\begin{reviewsourcelst}[title={foo/bar/test.rb},language={}]\nfoo\nbar\n\nbuz\n\\end{reviewsourcelst}\n|, actual
   end
 
   def test_quote


### PR DESCRIPTION
add new macro `reviewsource` and `reviewsourcecaption` for `//source` command.

cf. #651