### PR TITLE
EPUB3でspine内の静的目次の位置をPREDEFの後/CHAPSの前にする

### DIFF
--- a/lib/epubmaker/content.rb
+++ b/lib/epubmaker/content.rb
@@ -29,6 +29,10 @@ module EPUBMaker
     # Chapter type (pre/post/part/nil(body))
     attr_accessor :chaptype
 
+    def to_s
+      "Content id=#{@id}, file=#{@file}, media=#{@media}, title=#{@title}, level=#{@level}, notoc=#{@notoc}, properties=#{@properties}, chaptype=#{@chaptype}"
+    end
+
     # :call-seq:
     #    initialize(file, id, media, title, level, notoc)
     #    initialize(hash)

--- a/lib/epubmaker/content.rb
+++ b/lib/epubmaker/content.rb
@@ -29,8 +29,8 @@ module EPUBMaker
     # Chapter type (pre/post/part/nil(body))
     attr_accessor :chaptype
 
-    def to_s
-      "Content id=#{@id}, file=#{@file}, media=#{@media}, title=#{@title}, level=#{@level}, notoc=#{@notoc}, properties=#{@properties}, chaptype=#{@chaptype}"
+    def inspect
+      "<Content id=#{@id}, file=#{@file}, media=#{@media}, title=#{@title}, level=#{@level}, notoc=#{@notoc}, properties=#{@properties}, chaptype=#{@chaptype}>"
     end
 
     # :call-seq:

--- a/lib/epubmaker/epubv3.rb
+++ b/lib/epubmaker/epubv3.rb
@@ -173,10 +173,14 @@ EOT
         s << %Q(  <spine>\n)
       end
       s << %Q(    <itemref idref="#{@producer.params['bookname']}" linear="#{cover_linear}"/>\n)
-      s << %Q(    <itemref idref="#{@producer.params['bookname']}-toc.#{@producer.params['htmlext']}" />\n) if @producer.params['toc']
 
+      toc = nil
       @producer.contents.each do |item|
         next if item.media !~ /xhtml\+xml/ # skip non XHTML
+        if toc.nil? && item.chaptype != 'pre'
+          s << %Q(    <itemref idref="#{@producer.params['bookname']}-toc.#{@producer.params['htmlext']}" />\n) if @producer.params['toc']
+          toc = true
+        end
         s << %Q(    <itemref idref="#{item.id}"/>\n)
       end
       s << %Q(  </spine>\n)


### PR DESCRIPTION
Kindle版などでtoc: trueとしたときに配置される静的目次を、書籍の冒頭ではなく、一般的な書籍同様に前付の最後に置くようにします。

これ以上変えたいときは自己責任でフックでopfファイルを調整いただくということで。
