### PR TITLE
Specify source file encoding on generating config.

### DIFF
--- a/bin/review-init
+++ b/bin/review-init
@@ -112,7 +112,7 @@ end
 
 def generate_config(dir)
   today = Time.now.strftime("%Y-%m-%d")
-  content = File.read(@review_dir + "/doc/config.yml.sample")
+  content = File.read(@review_dir + "/doc/config.yml.sample", {:encoding => 'utf-8'})
   content.gsub!(/^#\s*coverimage:.*$/, 'coverimage: cover.jpg')
   content.gsub!(/^#\s*date:.*$/, "date: #{today}")
   content.gsub!(/^#\s*history:.*$/, %Q|history: [["#{today}"]]|)


### PR DESCRIPTION
Windows環境でreview-initを実行する際，config.yml.sampleの読み込みでエンコーディングエラーにならないよう，読み込みファイルのエンコーディングを'utf-8'として指定する。