### PR TITLE
//emtableの導入

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -183,6 +183,10 @@ module ReVIEW
     end
     private :adjust_n_cols
 
+    def emtable(lines, caption = nil)
+      table(lines, nil, caption)
+    end
+
     #def footnote(id, str)
     #  @footnotes.push [id, str]
     #end

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -135,6 +135,7 @@ module ReVIEW
     defblock :cmd, 0..1
     defblock :table, 0..2
     defblock :imgtable, 0..2
+    defblock :emtable, 0..1
     defblock :quote, 0
     defblock :image, 2..3, true
     defblock :source, 0..2

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -676,10 +676,14 @@ module ReVIEW
     end
 
     def table_header(id, caption)
-      if get_chap.nil?
-        puts %Q[<p class="caption">#{I18n.t("table")}#{I18n.t("format_number_header_without_chapter", [@chapter.table(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}</p>]
+      if id.nil?
+        puts %Q[<p class="caption">#{compile_inline(caption)}</p>]
       else
-        puts %Q[<p class="caption">#{I18n.t("table")}#{I18n.t("format_number_header", [get_chap, @chapter.table(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}</p>]
+        if get_chap.nil?
+          puts %Q[<p class="caption">#{I18n.t("table")}#{I18n.t("format_number_header_without_chapter", [@chapter.table(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}</p>]
+        else
+          puts %Q[<p class="caption">#{I18n.t("table")}#{I18n.t("format_number_header", [get_chap, @chapter.table(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}</p>]
+        end
       end
     end
 
@@ -725,6 +729,10 @@ module ReVIEW
     def imgtable_image(id, caption, metric)
       metrics = parse_metric("html", metric)
       puts %Q[<img src="#{@chapter.image(id).path.sub(/\A\.\//, "")}" alt="#{escape_html(compile_inline(caption))}"#{metrics} />]
+    end
+
+    def emtable(lines, caption = nil)
+      table(lines, nil, caption)
     end
 
     def comment(lines, comment = nil)

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -563,10 +563,14 @@ module ReVIEW
     end
 
     def table_header(id, caption)
-      if get_chap.nil?
-        puts %Q[<caption>#{I18n.t("table")}#{I18n.t("format_number_without_chapter", [@chapter.table(id).number])}#{I18n.t("caption_prefix_idgxml")}#{compile_inline(caption)}</caption>]
+      if id.nil?
+        puts %Q[<caption>#{compile_inline(caption)}</caption>]
       else
-        puts %Q[<caption>#{I18n.t("table")}#{I18n.t("format_number", [get_chap, @chapter.table(id).number])}#{I18n.t("caption_prefix_idgxml")}#{compile_inline(caption)}</caption>]
+        if get_chap.nil?
+          puts %Q[<caption>#{I18n.t("table")}#{I18n.t("format_number_without_chapter", [@chapter.table(id).number])}#{I18n.t("caption_prefix_idgxml")}#{compile_inline(caption)}</caption>]
+        else
+          puts %Q[<caption>#{I18n.t("table")}#{I18n.t("format_number", [get_chap, @chapter.table(id).number])}#{I18n.t("caption_prefix_idgxml")}#{compile_inline(caption)}</caption>]
+        end
       end
     end
 
@@ -587,6 +591,10 @@ module ReVIEW
 
     def table_end
       print "<?dtp tablerow last?>"
+    end
+
+    def emtable(lines, caption = nil)
+      table(lines, nil, caption)
     end
 
     def imgtable(lines, id, caption = nil, metric = nil)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -535,12 +535,20 @@ module ReVIEW
     end
 
     def table_header(id, caption)
-      if caption.present?
-        @table_caption = true
-        puts '\begin{table}[h]'
-        puts macro('reviewtablecaption', compile_inline(caption))
+      if id.nil?
+        if caption.present?
+          @table_caption = true
+          puts '\begin{table}[h]'
+          puts macro('reviewtablecaption*', compile_inline(caption))
+        end
+      else
+        if caption.present?
+          @table_caption = true
+          puts '\begin{table}[h]'
+          puts macro('reviewtablecaption', compile_inline(caption))
+        end
+        puts macro('label', table_label(id))
       end
-      puts macro('label', table_label(id))
     end
 
     def table_begin(ncols)
@@ -595,6 +603,10 @@ module ReVIEW
       end
       @table_caption = nil
       blank
+    end
+
+    def emtable(lines, caption = nil)
+      table(lines, nil, caption)
     end
 
     def imgtable(lines, id, caption = nil, metric = nil)

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -241,10 +241,14 @@ module ReVIEW
     end
 
     def table_header(id, caption)
-      if get_chap.nil?
-        puts %Q[#{I18n.t("table")}#{I18n.t("format_number_header_without_chapter", [@chapter.table(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}]
+      if id.nil?
+        puts compile_inline(caption)
       else
-        puts %Q[#{I18n.t("table")}#{I18n.t("format_number_header", [get_chap, @chapter.table(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}]
+        if get_chap.nil?
+          puts %Q[#{I18n.t("table")}#{I18n.t("format_number_header_without_chapter", [@chapter.table(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}]
+        else
+          puts %Q[#{I18n.t("table")}#{I18n.t("format_number_header", [get_chap, @chapter.table(id).number])}#{I18n.t("caption_prefix")}#{compile_inline(caption)}]
+        end
       end
       blank
     end

--- a/lib/review/rstbuilder.rb
+++ b/lib/review/rstbuilder.rb
@@ -317,8 +317,10 @@ module ReVIEW
     end
 
     def table_header(id, caption)
-      blank
-      puts ".. _#{id}:"
+      unless id.nil?
+        blank
+        puts ".. _#{id}:"
+      end
       blank
       puts ".. list-table:: #{compile_inline(caption)}"
       puts "   :header-rows: 1"
@@ -350,6 +352,10 @@ module ReVIEW
 
     def table_end
       blank
+    end
+
+    def emtable(lines, caption = nil)
+      table(lines, nil, caption)
     end
 
     def comment(lines, comment = nil)

--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -8,6 +8,8 @@
 <%- else -%>
 \usepackage[deluxe]{otf}
 <%- end -%>
+\usepackage{caption}
+\usepackage{suffix}
 \usepackage[T1]{fontenc}\usepackage{textcomp}%T1/TS1
 % \usepackage{lmodern}
 \usepackage[dvipdfmx]{graphicx}
@@ -135,6 +137,9 @@
 
 \newcommand{\reviewtablecaption}[1]{%
   \caption{#1}}
+
+\WithSuffix\newcommand\reviewtablecaption*[1]{%
+  \caption*{#1}}
 
 \newcommand{\reviewimgtablecaption}[1]{%
   \caption{#1}\vspace{-3mm}}

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -4,6 +4,8 @@
 % \usepackage{fixltx2e}[2006/09/13 v1.1m]
 
 \usepackage[deluxe,uplatex]{otf}
+\usepackage{caption}
+\usepackage{suffix}
 \usepackage[T1]{fontenc}\usepackage{textcomp}%T1/TS1
 % \usepackage{lmodern}
 \usepackage[dvipdfmx]{graphicx}
@@ -95,6 +97,9 @@
 
 \newcommand{\reviewtablecaption}[1]{%
   \caption{#1}}
+
+\WithSuffix\newcommand\reviewtablecaption*[1]{%
+  \caption*{#1}}
 
 \newcommand{\reviewimgtablecaption}[1]{%
   \caption{#1}\vspace{-3mm}}

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1515,6 +1515,12 @@ EOS
     assert_equal %Q|<p><span class="tableref">表1.1</span></p>\n|, actual
   end
 
+  def test_emtable
+    actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    assert_equal %Q|<div class="table">\n<p class="caption">foo</p>\n<table>\n<tr><th>aaa</th><th>bbb</th></tr>\n<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>\n</table>\n</div>\n<div class="table">\n<table>\n<tr><th>aaa</th><th>bbb</th></tr>\n<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>\n</table>\n</div>\n|,
+                 actual
+  end
+
   def test_imgtable
     def @chapter.image(id)
       item = Book::ImageIndex::Item.new("sampleimg",1, 'sample img')

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -143,7 +143,6 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
                  actual
   end
 
-
   def test_inline_br
     actual = compile_inline("@<br>{}")
     assert_equal %Q|\n|, actual

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -137,6 +137,13 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.458">A</td></tbody></table>|, actual
   end
 
+  def test_emtable
+    actual = compile_block("//emtable[foo]{\nA\n//}\n//emtable{\nA\n//}")
+    assert_equal %Q|<table><caption>foo</caption><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table><table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table>|,
+                 actual
+  end
+
+
   def test_inline_br
     actual = compile_inline("@<br>{}")
     assert_equal %Q|\n|, actual

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -540,6 +540,12 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(\\begin{reviewtable}{|p{5mm}|cr|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
   end
 
+  def test_emtable
+    actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    assert_equal "\\begin{table}[h]\n\\reviewtablecaption*{foo}\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n\\end{table}\n\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
+                 actual
+  end
+
   def test_imgtable
     def @chapter.image(id)
       item = Book::ImageIndex::Item.new("sampleimg",1, 'sample img')

--- a/test/test_rstbuilder.rb
+++ b/test/test_rstbuilder.rb
@@ -150,6 +150,11 @@ class RSTBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|   * - ★1☆\n     - ▲2☆\n   * - ★3☆\n     - ▲4☆<>&\n\n|, actual
   end
 
+  def test_emtable
+    actual = compile_block("//emtable[foo]{\nA\n//}\n//emtable{\nA\n//}")
+    assert_equal %Q|.. list-table:: foo\n   :header-rows: 1\n\n   * - A\n\n   * - A\n\n|, actual
+  end
+
   def test_paragraph
     actual = compile_block("foo\nbar\n")
     assert_equal %Q|foobar\n\n|, actual

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -147,7 +147,7 @@ class TOPBuidlerTest < Test::Unit::TestCase
 
   def test_inline_in_table
     actual = compile_block("//table{\n★1☆\t▲2☆\n------------\n★3☆\t▲4☆<>&\n//}\n")
-    assert_equal %Q|★★1☆☆\t★▲2☆☆\n★3☆\t▲4☆<>&\n◆→終了:表←◆\n\n|, actual
+    assert_equal %Q|◆→開始:表←◆\n★★1☆☆\t★▲2☆☆\n★3☆\t▲4☆<>&\n◆→終了:表←◆\n\n|, actual
   end
 
   def test_paragraph
@@ -208,6 +208,26 @@ class TOPBuidlerTest < Test::Unit::TestCase
     end
 
     assert_equal %Q|[1]|, compile_inline("@<bib>{samplebib}")
+  end
+
+  def test_table
+    actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    assert_equal %Q|◆→開始:表←◆\n★aaa☆\t★bbb☆\nccc\tddd<>&\n◆→終了:表←◆\n\n|,
+                 actual
+  end
+
+  def test_inline_table
+    def @chapter.table(id)
+      Book::TableIndex::Item.new("sampletable",1)
+    end
+    actual = compile_block("@<table>{sampletest}\n")
+    assert_equal %Q|表1.1\n|, actual
+  end
+
+  def test_emtable
+    actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    assert_equal %Q|◆→開始:表←◆\nfoo\n\n★aaa☆\t★bbb☆\nccc\tddd<>&\n◆→終了:表←◆\n\n◆→開始:表←◆\n★aaa☆\t★bbb☆\nccc\tddd<>&\n◆→終了:表←◆\n\n|,
+                 actual
   end
 
   def test_major_blocks


### PR DESCRIPTION
#255 の対応。
書式としてはidなしのtableで、

```
//emtable[caption]{
//emtable{
```

latexではreviewtablecaption*にしたかったので、caption.styとsuffix.styを取り込んでいます。

Builder#tableを各個ビルダで結局似たりよったりのオーバライドが必要になっているのはイケてない気がするので、取り込んだあとにその対処に乗り出したいところです。