### PR TITLE
ドラフトコメントのサポート

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -762,10 +762,7 @@ module ReVIEW
       lines.unshift comment unless comment.blank?
       if @book.config["draft"]
         str = lines.join("<br />")
-        puts %Q(<div class="draft-comment">#{str}</div>)
-      else
-        str = lines.join("\n")
-        puts %Q(<!-- #{escape_comment(str)} -->)
+        puts %Q(<div class="draft-comment">#{escape_html(str)}</div>)
       end
     end
 
@@ -1165,7 +1162,7 @@ module ReVIEW
       if @book.config["draft"]
         %Q(<span class="draft-comment">#{escape_html(str)}</span>)
       else
-        %Q(<!-- #{escape_comment(escape_html(str))} -->)
+        ""
       end
     end
 

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -630,8 +630,21 @@ module ReVIEW
       end
     end
 
-    def comment(str)
-      print %Q(<!-- [Comment] #{escape_html(str)} -->)
+    def comment(lines, comment = nil)
+      if @book.config["draft"]
+        lines ||= []
+        lines.unshift comment unless comment.blank?
+        str = lines.join("\n")
+        print "<msg>#{escape_html(str)}</msg>"
+      end
+    end
+
+    def inline_comment(str)
+      if @book.config["draft"]
+        %Q(<msg>#{escape_html(str)}</msg>)
+      else
+        ''
+      end
     end
 
     def footnote(id, str)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -644,7 +644,7 @@ module ReVIEW
       lines ||= []
       lines.unshift comment unless comment.blank?
       if @book.config["draft"]
-        str = lines.join("")
+        str = lines.join('\par ')
         puts macro('pdfcomment', escape(str))
       end
     end

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -301,6 +301,22 @@ module ReVIEW
       end
     end
 
+    def comment(lines, comment = nil)
+      if @book.config["draft"]
+        lines ||= []
+        lines.unshift comment unless comment.blank?
+        str = lines.join("<br />")
+        puts %Q(<div class="red">#{escape_html(str)}</div>)
+      end
+    end
+
+    def inline_comment(str)
+      if @book.config["draft"]
+        %Q(<span class="red">#{escape_html(str)}</span>)
+      else
+        ''
+      end
+    end
   end
 
 end # module ReVIEW

--- a/lib/review/md2inaobuilder.rb
+++ b/lib/review/md2inaobuilder.rb
@@ -44,15 +44,6 @@ module ReVIEW
       puts '</dl>'
     end
 
-    def comment(lines, comment = nil)
-      lines ||= []
-      lines.unshift comment unless comment.blank?
-      str = lines.join("\n")
-      puts '<span class="red">'
-      puts str
-      puts '</span>'
-    end
-
     def compile_ruby(base, ruby)
       if base.length == 1
         %Q[<span class='monoruby'>#{escape_html(base)}(#{escape_html(ruby)})</span>]

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -381,10 +381,12 @@ module ReVIEW
     end
 
     def comment(lines, comment = nil)
-      lines ||= []
-      lines.unshift comment unless comment.blank?
-      str = lines.join("")
-      puts "◆→DTP連絡:#{str}←◆"
+      if @book.config["draft"]
+        lines ||= []
+        lines.unshift comment unless comment.blank?
+        str = lines.join("")
+        puts "◆→#{str}←◆"
+      end
     end
 
     def footnote(id, str)
@@ -501,7 +503,7 @@ module ReVIEW
 
     def inline_comment(str)
       if @book.config["draft"]
-        %Q[◆→DTP連絡:#{str}←◆]
+        "◆→#{str}←◆"
       else
         ""
       end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1464,4 +1464,25 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_comment
+    actual = compile_block("//comment[コメント]")
+    assert_equal %Q||, actual
+  end
+
+  def test_comment_for_draft
+    @config["draft"] = true
+    actual = compile_block("//comment[コメント]")
+    assert_equal %Q|<div class="draft-comment">コメント</div>\n|, actual
+  end
+
+  def test_inline_comment
+    actual = compile_inline("test @<comment>{コメント} test2")
+    assert_equal %Q|test  test2|, actual
+  end
+
+  def test_inline_comment_for_draft
+    @config["draft"] = true
+    actual = compile_inline("test @<comment>{コメント} test2")
+    assert_equal %Q|test <span class="draft-comment">コメント</span> test2|, actual
+  end
 end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -676,4 +676,25 @@ EOS
     assert_equal expected.chomp, actual
   end
 
+  def test_comment
+    actual = compile_block("//comment[コメント]")
+    assert_equal %Q||, actual
+  end
+
+  def test_comment_for_draft
+    @config["draft"] = true
+    actual = compile_block("//comment[コメント]")
+    assert_equal %Q|<msg>コメント</msg>|, actual
+  end
+
+  def test_inline_comment
+    actual = compile_inline("test @<comment>{コメント} test2")
+    assert_equal %Q|test  test2|, actual
+  end
+
+  def test_inline_comment_for_draft
+    @config["draft"] = true
+    actual = compile_inline("test @<comment>{コメント} test2")
+    assert_equal %Q|test <msg>コメント</msg> test2|, actual
+  end
 end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -873,4 +873,25 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_comment
+    actual = compile_block("//comment[コメント]")
+    assert_equal %Q||, actual
+  end
+
+  def test_comment_for_draft
+    @config["draft"] = true
+    actual = compile_block("//comment[コメント]")
+    assert_equal %Q|\\pdfcomment{コメント}\n|, actual
+  end
+
+  def test_inline_comment
+    actual = compile_inline("test @<comment>{コメント} test2")
+    assert_equal %Q|test  test2|, actual
+  end
+
+  def test_inline_comment_for_draft
+    @config["draft"] = true
+    actual = compile_inline("test @<comment>{コメント} test2")
+    assert_equal %Q|test \\pdfcomment{コメント} test2|, actual
+  end
 end

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -46,6 +46,17 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_inline_comment
+    actual = compile_inline("test @<comment>{コメント} test2")
+    assert_equal %Q|test  test2|, actual
+  end
+
+  def test_inline_comment_for_draft
+    @config["draft"] = true
+    actual = compile_inline("test @<comment>{コメント} test2")
+    assert_equal %Q|test <span class="red">コメント</span> test2|, actual
+  end
+
   def test_ul_nest1
     src =<<-EOS
   * AAA
@@ -62,7 +73,6 @@ EOS
     assert_equal "```shell-session\nlineA\nlineB\n```\n", actual
   end
 
-
   def test_dlist
     actual = compile_block(": foo\n  foo.\n  bar.\n")
     assert_equal %Q|<dl>\n<dt>foo</dt>\n<dd>foo.bar.</dd>\n</dl>\n|, actual
@@ -77,6 +87,17 @@ EOS
     source = ": title\n  body\n\#@ comment\n\#@ comment\n: title2\n  body2\n"
     actual = compile_block(source)
     assert_equal %Q|<dl>\n<dt>title</dt>\n<dd>body</dd>\n<dt>title2</dt>\n<dd>body2</dd>\n</dl>\n|, actual
+  end
+
+  def test_comment
+    actual = compile_block("//comment[コメント]")
+    assert_equal %Q||, actual
+  end
+
+  def test_comment_for_draft
+    @config["draft"] = true
+    actual = compile_block("//comment[コメント]")
+    assert_equal %Q|<div class="red">コメント</div>\n|, actual
   end
 
   def test_list

--- a/test/test_md2inaobuilder.rb
+++ b/test/test_md2inaobuilder.rb
@@ -57,11 +57,6 @@ BBB
     EOS
   end
 
-  def test_comment
-    actual = compile_block("//comment{\nHello, world!\n//}\n")
-    assert_equal "<span class=\"red\">\nHello, world!\n</span>\n", actual
-  end
-
   def test_ruby_mono
     actual = compile_block("@<ruby>{謳,うた}い文句")
     assert_equal "　<span class='monoruby'>謳(うた)</span>い文句\n\n", actual

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -142,7 +142,7 @@ class TOPBuidlerTest < Test::Unit::TestCase
   def test_inline_comment_for_draft
     @config["draft"] = true
     actual = compile_inline("test @<comment>{コメント} test2")
-    assert_equal %Q|test ◆→DTP連絡:コメント←◆ test2|, actual
+    assert_equal %Q|test ◆→コメント←◆ test2|, actual
   end
 
   def test_inline_in_table
@@ -168,6 +168,17 @@ class TOPBuidlerTest < Test::Unit::TestCase
   def test_noindent
     actual = compile_block("//noindent\nfoo\nbar\n\nfoo2\nbar2\n")
     assert_equal %Q|◆→DTP連絡:次の1行インデントなし←◆\nfoobar\nfoo2bar2\n|, actual
+  end
+
+  def test_comment
+    actual = compile_block("//comment[コメント]")
+    assert_equal %Q||, actual
+  end
+
+  def test_comment_for_draft
+    @config["draft"] = true
+    actual = compile_block("//comment[コメント]")
+    assert_equal %Q|◆→コメント←◆\n|, actual
   end
 
   def test_list


### PR DESCRIPTION
cf #360 
どのビルダでも、
- --draft有効時にcommentタグの内容を表現する。
- 無効時に無視する。
