### PR TITLE
dlistの終了条件に箇条書きも含める

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -416,7 +416,7 @@ module ReVIEW
       @strategy.dl_begin
       while /\A\s*:/ =~ f.peek
         @strategy.dt text(f.gets.sub(/\A\s*:/, '').strip)
-        @strategy.dd(f.break(/\A(\S|\s*:)/).map {|line| text(line.strip) })
+        @strategy.dd(f.break(/\A(\S|\s*:|\s+\d+\.\s|\s+\*\s)/).map {|line| text(line.strip) })
         f.skip_blank_lines
         f.skip_comment_lines
       end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -565,6 +565,11 @@ EOS
     assert_equal %Q|<dl>\n<dt>title</dt>\n<dd>body</dd>\n<dt>title2</dt>\n<dd>body2</dd>\n</dl>\n|, actual
   end
 
+  def test_dlist_beforeulol
+    actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")
+    assert_equal %Q|<dl>\n<dt>foo</dt>\n<dd>foo.</dd>\n</dl>\n<p>para</p>\n<dl>\n<dt>foo</dt>\n<dd>foo.</dd>\n</dl>\n<ol>\n<li>bar</li>\n</ol>\n<dl>\n<dt>foo</dt>\n<dd>foo.</dd>\n</dl>\n<ul>\n<li>bar</li>\n</ul>\n|, actual
+  end
+
   def test_list
     def @chapter.list(id)
       Book::ListIndex::Item.new("samplelist",1)

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -188,6 +188,11 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|<replace idref="texinline-1"><pre>\\sin</pre></replace> <replace idref="texinline-2"><pre>\\frac{1}{2}</pre></replace>|, actual
   end
 
+  def test_dlist_beforeulol
+    actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")
+    assert_equal %Q|<dl><dt>foo</dt><dd>foo.</dd></dl><p>para</p><dl><dt>foo</dt><dd>foo.</dd></dl><ol><li aid:pstyle="ol-item" olnum="1" num="1">bar</li></ol><dl><dt>foo</dt><dd>foo.</dd></dl><ul><li aid:pstyle="ul-item">bar</li></ul>|, actual
+  end
+
   def test_paragraph
     actual = compile_block("foo\nbar\n")
     assert_equal %Q|<p>foobar</p>|, actual

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -252,6 +252,11 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|\n\\begin{description}\n\\item[foo\\lbrack{}bar\\rbrack{}] \\mbox{} \\\\\nfoo.bar.\n\\end{description}\n|, actual
   end
 
+  def test_dlist_beforeulol
+    actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")
+    assert_equal %Q|\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\n\\end{description}\n\npara\n\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\n\\end{description}\n\n\\begin{enumerate}\n\\item bar\n\\end{enumerate}\n\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\n\\end{description}\n\n\\begin{itemize}\n\\item bar\n\\end{itemize}\n|, actual
+  end
+
   def test_cmd
     actual = compile_block("//cmd{\nfoo\nbar\n\nbuz\n//}\n")
     assert_equal %Q|\n\\begin{reviewcmd}\nfoo\nbar\n\nbuz\n\\end{reviewcmd}\n|, actual

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -150,6 +150,11 @@ class TOPBuidlerTest < Test::Unit::TestCase
     assert_equal %Q|◆→開始:表←◆\n★★1☆☆\t★▲2☆☆\n★3☆\t▲4☆<>&\n◆→終了:表←◆\n\n|, actual
   end
 
+  def test_dlist_beforeulol
+    actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")
+    assert_equal %Q|★foo☆\n\tfoo.\n\t\n\npara\n\n★foo☆\n\tfoo.\n\t\n\n1\tbar\n\n★foo☆\n\tfoo.\n\t\n\n●\tbar\n\n|, actual
+  end
+
   def test_paragraph
     actual = compile_block("foo\nbar\n")
     assert_equal %Q|foobar\n|, actual


### PR DESCRIPTION
#794 の修正。

ddの処理で通常段落か「:」かしか判断していなかったので、*や1.がddに含まれてしまっていた。
