### PR TITLE
image_finder.rb: support symlinked directory

### DIFF
--- a/lib/review/book/image_finder.rb
+++ b/lib/review/book/image_finder.rb
@@ -22,7 +22,7 @@ module ReVIEW
       end
 
       def get_entries
-        Dir.glob(File.join(@basedir, "**/*.*"))
+        Dir.glob(File.join(@basedir, "**{,/*/**}/*.*")).uniq
       end
 
       def add_entry(path)

--- a/test/test_image_finder.rb
+++ b/test/test_image_finder.rb
@@ -79,4 +79,22 @@ class ImageFinderTest < Test::Unit::TestCase
       FileUtils.remove_entry_secure dir
     end
   end
+
+  def test_find_path_dir_symlink
+    dir = Dir.mktmpdir
+    begin
+      path_src = dir+"/src"
+      path_dst = dir+"/ch01"
+      FileUtils.mkdir_p(path_src)
+      FileUtils.symlink(path_src, path_dst)
+      path_srcimg = path_src+"/foo.jpg"
+      path_dstimg = path_dst+"/foo.jpg"
+      FileUtils.touch(path_srcimg)
+
+      finder = ReVIEW::Book::ImageFinder.new(dir, "ch01", "builder", [".jpg"])
+      assert_equal(path_dstimg, finder.find_path("foo"))
+    ensure
+      FileUtils.remove_entry_secure dir
+    end
+  end
 end


### PR DESCRIPTION
imagesディレクトリの下のディレクトリとしてシンボリックリンクを使えるようにするためのパッチです。

image_finder.rbの`Dir.glob(File.join(@basedir, "**/*.*"))`は、ファイルのシンボリックリンクは辿ってくれるようですが、ディレクトリについては辿ってくれないようです。

以下のURLによると、`Dir.glob("**{,/*/**}/*.*")`で解決しそうだったので、コードを変更しテストを追加しました。
http://stackoverflow.com/questions/357754/can-i-traverse-symlinked-directories-in-ruby-with-a-glob