### PR TITLE
rubocop 0.51対応

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -89,6 +89,9 @@ Style/ClassCheck:
 Style/ClassMethods:
   Enabled: true
 
+Style/CommentedKeyword:
+  Enabled: false
+
 # Do not introduce global variables.
 Style/GlobalVars:
   Enabled: true
@@ -232,6 +235,9 @@ Style/SingleLineMethods:
 
 Style/SpecialGlobalVars:
   Enabled: true
+
+Style/StderrPuts:
+  Enabled: false
 
 Style/StringLiterals:
   Enabled: true

--- a/review.gemspec
+++ b/review.gemspec
@@ -21,11 +21,11 @@ Gem::Specification.new do |gem|
   ]
   gem.require_paths = ['lib']
 
-  gem.add_dependency('rubyzip')
-  gem.add_dependency('rouge')
   gem.add_dependency('image_size')
-  gem.add_development_dependency('rake')
-  gem.add_development_dependency('test-unit')
+  gem.add_dependency('rouge')
+  gem.add_dependency('rubyzip')
   gem.add_development_dependency('pygments.rb')
+  gem.add_development_dependency('rake')
   gem.add_development_dependency('rubocop')
+  gem.add_development_dependency('test-unit')
 end

--- a/test/test_makerhelper.rb
+++ b/test/test_makerhelper.rb
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 require 'test_helper'
 require 'review/makerhelper'
 require 'tmpdir'


### PR DESCRIPTION
新規2つはどちらも都合が悪い。

- warnはcompileは置き換えをしているので対処しづらい
- commentはたくさんあり、対処する必然性もない