### PR TITLE
HTMLBuilder: chapterlinkがtrueのときに@<list>のハイパーリンクを有効にする

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -1008,10 +1008,16 @@ module ReVIEW
 
     def inline_list(id)
       chapter, id = extract_chapter_id(id)
+      str = nil
       if get_chap(chapter).nil?
-        %Q(<span class="listref">#{I18n.t("list")}#{I18n.t("format_number_without_header", [chapter.list(id).number])}</span>)
+        str = "#{I18n.t("list")}#{I18n.t("format_number_without_header", [chapter.list(id).number])}"
       else
-        %Q(<span class="listref">#{I18n.t("list")}#{I18n.t("format_number", [get_chap(chapter), chapter.list(id).number])}</span>)
+        str = "#{I18n.t("list")}#{I18n.t("format_number", [get_chap(chapter), chapter.list(id).number])}"
+      end
+      if @book.config["chapterlink"]
+        %Q(<span class="listref"><a href="./#{chapter.id}#{extname}##{id}">#{str}</a></span>)
+      else
+        %Q(<span class="listref">#{str}</span>)
       end
     rescue KeyError
       error "unknown list: #{id}"

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -524,6 +524,22 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|<p><span class="listref">リスト1.1</span></p>\n|, actual
   end
 
+  def test_inline_list_href
+    book = ReVIEW::Book::Base.load
+    book.config["chapterlink"] = true
+    book.catalog = ReVIEW::Catalog.new({"CHAPS"=>%w(ch1.re ch2.re)})
+    io1 = StringIO.new("//list[sampletest]{\nfoo\n//}\n")
+    io2 = StringIO.new("= BAR\n")
+    chap1 = ReVIEW::Book::Chapter.new(book, 1, 'ch1', 'ch1.re', io1)
+    chap2 = ReVIEW::Book::Chapter.new(book, 2, 'ch2', 'ch2.re', io2)
+    book.parts = [ReVIEW::Book::Part.new(self, nil, [chap1, chap2])]
+    builder = ReVIEW::HTMLBuilder.new
+    comp = ReVIEW::Compiler.new(builder)
+    builder.bind(comp, chap2, nil)
+    actual = builder.inline_list("ch1|sampletest")
+    assert_equal %Q|<span class="listref"><a href="./ch1.html#sampletest">リスト1.1</a></span>|, actual
+  end
+
   def test_list_pygments
     def @chapter.list(id)
       Book::ListIndex::Item.new("samplelist",1)


### PR DESCRIPTION
imgやtableに対してlistだけこの処理が抜けてた。