### PR TITLE
add `//embed{...//}` and `@<embed>{...}`

### DIFF
--- a/doc/format.md
+++ b/doc/format.md
@@ -688,7 +688,9 @@ Usage:
 
 ## Raw Data Block
 
-When you want to write non-Re:VIEW line, use `//raw`.
+When you want to write non-Re:VIEW line, use `//raw` or `//embed`.
+
+### `//raw` block
 
 Usage:
 
@@ -714,6 +716,39 @@ this is a special line.
 (In other formats, it is just ignored.)
 
 Note: `//raw` and `@<raw>` may break structured document easily.
+
+### `//embed` block
+
+Usage:
+
+```
+//embed{
+<div class="special">
+this is a special line.
+</div>
+//}
+
+//embed[html,markdown]{
+<div class="special">
+this is a special line.
+</div>
+//}
+```
+
+In above line, `html` and `markdown` is a builder name that handle raw data.
+
+Output:
+
+(In HTML:)
+
+```
+<div class="special">
+this is a special line.
+</div>
+```
+
+(In other formats, it is just ignored.)
+
 
 ## Inline Commands
 

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -344,6 +344,20 @@ module ReVIEW
       end
     end
 
+    def embed(lines, arg = nil)
+      if arg
+        builders = arg.gsub(/^\s*\|/, "").gsub(/\|\s*$/, "").gsub(/\s/, "").split(/,/)
+        c = target_name
+        if builders.include?(c)
+          print lines.join()
+        else
+          ""
+        end
+      else
+        print lines.join()
+      end
+    end
+
     def warn(msg)
       $stderr.puts "#{@location}: warning: #{msg}"
     end
@@ -475,6 +489,19 @@ module ReVIEW
         end
       else
         args.gsub("\\n", "\n")
+      end
+    end
+
+    def inline_embed(args)
+      if matched = args.match(/\|(.*?)\|(.*)/)
+        builders = matched[1].split(/,/).map{|i| i.gsub(/\s/, '') }
+        if builders.include?(target_name)
+          matched[2]
+        else
+          ""
+        end
+      else
+        args
       end
     end
 

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1358,18 +1358,23 @@ EOS
   def test_inline_embed_n1
     assert_equal '\\n', compile_inline('@<embed>{\\n}')
   end
+
   def test_inline_embed_n2
     assert_equal '\\n', compile_inline('@<embed>{\\\\n}')
   end
+
   def test_inline_embed_brace_right0
     assert_equal '}', compile_inline('@<embed>{\\}}')
   end
+
   def test_inline_embed_brace_right1
     assert_equal '\\}', compile_inline('@<embed>{\\\\}}')
   end
+
   def test_inline_embed_brace_right2
     assert_equal '\\}', compile_inline('@<embed>{\\\\\\}}')
   end
+
   def test_inline_embed_brace_right3
     assert_equal '\\\\}', compile_inline('@<embed>{\\\\\\\\}}')
   end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1322,6 +1322,58 @@ EOS
     assert_equal "nor\nmal", compile_inline("@<raw>{|html|nor\\nmal}")
   end
 
