### PR TITLE
TOPBuilder: remove an unused method: messages()

### DIFF
--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -129,10 +129,6 @@ module ReVIEW
       $stderr.puts "#{@location.filename}:#{@location.lineno}: error: #{msg}"
     end
 
-    def messages
-      error_messages() + warning_messages()
-    end
-
     def headline(level, label, caption)
       prefix = ""
       blank


### PR DESCRIPTION
It seems that TOPBuilder never use this method (Furthermore, `error_messages()` and  `warning_messages()` are not defined in TOPBuilder... )