### PR TITLE
画像が見つからないときは常に警告する

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -603,6 +603,7 @@ module ReVIEW
     end
 
     def image_dummy(id, caption, lines)
+      warn "image not bound: #{id}"
       puts %Q[<div id="#{normalize_id(id)}" class="image">]
       puts %Q[<pre class="dummyimage">]
       lines.each do |line|
@@ -611,7 +612,6 @@ module ReVIEW
       puts %Q[</pre>]
       image_header id, caption
       puts %Q[</div>]
-      warn "no such image: #{id}"
     end
 
     def image_header(id, caption)
@@ -751,7 +751,14 @@ module ReVIEW
       begin
         puts %Q[<img src="#{@chapter.image(id).path.sub(/\A\.\//, "")}" alt="#{escape_html(compile_inline(caption))}"#{metrics} />]
       rescue
-        puts %Q[<pre>missing image: #{id}</pre>]
+        warn "image not bound: #{id}"
+        if _lines
+          puts %Q[<pre class="dummyimage">]
+          _lines.each do |line|
+            puts detab(line)
+          end
+          puts %Q[</pre>]
+        end
       end
 
       unless caption.empty?
@@ -1126,6 +1133,7 @@ module ReVIEW
       begin
         %Q[<img src="#{@chapter.image(id).path.sub(/\A\.\//, "")}" alt="[#{id}]" />]
       rescue
+        warn "image not bound: #{id}"
         %Q[<pre>missing image: #{id}</pre>]
       end
     end

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -431,7 +431,7 @@ module ReVIEW
       print %Q[</pre>]
       image_header id, caption
       puts "</img>"
-      warn "no such image: #{id}"
+      warn "image not bound: #{id}"
     end
 
     def image_header(id, caption)
@@ -722,7 +722,7 @@ module ReVIEW
       begin
         %Q[<Image href="file://#{@chapter.image(id).path.sub(/\A\.\//, "")}" type="inline" />]
       rescue
-        warn "no such icon image: #{id}"
+        warn "image not bound: #{id}"
         ""
       end
     end
@@ -1010,7 +1010,7 @@ module ReVIEW
       begin
         puts %Q[<Image href="file://#{@chapter.image(id).path.sub(/\A\.\//, "")}"#{metrics} />]
       rescue
-        warn %Q[no such image: #{id}]
+        warn %Q[image not bound: #{id}]
       end
       puts %Q[<caption>#{compile_inline(caption)}</caption>] if caption.present?
       puts "</img>"

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -302,6 +302,7 @@ module ReVIEW
       if @chapter.image(id).bound?
         puts "◆→#{@chapter.image(id).path}#{metrics}←◆"
       else
+        warn "image not bound: #{id}"
         lines.each do |line|
           puts line
         end
@@ -490,7 +491,7 @@ module ReVIEW
       begin
         return "◆→画像 #{@chapter.image(id).path.sub(/\A\.\//, "")}←◆"
       rescue
-        warn "no such icon image: #{id}"
+        warn "image not bound: #{id}"
         return "◆→画像 #{id}←◆"
       end
     end
@@ -746,7 +747,7 @@ module ReVIEW
       begin
         puts "◆→画像 #{@chapter.image(id).path.sub(/\A\.\//, "")}#{metrics}←◆"
       rescue
-        warn "no such image: #{id}"
+        warn "image not bound: #{id}"
         puts "◆→画像 #{id}←◆"
       end
       puts "図　#{compile_inline(caption)}" if caption.present?


### PR DESCRIPTION
cf #803 

image, icon, indepimageにおいて、画像が見つからないときは無言ではなく必ずwarnで警告するようにした。
また、メッセージがno such image: ID だと挙動として変なので、元のに合わせて image not bound: ID で揃えた。
