### PR TITLE
allow free format in history of config.yml

### DIFF
--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -259,11 +259,14 @@ EOT
             revstr = ReVIEW::I18n.t("nth_impression", "#{rev+1}")
             if item =~ /\A\d+\-\d+\-\d+\Z/
               buf << %Q[      <p>#{ReVIEW::I18n.t("published_by1", [date_to_s(item), editstr+revstr])}</p>\n]
-            else
+            elsif item =~ /\A(\d+\-\d+\-\d+)[\s　](.+)/
               # custom date with string
               item.match(/\A(\d+\-\d+\-\d+)[\s　](.+)/) do |m|
                 buf << %Q[      <p>#{ReVIEW::I18n.t("published_by3", [date_to_s(m[1]), m[2]])}</p>\n]
               end
+            else
+              # free format
+              buf << %Q[      <p>#{item}</p>\n]
             end
           end
         end

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -311,11 +311,14 @@ module ReVIEW
             revstr = ReVIEW::I18n.t("nth_impression", "#{rev+1}")
             if item =~ /\A\d+\-\d+\-\d+\Z/
               buf << ReVIEW::I18n.t("published_by1", [date_to_s(item), editstr+revstr])
-            else
+            elsif item =~ /\A(\d+\-\d+\-\d+)[\s　](.+)/
               # custom date with string
               item.match(/\A(\d+\-\d+\-\d+)[\s　](.+)/) do |m|
                 buf << ReVIEW::I18n.t("published_by3", [date_to_s(m[1]), m[2]])
               end
+            else
+              # free format
+              buf << item
             end
           end
         end

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -662,6 +662,57 @@ EOT
     assert_equal expect, @output.string
   end
 
+  def test_colophon_history
+    @producer.params["aut"] = ["Mr.Smith"]
+    @producer.params["pbl"] = ["BLUEPRINT"]
+    @producer.params["pht"] = ["Mrs.Smith"]
+    @producer.merge_params({"language" => "ja"})
+    @producer.params["history"] = [[
+                                    "2011-08-03",
+                                    "2012-02-15",
+                                  ],[
+                                    "2012-10-01",
+                                  ],[
+                                    "2013-03-01",
+                                   ]]
+    epub = @producer.instance_eval{@epub}
+    result = epub.colophon_history
+    expect = <<-EOT
+    <div class=\"pubhistory\">
+      <p>2011年8月3日　初版第1刷　発行</p>
+      <p>2012年2月15日　初版第2刷　発行</p>
+      <p>2012年10月1日　第2版第1刷　発行</p>
+      <p>2013年3月1日　第3版第1刷　発行</p>
+    </div>
+    EOT
+    assert_equal expect, result
+  end
+
+  def test_colophon_history_freeformat
+    @producer.params["aut"] = ["Mr.Smith"]
+    @producer.params["pbl"] = ["BLUEPRINT"]
+    @producer.params["pht"] = ["Mrs.Smith"]
+    @producer.merge_params({"language" => "ja"})
+    @producer.params["history"] = [[
+                                    "2011年8月3日 ver 1.1.0発行",
+                                  ],[
+                                    "2011年10月12日 ver 1.2.0発行",
+                                  ],[
+                                    "2012年1月31日 ver 1.2.1発行",
+                                  ]]
+
+    epub = @producer.instance_eval{@epub}
+    result = epub.colophon_history
+    expect = <<-EOT
+    <div class=\"pubhistory\">
+      <p>2011年8月3日 ver 1.1.0発行</p>
+      <p>2011年10月12日 ver 1.2.0発行</p>
+      <p>2012年1月31日 ver 1.2.1発行</p>
+    </div>
+    EOT
+    assert_equal expect, result
+  end
+
   def test_colophon_pht
     @producer.params["aut"] = ["Mr.Smith"]
     @producer.params["pbl"] = ["BLUEPRINT"]

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -234,4 +234,22 @@ class PDFMakerTest < Test::Unit::TestCase
     assert_equal expect, history
   end
 
+  def test_colophon_history_freeformat
+    @config["aut"] = ["Mr.Smith"]
+    @config["pbl"] = ["BLUEPRINT"]
+    @config["pht"] = ["Mrs.Smith"]
+    @config.merge!({"language" => "ja",
+                    "history" => [[
+                                    "2011年8月3日 ver 1.1.0発行",
+                                  ],[
+                                    "2011年10月12日 ver 1.2.0発行",
+                                  ],[
+                                    "2012年1月31日 ver 1.2.1発行",
+                                  ]] })
+    history = @maker.make_history_list
+    expect = ["2011年8月3日 ver 1.1.0発行",
+              "2011年10月12日 ver 1.2.0発行",
+              "2012年1月31日 ver 1.2.1発行"]
+    assert_equal expect, history
+  end
 end


### PR DESCRIPTION
`@config["history"]` allowed `YYYY-MM-DD` and `YYYY-MM-DD some_comments`.
With this fix, when history does not match this pattern, use the value as is.