### PR TITLE
fix imagedir handling

### DIFF
--- a/lib/review/book/compilable.rb
+++ b/lib/review/book/compilable.rb
@@ -2,7 +2,7 @@
 # $Id: book.rb 4315 2009-09-02 04:15:24Z kmuto $
 #
 # Copyright (c) 2002-2008 Minero Aoki
-#               2009 Minero Aoki, Kenshi Muto
+#               2009-2017 Minero Aoki, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -118,20 +118,20 @@ module ReVIEW
       def numberless_image_index
         @numberless_image_index ||=
           NumberlessImageIndex.parse(lines(), id(),
-                                     "#{book.basedir}/#{@book.image_dir}",
+                                     "#{book.basedir}/#{@book.config['imagedir']}",
                                      @book.image_types, @book.config['builder'])
       end
 
       def image_index
         @image_index ||= ImageIndex.parse(lines(), id(),
-                                          "#{book.basedir}/#{@book.image_dir}",
+                                          "#{book.basedir}/#{@book.config['imagedir']}",
                                           @book.image_types, @book.config['builder'])
         @image_index
       end
 
       def icon_index
         @icon_index ||= IconIndex.parse(lines(), id(),
-                                        "#{book.basedir}/#{@book.image_dir}",
+                                        "#{book.basedir}/#{@book.config['imagedir']}",
                                         @book.image_types, @book.config['builder'])
         @icon_index
       end
@@ -139,7 +139,7 @@ module ReVIEW
       def indepimage_index
         @indepimage_index ||=
           IndepImageIndex.parse(lines(), id(),
-                                "#{book.basedir}/#{@book.image_dir}",
+                                "#{book.basedir}/#{@book.config['imagedir']}",
                                 @book.image_types, @book.config['builder'])
       end
 

--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -1,7 +1,7 @@
 # encoding: utf-8
 #
 # Copyright (c) 2002-2007 Minero Aoki
-#               2008-2009 Minero Aoki, Kenshi Muto
+#               2008-2017 Minero Aoki, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -104,16 +104,16 @@ module ReVIEW
           verify_target_images(basetmpdir)
           copy_images(@params["imagedir"], basetmpdir)
         else
-          copy_images(@params["imagedir"], "#{basetmpdir}/images")
+          copy_images(@params["imagedir"], "#{basetmpdir}/#{@params["imagedir"]}")
         end
 
-        copy_resources("covers", "#{basetmpdir}/images")
-        copy_resources("adv", "#{basetmpdir}/images")
+        copy_resources("covers", "#{basetmpdir}/#{@params["imagedir"]}")
+        copy_resources("adv", "#{basetmpdir}/#{@params["imagedir"]}")
         copy_resources(@params["fontdir"], "#{basetmpdir}/fonts", @params["font_ext"])
 
         call_hook("hook_aftercopyimage", basetmpdir)
 
-        @producer.import_imageinfo("#{basetmpdir}/images", basetmpdir)
+        @producer.import_imageinfo("#{basetmpdir}/#{@params["imagedir"]}", basetmpdir)
         @producer.import_imageinfo("#{basetmpdir}/fonts", basetmpdir, @params["font_ext"])
 
         epubtmpdir = nil

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 #
-# Copyright (c) 2010-2016 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2017 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -232,7 +232,7 @@ module ReVIEW
           @config["usepackage"] = "\\usepackage{#{@config['texstyle']}}"
         end
 
-        copy_images(@config["imagedir"], File.join(@path, "images"))
+        copy_images(@config["imagedir"], File.join(@path, @config["imagedir"]))
         copyStyToDir(File.join(Dir.pwd, "sty"), @path)
         copyStyToDir(File.join(Dir.pwd, "sty"), @path, "fd")
         copyStyToDir(File.join(Dir.pwd, "sty"), @path, "cls")

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -93,10 +93,10 @@ module ReVIEW
       build_body(@path, yamlfile)
       copy_backmatter(@path)
 
-      copy_images(@config["imagedir"], "#{@path}/images")
+      copy_images(@config["imagedir"], "#{@path}/#{@config["imagedir"]}")
 
-      copy_resources("covers", "#{@path}/images")
-      copy_resources("adv", "#{@path}/images")
+      copy_resources("covers", "#{@path}/#{@config["imagedir"]}")
+      copy_resources("adv", "#{@path}/#{@config["imagedir"]}")
       copy_resources(@config["fontdir"], "#{@path}/fonts", @config["font_ext"])
     end
 
@@ -231,7 +231,7 @@ module ReVIEW
     def build_indexpage(basetmpdir)
       File.open("#{basetmpdir}/index.html", "w") do |f|
         if @config["coverimage"]
-          file = File.join("images", @config["coverimage"])
+          file = File.join(@config["imagedir"], @config["coverimage"])
           @body = <<-EOT
   <div id="cover-image" class="cover-image">
     <img src="#{file}" class="max"/>

--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -261,7 +261,7 @@
 \begin{titlepage}
 <%-     if @config["coverimage"] -%>
   \begin{center}
-    \includegraphics[<%= @coverimageoption%>]{./images/<%= @config["coverimage"] %>}
+    \includegraphics[<%= @coverimageoption%>]{./<%= @config["imagedir"] %>/<%= @config["coverimage"] %>}
   \end{center}
   \clearpage
 <%-     end -%>


### PR DESCRIPTION
#453 の修正を試みます。
手元のテストではimagedirの変更あり/なし、debugのあり/なし、EPUBMaker・PDFMaker・WebMakerで動作を確認。

なお、
- imagedirは作業フォルダ直下のフォルダであり、空白を含まない普通のファイル名規則に則っているものと前提する(これは今のimagesと同じなのでさほど問題ないはず)。
- EPUB、Web、PDF等の変換の際には、これまでのように「images」という名前に変更されることなく、imagedirで指定のフォルダ名がそのまま使われる。

テストケースを書きづらい…
