### PR TITLE
suppress rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -144,6 +144,9 @@ Style/IfUnlessModifier:
 Style/MutableConstant:
   Enabled: false
 
+Style/MultipleComparison:
+  Enabled: false
+
 Style/UnneededInterpolation:
   Enabled: false
 
@@ -343,6 +346,9 @@ Style/WhileUntilModifier:
   Enabled: false
 
 Style/IndentHeredoc:
+  Enabled: false
+
+Style/YodaCondition:
   Enabled: false
 
 #### Metrics


### PR DESCRIPTION
`Style/MultipleComparison` and `Style/YodaCondition` are not useful :-(