### PR TITLE
Use https: instead of git:

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -5,7 +5,7 @@ Maintainer: Kenshi Muto <kmuto@debian.org>
 Build-Depends: debhelper (>= 7.0.50~), quilt (>= 0.46-7~)
 Standards-Version: 3.9.1
 Homepage: http://github.com/kmuto/review
-Vcs-Git: git://github.com/kmuto/review.git
+Vcs-Git: https://github.com/kmuto/review.git
 
 Package: review
 Architecture: all

--- a/doc/quickstart.ja.md
+++ b/doc/quickstart.ja.md
@@ -47,7 +47,7 @@ Re:VIEW は GitHub で開発されており、バージョン管理ツールの 
 初めて取得するときには、次のようにします (コピーを作っています)。
 
 ```bash
-$ git clone git://github.com/kmuto/review.git
+$ git clone https://github.com/kmuto/review.git
 ```
 
 review というディレクトリに展開されるので、review/bin にパスを通すようにしておいてください。

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -46,7 +46,7 @@ $ gem install review
 You can get latest Re:VIEW sources from GitHub.
 
 ```bash
-$ git clone git://github.com/kmuto/review.git
+$ git clone https://github.com/kmuto/review.git
 ```
 
 You can use Re:VIEW to add `review/bin` directory to `$PATH` variable.


### PR DESCRIPTION
https://help.github.com/articles/which-remote-url-should-i-use/ で https: が推奨になっていて、今は選択肢に git: が出てこないということもあって、 https: を使うのが良いのではないでしょうか。

それから、元が git: になっていたということは read only を想定していると思うので、ssh にする必要もないのかなと思いました。