### PR TITLE
//tsizeでビルダ指定できるようにする

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -46,6 +46,7 @@ module ReVIEW
       @output = StringIO.new
       @book = @chapter.book if @chapter.present?
       @tabwidth = nil
+      @tsize = nil
       if @book && @book.config && @book.config["tabwidth"]
         @tabwidth = @book.config["tabwidth"]
       end
@@ -448,6 +449,18 @@ module ReVIEW
     end
 
     def ul_item_end
+    end
+
+    def tsize(str)
+      if matched = str.match(/\A\|(.*?)\|(.*)/)
+        builders = matched[1].split(/,/).map{|i| i.gsub(/\s/, '') }
+        c = self.class.to_s.gsub(/ReVIEW::/, '').gsub(/Builder/, '').downcase
+        if builders.include?(c)
+          @tsize = matched[2]
+        end
+      else
+        @tsize = str
+      end
     end
 
     def inline_raw(args)

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -278,10 +278,6 @@ module ReVIEW
       puts '</div>'
     end
 
-    def tsize(str)
-      # null
-    end
-
     def captionblock(type, lines, caption)
       puts %Q[<div class="#{type}">]
       unless caption.nil?

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -1048,10 +1048,6 @@ module ReVIEW
       print "<label id='#{id}' />"
     end
 
-    def tsize(str)
-      @tsize = str
-    end
-
     def dtp(str)
       print %Q(<?dtp #{str} ?>)
     end

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -517,8 +517,12 @@ module ReVIEW
       if @latex_tsize
         puts macro('begin', 'reviewtable', @latex_tsize)
       elsif @tsize
-        cellwidth = @tsize.split(/\s*,\s*/)
-        puts macro('begin', 'reviewtable', '|'+cellwidth.collect{|i| "p{#{i}mm}"}.join('|')+'|')
+        if @tsize =~ /\A[\d., ]+\Z/
+          cellwidth = @tsize.split(/\s*,\s*/)
+          puts macro('begin', 'reviewtable', '|'+cellwidth.collect{|i| "p{#{i}mm}"}.join('|')+'|')
+        else
+          puts macro('begin', 'reviewtable', @tsize)
+        end
       else
         puts macro('begin', 'reviewtable', (['|'] * (ncols + 1)).join('l'))
       end
@@ -931,10 +935,6 @@ module ReVIEW
       else
         macro("ref", url)
       end
-    end
-
-    def tsize(str)
-      @tsize = str
     end
 
     def latextsize(str)

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -712,11 +712,6 @@ module ReVIEW
       ""
     end
 
-    def tsize(id)
-      # FIXME
-      ""
-    end
-
     def dtp(str)
       # FIXME
     end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -114,6 +114,15 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
 
     actual = compile_block("//tsize[2]\n//table{\nA\tB\tC\n//}\n")
     assert_equal %Q|<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="3"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">A</td><td xyh="2,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="11.338">B</td><td xyh="3,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="11.338">C</td></tbody></table>|, actual
+
+    actual = compile_block("//tsize[|idgxml|2]\n//table{\nA\tB\tC\n//}\n")
+    assert_equal %Q|<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="3"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">A</td><td xyh="2,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="11.338">B</td><td xyh="3,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="11.338">C</td></tbody></table>|, actual
+
+    actual = compile_block("//tsize[|idgxml,html|2]\n//table{\nA\tB\tC\n//}\n")
+    assert_equal %Q|<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="3"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">A</td><td xyh="2,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="11.338">B</td><td xyh="3,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="11.338">C</td></tbody></table>|, actual
+
+    actual = compile_block("//tsize[|html|2]\n//table{\nA\tB\tC\n//}\n")
+    assert_equal %Q|<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="3"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">A</td><td xyh="2,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">B</td><td xyh="3,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">C</td></tbody></table>|, actual
   end
 
   def test_customize_mmtopt

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -499,6 +499,23 @@ class LATEXBuidlerTest < Test::Unit::TestCase
                  actual
   end
 
+  def test_customize_cellwidth
+    actual = compile_block("//tsize[2,3,5]\n//table{\nA\tB\tC\n//}\n")
+    assert_equal %Q(\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+
+    actual = compile_block("//tsize[|latex,html|2,3,5]\n//table{\nA\tB\tC\n//}\n")
+    assert_equal %Q(\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+
+    actual = compile_block("//tsize[|html|2,3,5]\n//table{\nA\tB\tC\n//}\n")
+    assert_equal %Q(\\begin{reviewtable}{|l|l|l|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+
+    actual = compile_block("//tsize[|latex|2,3,5]\n//table{\nA\tB\tC\n//}\n")
+    assert_equal %Q(\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+
+    actual = compile_block("//tsize[|latex||p{5mm}|cr|]\n//table{\nA\tB\tC\n//}\n")
+    assert_equal %Q(\\begin{reviewtable}{|p{5mm}|cr|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+  end
+
   def test_imgtable
     def @chapter.image(id)
       item = Book::ImageIndex::Item.new("sampleimg",1, 'sample img')


### PR DESCRIPTION
```
//tsize[2,3,5]
//tsize[|idgxml|2,3,5]
//tsize[|latex,idgxml|2,3,5]
//tsize[|latex||p{5mm}|cr|]
```

こんな感じで。既存成果物には影響ないはず。