### PR TITLE
@<pageref>の導入

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -312,6 +312,10 @@ module ReVIEW
       chapter.column(id).caption
     end
 
+    def inline_pageref(id)
+      "[link:#{id}]"
+    end
+
     def inline_tcy(arg)
       "#{arg}[rotate 90 degree]"
     end

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -226,6 +226,7 @@ module ReVIEW
     definline :include
     definline :tcy
     definline :embed
+    definline :pageref
 
     private
 

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -756,6 +756,11 @@ module ReVIEW
 
     alias_method :inline_ref, :inline_labelref
 
+    def inline_pageref(id)
+      warn "pageref op is unsupported on this builder: #{id}"
+      "[link:#{escape_html(id)}]"
+    end
+
     def inline_chapref(id)
       title = super
       if @book.config['chapterlink']

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -757,8 +757,7 @@ module ReVIEW
     alias_method :inline_ref, :inline_labelref
 
     def inline_pageref(id)
-      warn "pageref op is unsupported on this builder: #{id}"
-      "[link:#{escape_html(id)}]"
+      error "pageref op is unsupported on this builder: #{id}"
     end
 
     def inline_chapref(id)

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -16,7 +16,7 @@ module ReVIEW
     include TextUtils
     include HTMLUtils
 
-    %i[ttbold hint maru keytop labelref ref pageref balloon].each { |e| Compiler.definline(e) }
+    %i[ttbold hint maru keytop labelref ref balloon].each { |e| Compiler.definline(e) }
     Compiler.defsingle(:dtp, 1)
 
     Compiler.defblock(:insn, 0..1)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -96,7 +96,7 @@ module ReVIEW
       6 => 'subparagraph'
     }.freeze
 
-    def headline(level, _label, caption)
+    def headline(level, label, caption)
       _, anchor = headline_prefix(level)
       headline_name = HEADLINE[level]
       headline_name = 'part' if @chapter.is_a? ReVIEW::Book::Part
@@ -112,6 +112,7 @@ module ReVIEW
         puts macro('label', chapter_label)
       else
         puts macro('label', sec_label(anchor))
+        puts macro('label', label) if label
       end
     rescue
       error "unknown level: #{level}"
@@ -707,6 +708,10 @@ module ReVIEW
     rescue KeyError
       error "unknown chapter: #{id}"
       nofunc_text("[UnknownChapter:#{id}]")
+    end
+
+    def inline_pageref(id)
+      "\\pageref{#{id}}"
     end
 
     # FIXME: use TeX native label/ref.

--- a/lib/review/rstbuilder.rb
+++ b/lib/review/rstbuilder.rb
@@ -20,7 +20,7 @@ module ReVIEW
   class RSTBuilder < Builder
     include TextUtils
 
-    %i[ttbold hint maru keytop labelref ref pageref balloon strong].each { |e| Compiler.definline(e) }
+    %i[ttbold hint maru keytop labelref ref balloon strong].each { |e| Compiler.definline(e) }
     Compiler.defsingle(:dtp, 1)
 
     Compiler.defblock(:insn, 1)

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -13,7 +13,7 @@ module ReVIEW
   class TOPBuilder < Builder
     include TextUtils
 
-    %i[ttbold hint maru keytop labelref ref pageref balloon strong].each { |e| Compiler.definline(e) }
+    %i[ttbold hint maru keytop labelref ref balloon strong].each { |e| Compiler.definline(e) }
     Compiler.defsingle(:dtp, 1)
 
     Compiler.defblock(:insn, 1)

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -44,18 +44,18 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def test_headline_level2
     actual = compile_block("=={test} this is test.\n")
-    assert_equal %Q(\\section{this is test.}\n\\label{sec:1-1}\n), actual
+    assert_equal %Q(\\section{this is test.}\n\\label{sec:1-1}\n\\label{test}\n), actual
   end
 
   def test_headline_level3
     actual = compile_block("==={test} this is test.\n")
-    assert_equal %Q(\\subsection*{this is test.}\n\\label{sec:1-0-1}\n), actual
+    assert_equal %Q(\\subsection*{this is test.}\n\\label{sec:1-0-1}\n\\label{test}\n), actual
   end
 
   def test_headline_level3_with_secno
     @config['secnolevel'] = 3
     actual = compile_block("==={test} this is test.\n")
-    assert_equal %Q(\\subsection{this is test.}\n\\label{sec:1-0-1}\n), actual
+    assert_equal %Q(\\subsection{this is test.}\n\\label{sec:1-0-1}\n\\label{test}\n), actual
   end
 
   def test_label
@@ -199,6 +199,11 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     @config['secnolevel'] = 3
     actual = compile_inline('test @<hd>{chap1|test} test2')
     assert_equal 'test 「1.1.1 te\\textunderscore{}st」 test2', actual
+  end
+
+  def test_inline_pageref
+    actual = compile_inline('test p.@<pageref>{p1}')
+    assert_equal 'test p.\pageref{p1}', actual
   end
 
   def test_inline_ruby_comma


### PR DESCRIPTION
#836 の対応
主にLATEXBuilder向け。

参照用のIDは見出しの{}または//labelで指定する。
（これに伴い、見出しの{}の内容も\labelで書き出すようにしている）

IDの危険文字の判断はしないものとする（エスケープしようにもうまくいかなかったので、ユーザーの責任での対処にしたい）。

HTMLでは利用できないことを警告する。対応しようとすると他ファイルの参照のためにimageなどと同様に一度パースが必要になり、大掛かりになってしまう。