### PR TITLE
tocdepth値をtoclevel - 1にする

### DIFF
--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -312,7 +312,7 @@
 <%= @input_files["PREDEF"] %>
 
 <%- if @config["toc"] -%>
-\setcounter{tocdepth}{<%= @config["toclevel"] %>}
+\setcounter{tocdepth}{<%= @config["toclevel"] - 1 %>}
 \tableofcontents
 <%- end -%>
 


### PR DESCRIPTION
#846 
TeXのtocdepth値はtoclevelよりも-1する必要があった。
