### PR TITLE
LaTeXにおいてAPPENDIX内でlist, table, imageを使ったときに1-1のようになることの修正

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -2,7 +2,7 @@
 #
 # Copyright (c) 2002-2007 Minero Aoki
 #               2008-2009 Minero Aoki, Kenshi Muto
-#               2010-2016  Minero Aoki, Kenshi Muto, TAKAHASHI Masayoshi
+#               2010-2017 Minero Aoki, Kenshi Muto, TAKAHASHI Masayoshi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -339,7 +339,11 @@ module ReVIEW
           puts macro(command + 'caption', "#{compile_inline(caption)}")
         else
           begin
-            puts macro('reviewlistcaption', "#{I18n.t("list")}#{I18n.t("format_number_header", [@chapter.number, @chapter.list(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}")
+            if get_chap.nil?
+              puts macro('reviewlistcaption', "#{I18n.t("list")}#{I18n.t("format_number_header_without_chapter", [@chapter.list(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}")
+            else
+              puts macro('reviewlistcaption', "#{I18n.t("list")}#{I18n.t("format_number_header", [get_chap, @chapter.list(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}")
+            end
           rescue KeyError
             error "no such list: #{id}"
           end
@@ -739,17 +743,29 @@ module ReVIEW
     # FIXME: use TeX native label/ref.
     def inline_list(id)
       chapter, id = extract_chapter_id(id)
-      macro('reviewlistref', "#{chapter.number}.#{chapter.list(id).number}")
+      if get_chap(chapter).nil?
+        macro('reviewlistref', I18n.t("format_number_without_header", [chapter.list(id).number]))
+      else
+        macro('reviewlistref', I18n.t("format_number", [get_chap(chapter), chapter.list(id).number]))
+      end
     end
 
     def inline_table(id)
       chapter, id = extract_chapter_id(id)
-      macro('reviewtableref', "#{chapter.number}.#{chapter.table(id).number}", table_label(id, chapter))
+      if get_chap(chapter).nil?
+        macro('reviewtableref', I18n.t("format_number_without_header", [chapter.table(id).number]), table_label(id, chapter))
+      else
+        macro('reviewtableref', I18n.t("format_number", [get_chap(chapter), chapter.table(id).number]), table_label(id, chapter))
+      end
     end
 
     def inline_img(id)
       chapter, id = extract_chapter_id(id)
-      macro('reviewimageref', "#{chapter.number}.#{chapter.image(id).number}", image_label(id, chapter))
+      if get_chap(chapter).nil?
+        macro('reviewimageref', I18n.t("format_number_without_header", [chapter.image(id).number]), image_label(id, chapter))
+      else
+        macro('reviewimageref', I18n.t("format_number", [get_chap(chapter), chapter.image(id).number]), image_label(id, chapter))
+      end
     end
 
     def footnote(id, content)

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -937,4 +937,89 @@ EOS
     actual = compile_inline("test @<comment>{コメント} test2")
     assert_equal %Q|test \\pdfcomment{コメント} test2|, actual
   end
+
+  def test_appendix_list
+    @chapter.instance_eval do
+      def on_APPENDIX?
+        true
+      end
+    end
+    src =<<-EOS
+@<list>{foo}
+//list[foo][FOO]{
+//}
+EOS
+    expected =<<-EOS
+
+\\reviewlistref{A.1}
+
+\\reviewlistcaption{リストA.1: FOO}
+\\begin{reviewlist}
+\\end{reviewlist}
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+  end
+
+  def test_appendix_table
+    @chapter.instance_eval do
+      def on_APPENDIX?
+        true
+      end
+    end
+    src =<<-EOS
+@<table>{foo}
+//table[foo][FOO]{
+A	B
+//}
+EOS
+    expected =<<-EOS
+
+\\reviewtableref{A.1}{table:chap1:foo}
+
+\\begin{table}[h]
+\\reviewtablecaption{FOO}
+\\label{table:chap1:foo}
+\\begin{reviewtable}{|l|l|}
+\\hline
+\\reviewth{A} & B \\\\  \\hline
+\\end{reviewtable}
+\\end{table}
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+  end
+
+  def test_appendix_image
+    @chapter.instance_eval do
+      def on_APPENDIX?
+        true
+      end
+    end
+
+    def @chapter.image(id)
+      item = Book::NumberlessImageIndex::Item.new("sampleimg", 1)
+      item.instance_eval{@path="./images/chap1-sampleimg.png"}
+      item
+    end
+
+    src =<<-EOS
+@<img>{sampleimg}
+//image[sampleimg][FOO]{
+//}
+EOS
+    expected =<<-EOS
+
+\\reviewimageref{A.1}{image:chap1:sampleimg}
+
+\\begin{reviewimage}
+\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\caption{FOO}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+  end
+
 end


### PR DESCRIPTION
get_chapでフォーマット済みのものを使うようにする。
テストコードを書いたらマージしたいと思います。
