### PR TITLE
column の閉じが動作していなかったのを修正

### DIFF
--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -280,6 +280,7 @@ module ReVIEW
         headlines = []
         inside_column = false
         inside_block = nil
+        column_level = -1
         src.each do |line|
           if line =~ %r{\A//[a-z]+.*\{\Z}
             inside_block = true
@@ -293,19 +294,20 @@ module ReVIEW
 
           m = HEADLINE_PATTERN.match(line)
           next if m.nil? || m[1].size > 10 # Ignore too deep index
-          next if m[4].strip.empty? # no title
           index = m[1].size - 2
 
           # column
           if m[2] == 'column'
             inside_column = true
+            column_level = index
             next
           elsif m[2] == '/column'
             inside_column = false
             next
           end
-          inside_column = false if indexs.blank? || index <= indexs[-1]
+          inside_column = false if indexs.blank? || index <= column_level
           next if inside_column
+          next if m[4].strip.empty? # no title
 
           next unless index >= 0
           if indexs.size > (index + 1)

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -177,4 +177,35 @@ class IndexTest < Test::Unit::TestCase
     index = Book::HeadlineIndex.parse(src, chap)
     assert_equal '1.1.1', index.number('sec1-1')
   end
+
+  def test_headeline_index9
+    src = <<-EOB
+= chap1
+== sec1
+=== sec1-1
+===[column] column1
+===[/column]
+==== sec1-1-1
+=== sec1-2
+    EOB
+    book = Book::Base.load
+    chap = Book::Chapter.new(book, 1, '-', nil)
+    index = Book::HeadlineIndex.parse(src, chap)
+    assert_equal [1, 1, 1], index['sec1-1-1'].number
+  end
+
+  def test_headeline_index10
+    src = <<-EOB
+= chap1
+== sec1
+=== sec1-1
+====[column] column1
+==== sec1-1-1
+=== sec1-2
+    EOB
+    book = Book::Base.load
+    chap = Book::Chapter.new(book, 1, '-', nil)
+    index = Book::HeadlineIndex.parse(src, chap)
+    assert_equal [1, 1, 1], index['sec1-1-1'].number
+  end
 end


### PR DESCRIPTION
ドキュメントには `column` と同レベル以上の見出しか `[/column]` が来たら終了するとありますが、
動作していないようなので修正しました。

特に `[/column]` は 2.4.0 から動作しなくなったように思います。