### PR TITLE
define rubocop version to avoid version-sensitive errors

### DIFF
--- a/review.gemspec
+++ b/review.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency('rubyzip')
   gem.add_development_dependency('pygments.rb')
   gem.add_development_dependency('rake')
-  gem.add_development_dependency('rubocop')
+  gem.add_development_dependency('rubocop', '~> 0.52.0')
   gem.add_development_dependency('test-unit')
 end


### PR DESCRIPTION
rubocopの `Lint/RescueWithoutErrorClass` -> `Style/RescueStandardError` への対応です