### PR TITLE
error行の多重表示を防ぐ

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -345,6 +345,7 @@ module ReVIEW
     end
 
     def error(msg)
+      raise ApplicationError, msg if msg =~ /:\d+: error: /
       raise ApplicationError, "#{@location}: error: #{msg}"
     end
 

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -521,6 +521,8 @@ module ReVIEW
         result << @strategy.nofunc_text(words.shift)
       end
       result
+    rescue => err
+      error err.message
     end
     public :text # called from strategy
 

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -521,8 +521,6 @@ module ReVIEW
         result << @strategy.nofunc_text(words.shift)
       end
       result
-    rescue => err
-      error err.message
     end
     public :text # called from strategy
 


### PR DESCRIPTION
#860 の解決

builder.rb#errorが例外チェーンで2回呼び出されることがある模様。locationをすでに付けているようだったら付けないようにする。
