### PR TITLE
images/_review_mathを作成する

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -38,6 +38,7 @@ module ReVIEW
         'catalogfile' => 'catalog.yml',
         'language' => 'ja', # XXX default language should be JA??
         'mathml' => nil, # for HTML
+        'imgmath' => nil, # for HTML
         'htmlext' => 'html',
         'htmlversion' => 5,
         'imagedir' => 'images',

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -83,6 +83,8 @@ module ReVIEW
 
       FileUtils.rm_f("#{bookname}.epub")
       FileUtils.rm_rf(booktmpname) if @params['debug']
+      math_dir = "./#{@params['imagedir']}/_review_math"
+      FileUtils.rm_rf(math_dir) if @params['imgmath'] && Dir.exist?(math_dir)
 
       basetmpdir = build_path
       begin

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -526,7 +526,9 @@ module ReVIEW
         puts %Q(<div class="equation">)
         math_str = "\\begin{equation*}\n" + unescape_html(lines.join("\n")) + "\n\\end{equation*}\n"
         key = Digest::SHA256.hexdigest(math_str)
-        img_path = "./images/_gen_#{key}.png"
+        math_dir = "./#{@book.config['imagedir']}/_review_math"
+        Dir.mkdir(math_dir) unless Dir.exist?(math_dir)
+        img_path = "./#{math_dir}/_gen_#{key}.png"
         make_math_image(math_str, img_path)
         puts %Q(<img src="#{img_path}" />)
         puts '</div>'
@@ -885,7 +887,9 @@ module ReVIEW
       elsif @book.config['imgmath']
         math_str = '$' + str + '$'
         key = Digest::SHA256.hexdigest(str)
-        img_path = "./images/_gen_#{key}.png"
+        math_dir = "./#{@book.config['imagedir']}/_review_math"
+        Dir.mkdir(math_dir) unless Dir.exist?(math_dir)
+        img_path = "./#{math_dir}/_gen_#{key}.png"
         make_math_image(math_str, img_path)
         %Q(<span class="equation"><img src="#{img_path}" /></span>)
       else

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -59,6 +59,8 @@ module ReVIEW
     end
 
     def remove_old_files(path)
+      math_dir = "./#{@config['imagedir']}/_review_math"
+      FileUtils.rm_rf(math_dir) if @config['imgmath'] && Dir.exist?(math_dir)
       FileUtils.rm_rf(path)
     end
 

--- a/test/sample-book/src/Rakefile
+++ b/test/sample-book/src/Rakefile
@@ -69,4 +69,4 @@ file WEBROOT => SRC do
   sh "review-webmaker #{CONFIG_FILE}"
 end
 
-CLEAN.include([BOOK, BOOK_PDF, BOOK_EPUB, BOOK + '-pdf', BOOK + '-epub', WEBROOT])
+CLEAN.include([BOOK, BOOK_PDF, BOOK_EPUB, BOOK + '-pdf', BOOK + '-epub', WEBROOT, 'images/_review_math'])


### PR DESCRIPTION
(ブランチを再作成した)
#856 の解決

`images/_review_math`を作成し、作成した数式画像ファイルはそこに保持するようにする。
epubmaker, webmakerのHTML構築呼び出し前 および Rakefileのcleanルール にてこのフォルダを消すようにした。