### PR TITLE
HeaderIndexで@loggerの定義漏れ

### DIFF
--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -326,6 +326,7 @@ module ReVIEW
         @items = items
         @chap = chap
         @index = {}
+        @logger = ReVIEW.logger
         items.each do |i|
           @logger.warn "warning: duplicate ID: #{i.id}" if @index[i.id]
           @index[i.id] = i


### PR DESCRIPTION
#896の修正

`@logger`を定義し忘れていたので、警告を出そうとしたときにnil.warnになってしまう。
