### PR TITLE
hash型のbooktitle等パラメータへの対応

### DIFF
--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -236,9 +236,9 @@ module ReVIEW
       File.open("#{basetmpdir}/#{htmlfile}", 'w') do |f|
         @body = ''
         @body << %Q(<div class="titlepage">)
-        @body << %Q(<h1 class="tp-title">#{CGI.escapeHTML(@config['booktitle'])}</h1>)
-        @body << %Q(<h2 class="tp-author">#{join_with_separator(@config['aut'], ReVIEW::I18n.t('names_splitter'))}</h2>) if @config['aut']
-        @body << %Q(<h3 class="tp-publisher">#{join_with_separator(@config['prt'], ReVIEW::I18n.t('names_splitter'))}</h3>) if @config['prt']
+        @body << %Q(<h1 class="tp-title">#{CGI.escapeHTML(@config.name_of('booktitle'))}</h1>)
+        @body << %Q(<h2 class="tp-author">#{join_with_separator(@config.names_of('aut'), ReVIEW::I18n.t('names_splitter'))}</h2>) if @config['aut']
+        @body << %Q(<h3 class="tp-publisher">#{join_with_separator(@config.names_of('prt'), ReVIEW::I18n.t('names_splitter'))}</h3>) if @config['prt']
         @body << '</div>'
 
         @language = @config['language']

--- a/templates/web/html/layout-html5.html.erb
+++ b/templates/web/html/layout-html5.html.erb
@@ -11,12 +11,12 @@
 <% if @next.present? %><link rel="next" title="<%= h(@next_title)%>" href="<%= h(@next.id.to_s+"."+@book.config['htmlext']) %>"><% end %>
 <% if @prev.present? %><link rel="prev" title="<%= h(@prev_title)%>" href="<%= h(@prev.id.to_s+"."+@book.config['htmlext']) %>"><% end %>
   <meta name="generator" content="Re:VIEW" />
-  <title><%=h @title %> | <%=h @book.config["booktitle"]%></title>
+  <title><%=h @title %> | <%=h @book.config.name_of("booktitle")%></title>
 </head>
 <body<%= @body_ext %>>
   <div class="book">
     <nav class="side-content">
-      <h1><%=h @book.config["booktitle"] %></h1>
+      <h1><%=h @book.config.name_of("booktitle") %></h1>
       <%= @toc %>
       <p class="review-signature">powered by <a href="http://reviewml.org/">Re:VIEW</a></p>
     </nav>


### PR DESCRIPTION
```
booktitle: {name: "Re:VIEW文法変換リファレンス", file-as: "リビューブンポウヘンカンリファレンス"}
```

みたいなものをwebmakerにかけるとエラーやハッシュ文字列がHTMLに入ってしまうことの修正です。
