### PR TITLE
空見出しやブロック内見出し誤認によるHeadlineIndexの奇妙なエラー挙動の修正

### DIFF
--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -279,7 +279,18 @@ module ReVIEW
         indexs = []
         headlines = []
         inside_column = false
+        inside_block = nil
         src.each do |line|
+          if line =~ %r{\A//[a-z]+}
+            inside_block = true
+            next
+          elsif line =~ %r{\A//\}}
+            inside_block = nil
+            next
+          elsif inside_block
+            next
+          end
+
           m = HEADLINE_PATTERN.match(line)
           next if m.nil? || m[1].size > 10 # Ignore too deep index
           index = m[1].size - 2
@@ -288,8 +299,7 @@ module ReVIEW
           if m[2] == 'column'
             inside_column = true
             next
-          end
-          if m[2] == '/column'
+          elsif m[2] == '/column'
             inside_column = false
             next
           end

--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -281,7 +281,7 @@ module ReVIEW
         inside_column = false
         inside_block = nil
         src.each do |line|
-          if line =~ %r{\A//[a-z]+}
+          if line =~ %r{\A//[a-z]+.*\{\Z}
             inside_block = true
             next
           elsif line =~ %r{\A//\}}
@@ -293,6 +293,7 @@ module ReVIEW
 
           m = HEADLINE_PATTERN.match(line)
           next if m.nil? || m[1].size > 10 # Ignore too deep index
+          next if m[4].strip.empty? # no title
           index = m[1].size - 2
 
           # column

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -286,15 +286,17 @@ module ReVIEW
       index = level - 1
       if tag
         if tag !~ %r{\A/}
+          warn 'headline is empty.' if caption.empty?
           close_current_tagged_section(level)
           open_tagged_section(tag, level, label, caption)
         else
           open_tag = tag[1..-1]
           prev_tag_info = @tagged_section.pop
-          raise CompileError, "#{open_tag} is not opened." unless prev_tag_info.first == open_tag
+          error "#{open_tag} is not opened." if prev_tag_info.nil? || prev_tag_info.first != open_tag
           close_tagged_section(*prev_tag_info)
         end
       else
+        warn 'headline is empty.' if caption.empty?
         @headline_indexs = @headline_indexs[0..index] if @headline_indexs.size > (index + 1)
         @headline_indexs[index] = 0 if @headline_indexs[index].nil?
         @headline_indexs[index] += 1

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1583,6 +1583,17 @@ EOS
     assert_equal '「1.1 part1-1」', hd
   end
 
+  def test_inline_hd_with_block
+    io1 = StringIO.new("= test1\n=={foo} foo\n//emlist{\n======\nbar\n======\n}\n//}\n=={bar} bar")
+    chap1 = Book::Chapter.new(@book, 1, '-', nil, io1)
+    location = Location.new(nil, nil)
+    @builder.bind(@compiler, chap1, location)
+    hd = @builder.inline_hd('foo')
+    assert_equal '「1.1 foo」', hd
+    hd = @builder.inline_hd('bar')
+    assert_equal '「1.2 bar」', hd
+  end
+
   def test_table
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     assert_equal %Q(<div class="table">\n<table>\n<tr><th>aaa</th><th>bbb</th></tr>\n<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>\n</table>\n</div>\n),

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1175,7 +1175,7 @@ inside column
 
 ===[/column_dummy]
 EOS
-    assert_raise(ReVIEW::CompileError) do
+    assert_raise(ReVIEW::ApplicationError) do
       column_helper(review)
     end
   end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -479,7 +479,7 @@ inside column
 
 ===[/column_dummy]
 EOS
-    assert_raise(ReVIEW::CompileError) do
+    assert_raise(ReVIEW::ApplicationError) do
       column_helper(review)
     end
   end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -676,7 +676,7 @@ inside column
 
 ===[/column_dummy]
 EOS
-    assert_raise(ReVIEW::CompileError) do
+    assert_raise(ReVIEW::ApplicationError) do
       column_helper(review)
     end
   end


### PR DESCRIPTION
#121 の修正。

hdタグを使ったときにHeadlineIndexで再パースが行われるが、普通の見出し確認に比べて不十分な実装になっており、特定の状況下において異常なエラーが発生していた。

- 空見出しがあるときにnil.warnが生じていた。空見出しの場合はHeadlineIndexで飛ばすとともに、compiler#compile_headlineでheadline is empty.の警告を出すようにした。
- ブロック内はHeadlineIndexで解析しないようにした。
