### PR TITLE
chap, chaprefでIDが見つからないときにはundefined methodではなくID不明の旨のエラーを出す

### DIFF
--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -88,9 +88,11 @@ module ReVIEW
 
       def number(id)
         chapter = @index.fetch(id)
-        chapter.format_number
-      rescue # part
-        I18n.t('part', chapter.number)
+        begin
+          chapter.format_number
+        rescue # part
+          I18n.t('part', chapter.number)
+        end
       end
 
       def title(id)


### PR DESCRIPTION
#891の修正。
単純なロジックミスで、`@index.fetch(id)`までrescueで包んでいたのがまずかっただけ。

実行されて失敗したときには上位の例外捕捉でkey not foundと示されるようになる。