### PR TITLE
catalogでリテラル定義での部名はいじらずにそのままにする

### DIFF
--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -19,13 +19,14 @@ module ReVIEW
         @book = book
         @number = number
         @chapters = chapters
-        @name = name ? File.basename(name, '.re') : nil
+        @name = name
         @path = name
         @content = nil
         if io
           @content = io.read
         elsif @path && File.exist?(@path)
           @content = File.read(@path, mode: 'r:BOM|utf-8')
+          @name = File.basename(@name, '.re')
         end
         @title = name
         @title = nil if file?


### PR DESCRIPTION
#852 
ファイルが見つからないときは「そのまま」の文字列を使って部を構成するというロジックになっているが、先にFile.basenameで代入していたことで「I/O」の「I/」が消えるといった問題が生じていた。
（ほかにも.reという文字列で終わっていたら同様に消えてしまうはず）

ファイルが見つかったときだけbasename代入をするように修正。
