### PR TITLE
フェンス記法内で@をエスケープ

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -508,7 +508,7 @@ module ReVIEW
     def replace_fence(str)
       str.gsub(/@<(\w+)>([$|])(.+?)(\2)/) do
         op = $1
-        arg = $3.gsub('@', '!!!atmark!!!').gsub('\\}') { '\\\\}' }.gsub('}') { '\}' }.sub(/(?:\\)+$/) { |m| '\\\\' * m.size }
+        arg = $3.gsub('@', "\x01").gsub('\\}') { '\\\\}' }.gsub('}') { '\}' }.sub(/(?:\\)+$/) { |m| '\\\\' * m.size }
         "@<#{op}>{#{arg}}"
       end
     end
@@ -522,7 +522,7 @@ module ReVIEW
         result << compile_inline(words.shift.gsub(/\\\}/, '}').gsub(/\\\\/, '\\'))
         result << @strategy.nofunc_text(words.shift)
       end
-      result.gsub('!!!atmark!!!', '@')
+      result.gsub("\x01", '@')
     rescue => err
       error err.message
     end

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -508,7 +508,7 @@ module ReVIEW
     def replace_fence(str)
       str.gsub(/@<(\w+)>([$|])(.+?)(\2)/) do
         op = $1
-        arg = $3.gsub('\\}') { '\\\\}' }.gsub('}') { '\}' }.sub(/(?:\\)+$/) { |m| '\\\\' * m.size }
+        arg = $3.gsub('@', '!!!atmark!!!').gsub('\\}') { '\\\\}' }.gsub('}') { '\}' }.sub(/(?:\\)+$/) { |m| '\\\\' * m.size }
         "@<#{op}>{#{arg}}"
       end
     end
@@ -522,7 +522,7 @@ module ReVIEW
         result << compile_inline(words.shift.gsub(/\\\}/, '}').gsub(/\\\\/, '\\'))
         result << @strategy.nofunc_text(words.shift)
       end
-      result
+      result.gsub('!!!atmark!!!', '@')
     rescue => err
       error err.message
     end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1681,4 +1681,9 @@ EOS
     actual = compile_inline('test @<comment>{コメント} test2')
     assert_equal %Q(test <span class="draft-comment">コメント</span> test2), actual
   end
+
+  def test_inline_fence
+    actual = compile_inline('test @<code>|@<code>{$サンプル$}|')
+    assert_equal 'test <code class="inline-code tt">@&lt;code&gt;{$サンプル$}</code>', actual
+  end
 end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -953,6 +953,11 @@ EOS
     assert_equal 'test \\pdfcomment{コメント} test2', actual
   end
 
+  def test_inline_fence
+    actual = compile_inline('test @<code>|@<code>{$サンプル$}|')
+    assert_equal 'test \\texttt{@\\textless{}code\\textgreater{}\\{\\textdollar{}サンプル\\textdollar{}\\}}', actual
+  end
+
   def test_appendix_list
     @chapter.instance_eval do
       def on_appendix?


### PR DESCRIPTION
#876 の対応。

latexを含め各ビルダのエスケーピングにも安全な文字として、`!!!atmark!!!` に一度エスケープしてから戻す。

