### PR TITLE
//includeの破棄、@<include>の修正

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -428,7 +428,7 @@ module ReVIEW
     end
 
     def inline_include(file_name)
-      compile_inline File.read(file_name, mode: 'rt:BOM:utf-8').chomp
+      compile_inline File.read(file_name, mode: 'rt:BOM|utf-8').chomp
     end
 
     def ul_item_begin(lines)

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -428,11 +428,7 @@ module ReVIEW
     end
 
     def inline_include(file_name)
-      compile_inline File.read(file_name)
-    end
-
-    def include(file_name)
-      File.foreach(file_name) { |line| paragraph([line]) }
+      compile_inline File.read(file_name, mode: 'rt:BOM:utf-8').chomp
     end
 
     def ul_item_begin(lines)


### PR DESCRIPTION
#888 の対応。
動的読み込みは何かとトラブルのもとなので本当はどちらも除去したい（preproc推奨）が…

- `//include`は読み込める形式が限定され、ユーザーがいたづらに混乱する可能性が高いので除去。
- `@<include>`の最終末尾改行を削除。
- `@<include>`の読み込みの改行コードをLF揃えにする。

エンコーディングはUTF-8想定として読み込めないときにはただエラーでよいのだろうか。

inline→includeのまちがい