### PR TITLE
convertコマンドがなければtest_copy_images_to_dir_convertを飛ばす

### DIFF
--- a/test/test_makerhelper.rb
+++ b/test/test_makerhelper.rb
@@ -38,7 +38,7 @@ class MakerHelperTest < Test::Unit::TestCase
   end
 
   def test_copy_images_to_dir_convert
-    if /mswin|mingw|cygwin/ !~ RUBY_PLATFORM
+    if /mswin|mingw|cygwin/ !~ RUBY_PLATFORM && system("convert -version")
       touch_file("#{@tmpdir1}/foo.eps")
 
       image_files = MakerHelper.copy_images_to_dir(@tmpdir1, @tmpdir2,


### PR DESCRIPTION
ref #712

とりあえずconvertの有無で実行可否を考えるようにした。

pure RubyのためにはRMagick化したほうがいいけど、EPSを触るとなるとRMagickだけでなくGhostscriptも必要になるので厄介め。