+  def test_inline_embed0
+    assert_equal "normal", compile_inline("@<embed>{normal}")
+  end
+
+  def test_inline_embed1
+    assert_equal "body", compile_inline("@<embed>{|html|body}")
+  end
+
+  def test_inline_embed3
+    assert_equal "", compile_inline("@<embed>{|idgxml, latex|body}")
+  end
+
+  def test_inline_embed5
+    assert_equal 'nor\\nmal', compile_inline("@<embed>{|html|nor\\nmal}")
+  end
+
+  def test_inline_embed_math1
+    assert_equal '\[ \frac{\partial f}{\partial x} =x^2+xy \]', compile_inline('@<embed>{\[ \frac{\partial f\}{\partial x\} =x^2+xy \]}')
+  end
+
+  def test_inline_embed_math1a
+    assert_equal '\[ \frac{\partial f}{\partial x} =x^2+xy \]', compile_inline('@<embed>{\\[ \\frac{\\partial f\}{\\partial x\} =x^2+xy \\]}')
+  end
+
+  def test_inline_embed_math1b
+    assert_equal '\[ \frac{\partial f}{\partial x} =x^2+xy \]', compile_inline('@<embed>{\\\\[ \\\\frac{\\\\partial f\}{\\\\partial x\} =x^2+xy \\\\]}')
+  end
+
+  def test_inline_embed_math1c
+    assert_equal '\\[ \\frac{}{} \\]',
+                 compile_inline('@<embed>{\[ \\frac{\}{\} \\]}')
+  end
+
+  def test_inline_embed_n1
+    assert_equal '\\n', compile_inline('@<embed>{\\n}')
+  end
+  def test_inline_embed_n2
+    assert_equal '\\n', compile_inline('@<embed>{\\\\n}')
+  end
+  def test_inline_embed_brace_right0
+    assert_equal '}', compile_inline('@<embed>{\\}}')
+  end
+  def test_inline_embed_brace_right1
+    assert_equal '\\}', compile_inline('@<embed>{\\\\}}')
+  end
+  def test_inline_embed_brace_right2
+    assert_equal '\\}', compile_inline('@<embed>{\\\\\\}}')
+  end
+  def test_inline_embed_brace_right3
+    assert_equal '\\\\}', compile_inline('@<embed>{\\\\\\\\}}')
+  end
+
   def test_block_raw0
     actual = compile_block("//raw[<>!\"\\n& ]\n")
     expected = %Q(<>!\"\n& )
@@ -1349,6 +1401,48 @@ EOS
   def test_block_raw4
     actual = compile_block("//raw[|html <>!\"\\n& ]\n")
     expected = %Q(|html <>!\"\n& )
+    assert_equal expected, actual
+  end
+
+  def test_embed0
+    lines = '//embed{' + "\n" +
+            ' <>!\\"\\\\n& ' + "\n" +
+            '//}' + "\n"
+    actual = compile_block(lines)
+    expected = ' <>!\\"\\\\n& ' + "\n"
+    assert_equal expected, actual
+  end
+
+  def test_embed1
+    actual = compile_block("//embed[|html|]{\n" +
+                           "<>!\\\"\\\\n& \n" +
+                           "//}\n")
+    expected = %Q(<>!\\\"\\\\n& \n)
+    assert_equal expected, actual
+  end
+
+  def test_embed2
+    actual = compile_block("//embed[html, latex]{\n" +
+                           "<>!\\\"\\\\n& \n" +
+                           "//}\n")
+    expected = %Q(<>!\\\"\\\\n& \n)
+    assert_equal expected, actual
+  end
+
+  def test_embed2a
+    actual = compile_block("//embed[|html, latex|]{\n" +
+                           "<>!\\\"\\\\n& \n" +
+                           "//}\n")
+    expected = %Q(<>!\\\"\\\\n& \n)
+    assert_equal expected, actual
+  end
+
+  def test_embed2b
+    actual = compile_block("//embed[html, latex]{\n" +
+                           '#@# comments are not ignored in //embed block' + "\n" +
+                           "<>!\\\"\\\\n& \n" +
+                           "//}\n")
+    expected = '#@# comments are not ignored in //embed block' + "\n" + %Q(<>!\\\"\\\\n& \n)
     assert_equal expected, actual
   end
 


### PR DESCRIPTION
cf. #730 

試しに`//embed{...//}`と`@<embed>{...}`を実装しました。
`//embed{...//}`はあらゆるエスケープを無視してそのまま埋め込みます。ついでに`#@...`形式のコメントも無視せずそのまま埋め込みます。
`//}`の行はどうやっても埋め込めません（エスケープルールがないので）が、それは仕様ということにしておいた方が良さそう。先頭を空白にした` //}`なら埋め込めます。

`@<embed>{...}`はそのインライン版ですが、こちらはエスケープルールがあります。
* `}`は`\}`と書く
* `\`は`\\`と書く
* それ以外の文字はそのまま書く

というルールで任意の文字を埋め込めるはずです。