### PR TITLE
表紙と大扉を個別挙動にする

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -128,7 +128,7 @@ secnolevel: 2
 # ePUB3においてはこの設定によらず必ず作成される
 # mytoc: true
 
-# 表紙にするHTMLファイル。ファイル名を指定すると表紙として入る
+# 表紙にするファイル。ファイル名を指定すると表紙として入る (PDFMaker向けにはLaTeXソース断片、EPUBMaker向けにはHTMLファイル)
 # cover: null
 #
 # 表紙に配置し、書籍の影絵にも利用する画像ファイル。省略した場合はnull (画像を使わない)。画像ディレクトリ内に置いてもディレクトリ名は不要(例: cover.jpg)
@@ -140,7 +140,7 @@ secnolevel: 2
 # 自動生成される大扉ページを上書きするファイル。ファイル名を指定すると大扉として入る (PDFMaker向けにはLaTeXソース断片、EPUBMaker向けにはHTMLファイル)
 # titlefile: null
 #
-# 原書大扉ページにするHTMLファイル。ファイル名を指定すると原書大扉として入る (PDFMaker向けにはLaTeXソース断片、EPUBMaker向けにはHTMLファイル)
+# 原書大扉ページにするファイル。ファイル名を指定すると原書大扉として入る (PDFMaker向けにはLaTeXソース断片、EPUBMaker向けにはHTMLファイル)
 # originaltitlefile: null
 #
 # 権利表記ページファイル。ファイル名を指定すると権利表記として入る (PDFMaker向けにはLaTeXソース断片、EPUBMaker向けにはHTMLファイル)

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -344,7 +344,8 @@ module ReVIEW
       @okuduke = make_colophon
       @authors = make_authors
 
-      @custom_titlepage = make_custom_page(@config['cover']) || make_custom_page(@config['coverfile'])
+      @custom_coverpage = make_custom_page(@config['cover']) || make_custom_page(@config['coverfile'])
+      @custom_titlepage = make_custom_page(@config['titlefile'])
       @custom_originaltitlepage = make_custom_page(@config['originaltitlefile'])
       @custom_creditpage = make_custom_page(@config['creditfile'])
 

--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -261,17 +261,21 @@
 
 \reviewmainfont
 
+<%- if @config["cover"] -%>
+<%= @custom_coverpage %>
+<%- elsif @config["coverimage"] -%>
+\begin{titlepage}
+  \begin{center}
+    \includegraphics[<%= @coverimageoption%>]{./<%= @config["imagedir"] %>/<%= @config["coverimage"] %>}
+  \end{center}
+\end{titlepage}
+  \clearpage
+<%- end -%>
 <%- if @config["titlepage"] -%>
 <%-   if @custom_titlepage -%>
 <%= @custom_titlepage %>
 <%-   else -%>
 \begin{titlepage}
-<%-     if @config["coverimage"] -%>
-  \begin{center}
-    \includegraphics[<%= @coverimageoption%>]{./<%= @config["imagedir"] %>/<%= @config["coverimage"] %>}
-  \end{center}
-  \clearpage
-<%-     end -%>
 \thispagestyle{empty}
 \begin{center}%
   \mbox{} \vskip5zw


### PR DESCRIPTION
#848, #839 
PDFMakerのcover, titlepageの挙動をEPUBMakerに合わせます。

互換性が破壊される状況としては、「titlepage: null だけで表紙が入らないことも期待していた」という場合、coverimage: nullもおそらく指定する必要があります。