### PR TITLE
[README] Quick Startの`rake pdf`コマンドにTexが必要な旨を明記

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ $ review-init hello
 $ cd hello
 $ (... add and edit *.re file, config.yml and catalog.yml ...)
 $ rake epub  ## generating EPUB
-$ rake pdf   ## generating PDF
+$ rake pdf   ## generating PDF(Requirement TeX)
 ```
 
 For further information, see [doc/quickstart.md](https://github.com/kmuto/review/blob/readme-md/doc/quickstart.md)


### PR DESCRIPTION
# 概要

当方普段Texを使わないのですがMarkdownを手軽にPDF化出来ると本ツールを知人から勧められました。
インストールし`Quick Start`の通り`rake pdf`コマンドを実行しましたが、以下エラーにより停止してしまいました。

```
ryota.murakami@localhost ~/r/hello>rake pdf
review-pdfmaker config.yml
compiling hello.tex
/Users/ryota.murakami/repository/hello/gems/ruby/2.4.0/gems/review-2.3.0/lib/review/pdfmaker.rb:42:in `system_or_raise': failed to run command: ebb cover.jpg (RuntimeError)
	from /Users/ryota.murakami/repository/hello/gems/ruby/2.4.0/gems/review-2.3.0/lib/review/pdfmaker.rb:275:in `block in copy_images'
	from /Users/ryota.murakami/repository/hello/gems/ruby/2.4.0/gems/review-2.3.0/lib/review/pdfmaker.rb:268:in `chdir'
	from /Users/ryota.murakami/repository/hello/gems/ruby/2.4.0/gems/review-2.3.0/lib/review/pdfmaker.rb:268:in `copy_images'
	from /Users/ryota.murakami/repository/hello/gems/ruby/2.4.0/gems/review-2.3.0/lib/review/pdfmaker.rb:235:in `generate_pdf'
	from /Users/ryota.murakami/repository/hello/gems/ruby/2.4.0/gems/review-2.3.0/lib/review/pdfmaker.rb:132:in `execute'
	from /Users/ryota.murakami/repository/hello/gems/ruby/2.4.0/gems/review-2.3.0/lib/review/pdfmaker.rb:86:in `execute'
	from /Users/ryota.murakami/repository/hello/gems/ruby/2.4.0/gems/review-2.3.0/bin/review-pdfmaker:18:in `<top (required)>'
	from /Users/ryota.murakami/repository/hello/gems/ruby/2.4.0/bin/review-pdfmaker:22:in `load'
	from /Users/ryota.murakami/repository/hello/gems/ruby/2.4.0/bin/review-pdfmaker:22:in `<main>'
rake aborted!
```

エラーメッセージでググったところ幸運にも[qiitaの記事](http://qiita.com/nanbuwks/items/da9136f1b6f789aaffcf)でTexを別途インストールする必要がある事を知る事が出来たのですが、
`rake pdf`コマンド実行には事前にTexの導入が必要な事をドキュメントに明示した方が親切かなと思い、PRを作成させて頂きました。

私は以下の手順で実際のPDF生成まで行えました。
https://github.com/ryota-murakami/hello-review#procedure

宜しければ確認お願いしますm(_ _)m