### PR TITLE
LaTeXで扱える画像形式を調整

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -32,6 +32,7 @@ module ReVIEW
     end
 
     def builder_init_file
+      @chapter.book.image_types = %w(.ai .eps .pdf .tif .tiff .png .bmp .jpg .jpeg .gif)
       @blank_needed = false
       @latex_tsize = nil
       @tsize = nil


### PR DESCRIPTION
.aiは（あくまでPDF互換データとして）扱えるけど.psdはダメなので、ビルダで上書き定義する。