### PR TITLE
部ファイル内の見出しや図表リストの接頭字に部番号を使用

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -394,7 +394,11 @@ module ReVIEW
 
     def get_chap(chapter = @chapter)
       if @book.config["secnolevel"] > 0 && !chapter.number.nil? && !chapter.number.to_s.empty?
-        return chapter.format_number(nil)
+        if chapter.is_a? ReVIEW::Book::Part
+          return I18n.t('part_short', chapter.number)
+        else
+          return chapter.format_number(nil)
+        end
       end
       return nil
     end

--- a/lib/review/sec_counter.rb
+++ b/lib/review/sec_counter.rb
@@ -55,7 +55,13 @@ module ReVIEW
           end
         end
       elsif secnolevel >= level
-        prefix = @chapter.format_number(false)
+        prefix = ''
+        if @chapter.is_a? ReVIEW::Book::Part
+          prefix = I18n.t('part_short', @chapter.number)
+        else
+          prefix = @chapter.format_number(false)
+        end
+
         0.upto(level - 2) do |i|
           prefix << ".#{@counter[i]}"
         end


### PR DESCRIPTION
部のreファイル内で節見出しおよびimg, list, tableを使ったときに、locale.ymlでローマ数字などを設定していても「1.1」のようになってしまう。

部かどうかを判断し、返却結果を変えるようにした。