### PR TITLE
topbuilderでのmetricパラメータが無視かエラーになるのを修正

### DIFF
--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -280,7 +280,17 @@ module ReVIEW
       end
     end
 
+    def handle_metric(str)
+      str
+    end
+
+    def result_metric(array)
+      array.join(',')
+    end
+
     def image(lines, id, caption, metric=nil)
+      metrics = parse_metric('top', metric)
+      metrics = " #{metrics}" if metrics.present?
       blank
       puts "◆→開始:#{@titles["image"]}←◆"
       if get_chap.nil?
@@ -290,7 +300,7 @@ module ReVIEW
       end
       blank
       if @chapter.image(id).bound?
-        puts "◆→#{@chapter.image(id).path}←◆"
+        puts "◆→#{@chapter.image(id).path}#{metrics}←◆"
       else
         lines.each do |line|
           puts line
@@ -730,9 +740,11 @@ module ReVIEW
     alias_method :box, :insn
 
     def indepimage(_lines, id, caption=nil, metric=nil)
+      metrics = parse_metric('top', metric)
+      metrics = " #{metrics}" if metrics.present?
       blank
       begin
-        puts "◆→画像 #{@chapter.image(id).path.sub(/\A\.\//, "")} #{metric.join(" ")}←◆"
+        puts "◆→画像 #{@chapter.image(id).path.sub(/\A\.\//, "")}#{metrics}←◆"
       rescue
         warn "no such image: #{id}"
         puts "◆→画像 #{id}←◆"

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -288,7 +288,7 @@ class TOPBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\nfoo\n//}\n")
-    assert_equal %Q|◆→開始:図←◆\n図1.1　sample photo\n\n◆→./images/chap1-sampleimg.png←◆\n◆→終了:図←◆\n\n|, actual
+    assert_equal %Q|◆→開始:図←◆\n図1.1　sample photo\n\n◆→./images/chap1-sampleimg.png scale=1.2←◆\n◆→終了:図←◆\n\n|, actual
   end
 
   def test_texequation


### PR DESCRIPTION
topbuilderで

* imageにmetricパラメータを渡してもまったく無視されて何も残らない
* indepimageにmetricパラメータを渡さないとnil.joinが発生してエラー

となるのを修正する。
とはいえtopbuilder自体がパラメータで何かできるわけではないので、結果文字列にパラメータ文字列を埋め込むだけの挙動とした。

```
◆→画像 images/cover.jpg a=1,b=1←◆
```