### PR TITLE
dateが空なら今日の日付を設定

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -22,7 +22,7 @@ module ReVIEW
         "ill" => nil, # Illustrator
         "pht" => nil, # Photographer
         "trl" => nil, # Translator
-        "date" => nil, # publishing date
+        "date" => Time.now.strftime('%Y-%m-%d'), # publishing date
         "rights" => nil, # Copyright messages
         "description" => nil, # Description
         "urnid" => "urn:uid:#{SecureRandom.uuid}", # Identifier


### PR DESCRIPTION
ref #824 
epubmakerのほうでは付けてたけど、ちゃんと効いてなかった模様。またTeXのほうにも必要だったので、共通のconfigureのほうの初期値でdate=今日とした。
