### PR TITLE
remove ul_item() of html, idgxml, and markdown.

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -354,10 +354,6 @@ module ReVIEW
       puts '<ul>'
     end
 
-    def ul_item(lines)
-      puts "<li>#{lines.join}</li>"
-    end
-
     def ul_item_begin(lines)
       print "<li>#{lines.join}"
     end

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -213,10 +213,6 @@ module ReVIEW
       puts "<ul#{level == 1 ? nil : level}>"
     end
 
-    def ul_item(lines)
-      puts %Q(<li aid:pstyle="ul-item">#{lines.join.chomp}</li>)
-    end
-
     def ul_item_begin(lines)
       print %Q(<li aid:pstyle="ul-item">#{lines.join.chomp})
     end

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -74,10 +74,6 @@ module ReVIEW
       @ul_indent += 1
     end
 
-    def ul_item(lines)
-      puts "  " * (@ul_indent - 1) + "* " + "#{lines.join}"
-    end
-
     def ul_item_begin(lines)
       puts "  " * (@ul_indent - 1) + "* " + "#{lines.join}"
     end


### PR DESCRIPTION
呼び出されることのないul_itemを削除