### PR TITLE
allow `do..end`, `if ...end`, or `unless...end` for single-line blocks

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -12,6 +12,7 @@ require 'review/compiler'
 require 'review/sec_counter'
 require 'stringio'
 require 'cgi'
+require 'fileutils'
 
 module ReVIEW
   class Builder
@@ -148,8 +149,12 @@ module ReVIEW
       return if rows.empty?
       table_begin rows.first.size
       if sepidx
-        sepidx.times { tr(rows.shift.map { |s| th(s) }) }
-        rows.each { |cols| tr(cols.map { |s| td(s) }) }
+        sepidx.times do
+          tr(rows.shift.map { |s| th(s) })
+        end
+        rows.each do |cols|
+          tr(cols.map { |s| td(s) })
+        end
       else
         rows.each do |cols|
           h, *cs = *cols
@@ -160,9 +165,15 @@ module ReVIEW
     end
 
     def adjust_n_cols(rows)
-      rows.each { |cols| cols.pop while cols.last and cols.last.strip.empty? }
+      rows.each do |cols|
+        while cols.last and cols.last.strip.empty?
+          cols.pop
+        end
+      end
       n_maxcols = rows.map(&:size).max
-      rows.each { |cols| cols.concat [''] * (n_maxcols - cols.size) }
+      rows.each do |cols|
+        cols.concat [''] * (n_maxcols - cols.size)
+      end
       rows
     end
     private :adjust_n_cols
@@ -252,8 +263,12 @@ module ReVIEW
 
     def inline_ruby(arg)
       base, *ruby = *arg.scan(/(?:(?:(?:\\\\)*\\,)|[^,\\]+)+/)
-      base = base.gsub(/\\,/, ',') if base
-      ruby = ruby.join(',').gsub(/\\,/, ',') if ruby
+      if base
+        base = base.gsub(/\\,/, ',')
+      end
+      if ruby
+        ruby = ruby.join(',').gsub(/\\,/, ',')
+      end
       compile_ruby(base, ruby)
     end
 
@@ -265,7 +280,9 @@ module ReVIEW
     def inline_href(arg)
       url, label = *arg.scan(/(?:(?:(?:\\\\)*\\,)|[^,\\]+)+/).map(&:lstrip)
       url = url.gsub(/\\,/, ',').strip
-      label = label.gsub(/\\,/, ',').strip if label
+      if label
+        label = label.gsub(/\\,/, ',').strip
+      end
       compile_href(url, label)
     end
 
@@ -284,7 +301,9 @@ module ReVIEW
 
     def inline_hd(id)
       m = /\A([^|]+)\|(.+)/.match(id)
-      chapter = @book.contents.detect { |chap| chap.id == m[1] } if m && m[1]
+      if m && m[1]
+        chapter = @book.contents.detect { |chap| chap.id == m[1] }
+      end
       if chapter
         inline_hd_chap(chapter, m[2])
       else
@@ -297,7 +316,9 @@ module ReVIEW
 
     def inline_column(id)
       m = /\A([^|]+)\|(.+)/.match(id)
-      chapter = @book.chapters.detect { |chap| chap.id == m[1] } if m && m[1]
+      if m && m[1]
+        chapter = @book.chapters.detect { |chap| chap.id == m[1] }
+      end
       if chapter
         inline_column_chap(chapter, m[2])
       else
@@ -324,7 +345,9 @@ module ReVIEW
       if matched = str.match(/\|(.*?)\|(.*)/)
         builders = matched[1].split(',').map { |i| i.gsub(/\s/, '') }
         c = target_name
-        print matched[2].gsub('\\n', "\n") if builders.include?(c)
+        if builders.include?(c)
+          print matched[2].gsub('\\n', "\n")
+        end
       else
         print str.gsub('\\n', "\n")
       end
@@ -345,8 +368,11 @@ module ReVIEW
     end
 
     def error(msg)
-      raise ApplicationError, msg if msg =~ /:\d+: error: /
-      raise ApplicationError, "#{@location}: error: #{msg}"
+      if msg =~ /:\d+: error: /
+        raise ApplicationError, msg
+      else
+        raise ApplicationError, "#{@location}: error: #{msg}"
+      end
     end
 
     def handle_metric(str)
@@ -374,15 +400,20 @@ module ReVIEW
 
     def get_chap(chapter = @chapter)
       if @book.config['secnolevel'] > 0 && !chapter.number.nil? && !chapter.number.to_s.empty?
-        return I18n.t('part_short', chapter.number) if chapter.is_a?(ReVIEW::Book::Part)
-        return chapter.format_number(nil)
+        if chapter.is_a?(ReVIEW::Book::Part)
+          return I18n.t('part_short', chapter.number)
+        else
+          return chapter.format_number(nil)
+        end
       end
       nil
     end
 
     def extract_chapter_id(chap_ref)
       m = /\A([\w+-]+)\|(.+)/.match(chap_ref)
-      return [@book.contents.detect { |chap| chap.id == m[1] }, m[2]] if m
+      if m
+        return [@book.contents.detect { |chap| chap.id == m[1] }, m[2]]
+      end
       [@chapter, chap_ref]
     end
 
@@ -401,7 +432,7 @@ module ReVIEW
     def graph(lines, id, command, caption = nil)
       c = target_name
       dir = File.join(@book.basedir, @book.image_dir, c)
-      Dir.mkdir(dir) unless File.exist?(dir)
+      FileUtils.mkdir_p(dir)
       file = "#{id}.#{image_ext}"
       file_path = File.join(dir, file)
 
@@ -432,7 +463,9 @@ module ReVIEW
     end
 
     def include(file_name)
-      File.foreach(file_name) { |line| paragraph([line]) }
+      File.foreach(file_name) do |line|
+        paragraph([line])
+      end
     end
 
     def ul_item_begin(lines)

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -20,7 +20,9 @@ module ReVIEW
     include TextUtils
     include HTMLUtils
 
-    [:ref].each { |e| Compiler.definline(e) }
+    [:ref].each do |e|
+      Compiler.definline(e)
+    end
     Compiler.defblock(:planning, 0..1)
     Compiler.defblock(:best, 0..1)
     Compiler.defblock(:security, 0..1)
@@ -101,7 +103,9 @@ module ReVIEW
       @next_title = @next ? compile_inline(@next.title) : ''
       @prev_title = @prev ? compile_inline(@prev.title) : ''
 
-      @toc = ReVIEW::WEBTOCPrinter.book_to_string(@book) if @book.config.maker == 'webmaker'
+      if @book.config.maker == 'webmaker'
+        @toc = ReVIEW::WEBTOCPrinter.book_to_string(@book)
+      end
 
       ReVIEW::Template.load(layoutfile).result(binding)
     end
@@ -116,10 +120,14 @@ module ReVIEW
 
     def headline(level, label, caption)
       prefix, anchor = headline_prefix(level)
-      prefix = %Q(<span class="secno">#{prefix}</span>) if prefix
+      if prefix
+        prefix = %Q(<span class="secno">#{prefix}</span>)
+      end
       puts '' if level > 1
       a_id = ''
-      a_id = %Q(<a id="h#{anchor}"></a>) if anchor
+      if anchor
+        a_id = %Q(<a id="h#{anchor}"></a>)
+      end
 
       if caption.empty?
         puts a_id if label
@@ -282,7 +290,9 @@ module ReVIEW
       puts %Q(<div class="syntax">)
       puts %Q(<p class="caption">#{compile_inline(caption)}</p>) if caption.present?
       print %Q(<pre class="syntax">)
-      lines.each { |line| puts detab(line) }
+      lines.each do |line|
+        puts detab(line)
+      end
       puts '</pre>'
       puts '</div>'
     end
@@ -435,7 +445,9 @@ module ReVIEW
         class_names.push('highlight') if highlight?
         print %Q(<pre class="#{class_names.join(' ')}">)
         first_line_num = line_num
-        lines.each_with_index { |line, i| puts detab((i + first_line_num).to_s.rjust(2) + ': ' + line) }
+        lines.each_with_index do |line, i|
+          puts detab((i + first_line_num).to_s.rjust(2) + ': ' + line)
+        end
         puts '</pre>'
       end
     end
@@ -470,7 +482,9 @@ module ReVIEW
         class_names.push('highlight') if highlight?
         print %Q(<pre class="#{class_names.join(' ')}">)
         first_line_num = line_num
-        lines.each_with_index { |line, i| puts detab((i + first_line_num).to_s.rjust(2) + ': ' + line) }
+        lines.each_with_index do |line, i|
+          puts detab((i + first_line_num).to_s.rjust(2) + ': ' + line)
+        end
         puts '</pre>'
       end
 
@@ -490,7 +504,9 @@ module ReVIEW
 
     def quotedlist(lines, css_class)
       print %Q(<blockquote><pre class="#{css_class}">)
-      lines.each { |line| puts detab(line) }
+      lines.each do |line|
+        puts detab(line)
+      end
       puts '</pre></blockquote>'
     end
     private :quotedlist
@@ -541,7 +557,9 @@ module ReVIEW
     end
 
     def handle_metric(str)
-      return { 'class' => sprintf('width-%03dper', ($1.to_f * 100).round) } if str =~ /\Ascale=([\d.]+)\Z/
+      if str =~ /\Ascale=([\d.]+)\Z/
+        return { 'class' => sprintf('width-%03dper', ($1.to_f * 100).round) }
+      end
 
       k, v = str.split('=', 2)
       { k => v.sub(/\A["']/, '').sub(/["']\Z/, '') }
@@ -572,7 +590,9 @@ module ReVIEW
       warn "image not bound: #{id}"
       puts %Q(<div id="#{normalize_id(id)}" class="image">)
       puts %Q(<pre class="dummyimage">)
-      lines.each { |line| puts detab(line) }
+      lines.each do |line|
+        puts detab(line)
+      end
       puts '</pre>'
       image_header id, caption
       puts '</div>'
@@ -615,8 +635,12 @@ module ReVIEW
       table_begin rows.first.size
       return if rows.empty?
       if sepidx
-        sepidx.times { tr(rows.shift.map { |s| th(s) }) }
-        rows.each { |cols| tr(cols.map { |s| td(s) }) }
+        sepidx.times do
+          tr(rows.shift.map { |s| th(s) })
+        end
+        rows.each do |cols|
+          tr(cols.map { |s| td(s) })
+        end
       else
         rows.each do |cols|
           h, *cs = *cols
@@ -711,7 +735,9 @@ module ReVIEW
         warn "image not bound: #{id}"
         if lines
           puts %Q(<pre class="dummyimage">)
-          lines.each { |line| puts detab(line) }
+          lines.each do |line|
+            puts detab(line)
+          end
           puts '</pre>'
         end
       end
@@ -744,7 +770,9 @@ module ReVIEW
 
     def bpo(lines)
       puts '<bpo>'
-      lines.each { |line| puts detab(line) }
+      lines.each do |line|
+        puts detab(line)
+      end
       puts '</bpo>'
     end
 
@@ -1110,7 +1138,9 @@ module ReVIEW
     def inline_tcy(str)
       # 縦中横用のtcy、uprightのCSSスタイルについては電書協ガイドラインを参照
       style = 'tcy'
-      style = 'upright' if str.size == 1 && str.match(/[[:ascii:]]/)
+      if str.size == 1 && str.match(/[[:ascii:]]/)
+        style = 'upright'
+      end
       %Q(<span class="#{style}">#{escape_html(str)}</span>)
     end
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -17,7 +17,9 @@ module ReVIEW
     include LaTeXUtils
     include TextUtils
 
-    %i[dtp hd_chap].each { |e| Compiler.definline(e) }
+    %i[dtp hd_chap].each do |e|
+      Compiler.definline(e)
+    end
 
     Compiler.defsingle(:latextsize, 1)
 
@@ -44,7 +46,9 @@ module ReVIEW
       @index_mecab = nil
       return true unless @book.config['pdfmaker']['makeindex']
 
-      @index_db = load_idxdb(@book.config['pdfmaker']['makeindex_dic']) if @book.config['pdfmaker']['makeindex_dic']
+      if @book.config['pdfmaker']['makeindex_dic']
+        @index_db = load_idxdb(@book.config['pdfmaker']['makeindex_dic'])
+      end
       return true unless @book.config['pdfmaker']['makeindex_mecab']
       begin
         require 'MeCab'
@@ -99,15 +103,18 @@ module ReVIEW
     def headline(level, label, caption)
       _, anchor = headline_prefix(level)
       headline_name = HEADLINE[level]
-      headline_name = 'part' if @chapter.is_a? ReVIEW::Book::Part
-      prefix = if level > @book.config['secnolevel'] || (@chapter.number.to_s.empty? && level > 1)
-                 '*'
-               else
-                 ''
-               end
+      if @chapter.is_a? ReVIEW::Book::Part
+        headline_name = 'part'
+      end
+      prefix = ''
+      if level > @book.config['secnolevel'] || (@chapter.number.to_s.empty? && level > 1)
+        prefix = '*'
+      end
       blank unless @output.pos == 0
       puts macro(headline_name + prefix, compile_inline(caption))
-      puts "\\addcontentsline{toc}{#{headline_name}}{#{compile_inline(caption)}}" if prefix == '*' && level <= @book.config['toclevel'].to_i
+      if prefix == '*' && level <= @book.config['toclevel'].to_i
+        puts "\\addcontentsline{toc}{#{headline_name}}{#{compile_inline(caption)}}"
+      end
       if level == 1
         puts macro('label', chapter_label)
       else
@@ -154,7 +161,9 @@ module ReVIEW
         puts "\\hypertarget{#{column_label(caption)}}{}"
       end
       puts macro('reviewcolumnhead', nil, compile_inline(caption))
-      puts "\\addcontentsline{toc}{#{HEADLINE[level]}}{#{compile_inline(caption)}}" if level <= @book.config['toclevel'].to_i
+      if level <= @book.config['toclevel'].to_i
+        puts "\\addcontentsline{toc}{#{HEADLINE[level]}}{#{compile_inline(caption)}}"
+      end
     end
 
     def column_end(_level)
@@ -176,7 +185,9 @@ module ReVIEW
       blank
       puts macro('reviewboxcaption', compile_inline(caption)) if caption
       puts '\begin{reviewbox}'
-      lines.each { |line| puts detab(line) }
+      lines.each do |line|
+        puts detab(line)
+      end
       puts '\end{reviewbox}'
       blank
     end
@@ -238,7 +249,9 @@ module ReVIEW
 
     def paragraph(lines)
       blank
-      lines.each { |line| puts line }
+      lines.each do |line|
+        puts line
+      end
       blank
     end
 
@@ -321,7 +334,9 @@ module ReVIEW
         end
       end
       body = ''
-      lines.each_with_index { |line, idx| body.concat(yield(line, idx)) }
+      lines.each_with_index do |line, idx|
+        body.concat(yield(line, idx))
+      end
       puts macro('begin', command)
       print body
       puts macro('end', command)
@@ -329,7 +344,9 @@ module ReVIEW
     end
 
     def common_code_block_lst(_id, lines, command, title, caption, lang, first_line_num: 1)
-      print '\vspace{-1.5em}' if title == 'title' && caption.blank?
+      if title == 'title' && caption.blank?
+        print '\vspace{-1.5em}'
+      end
       body = lines.inject('') { |i, j| i + detab(unescape_latex(j)) + "\n" }
       args = make_code_block_args(title, caption, lang, first_line_num: first_line_num)
       puts %Q(\\begin{#{command}}[#{args}])
@@ -350,7 +367,9 @@ module ReVIEW
               end
       lexer = lang if lang.present?
       args = %Q(#{title}={#{caption_str}},language={#{lexer}})
-      args += ",firstnumber=#{first_line_num}" if first_line_num != 1
+      if first_line_num != 1
+        args += ",firstnumber=#{first_line_num}"
+      end
       args
     end
 
@@ -395,7 +414,9 @@ module ReVIEW
       puts '\begin{reviewdummyimage}'
       # path = @chapter.image(id).path
       puts "--[[path = #{id} (#{existence(id)})]]--"
-      lines.each { |line| puts detab(line.rstrip) }
+      lines.each do |line|
+        puts detab(line.rstrip)
+      end
       puts macro('label', image_label(id))
       puts compile_inline(caption)
       puts '\end{reviewdummyimage}'
@@ -454,7 +475,9 @@ module ReVIEW
         warn "image not bound: #{id}"
         puts '\begin{reviewdummyimage}'
         puts "--[[path = #{id} (#{existence(id)})]]--"
-        lines.each { |line| puts detab(line.rstrip) }
+        lines.each do |line|
+          puts detab(line.rstrip)
+        end
       end
 
       puts macro('reviewindepimagecaption', %Q(#{I18n.t('numberless_image')}#{I18n.t('caption_prefix')}#{compile_inline(caption)})) if caption.present?
@@ -490,8 +513,12 @@ module ReVIEW
       return if rows.empty?
       table_begin rows.first.size
       if sepidx
-        sepidx.times { tr(rows.shift.map { |s| th(s) }) }
-        rows.each { |cols| tr(cols.map { |s| td(s) }) }
+        sepidx.times do
+          tr(rows.shift.map { |s| th(s) })
+        end
+        rows.each do |cols|
+          tr(cols.map { |s| td(s) })
+        end
       else
         rows.each do |cols|
           h, *cs = *cols
@@ -627,7 +654,9 @@ module ReVIEW
     def texequation(lines)
       blank
       puts macro('begin', 'equation*')
-      lines.each { |line| puts unescape_latex(line) }
+      lines.each do |line|
+        puts unescape_latex(line)
+      end
       puts macro('end', 'equation*')
       blank
     end
@@ -644,12 +673,16 @@ module ReVIEW
 
     def direct(lines, fmt)
       return unless fmt == 'latex'
-      lines.each { |line| puts line }
+      lines.each do |line|
+        puts line
+      end
     end
 
     def comment(lines, comment = nil)
       lines ||= []
-      lines.unshift comment unless comment.blank?
+      unless comment.blank?
+        lines.unshift comment
+      end
       return true unless @book.config['draft']
       str = lines.join('\par ')
       puts macro('pdfcomment', escape(str))
@@ -743,7 +776,9 @@ module ReVIEW
     end
 
     def footnote(id, content)
-      puts macro("footnotetext[#{@chapter.footnote(id).number}]", compile_inline(content.strip)) if @book.config['footnotetext']
+      if @book.config['footnotetext']
+        puts macro("footnotetext[#{@chapter.footnote(id).number}]", compile_inline(content.strip))
+      end
     end
 
     def inline_fn(id)

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -28,7 +28,9 @@ module ReVIEW
     end
 
     def blank
-      @output.puts unless @blank_seen
+      unless @blank_seen
+        @output.puts
+      end
       @blank_seen = true
     end
 
@@ -132,7 +134,9 @@ module ReVIEW
     end
 
     def compile_href(url, label)
-      label = url if label.blank?
+      if label.blank?
+        label = url
+      end
       "[#{label}](#{url})"
     end
 
@@ -193,7 +197,9 @@ module ReVIEW
 
     def cmd(lines)
       puts '```shell-session'
-      lines.each { |line| puts detab(line) }
+      lines.each do |line|
+        puts detab(line)
+      end
       puts '```'
     end
 
@@ -297,7 +303,9 @@ module ReVIEW
     def comment(lines, comment = nil)
       return unless @book.config['draft']
       lines ||= []
-      lines.unshift comment unless comment.blank?
+      unless comment.blank?
+        lines.unshift comment
+      end
       str = lines.join('<br />')
       puts %Q(<div class="red">#{escape_html(str)}</div>)
     end

--- a/lib/review/md2inaobuilder.rb
+++ b/lib/review/md2inaobuilder.rb
@@ -20,7 +20,9 @@ module ReVIEW
     def cmd(lines)
       # WEB+DB では使っていないらしいけど
       puts '!!! cmd'
-      lines.each { |line| puts detab(line) }
+      lines.each do |line|
+        puts detab(line)
+      end
       puts ''
     end
 

--- a/lib/review/rstbuilder.rb
+++ b/lib/review/rstbuilder.rb
@@ -20,7 +20,9 @@ module ReVIEW
   class RSTBuilder < Builder
     include TextUtils
 
-    %i[ttbold hint maru keytop labelref ref balloon strong].each { |e| Compiler.definline(e) }
+    %i[ttbold hint maru keytop labelref ref balloon strong].each do |e|
+      Compiler.definline(e)
+    end
     Compiler.defsingle(:dtp, 1)
 
     Compiler.defblock(:insn, 1)
@@ -152,7 +154,9 @@ module ReVIEW
     end
 
     def dd(lines)
-      split_paragraph(lines).each { |paragraph| puts "  #{paragraph.gsub(/\n/, '')}" }
+      split_paragraph(lines).each do |paragraph|
+        puts "  #{paragraph.gsub(/\n/, '')}"
+      end
     end
 
     def dl_end
@@ -160,7 +164,9 @@ module ReVIEW
 
     def paragraph(lines)
       pre = ''
-      pre = '   ' if @in_role == true
+      if @in_role
+        pre = '   '
+      end
       puts pre + lines.join
       puts "\n"
     end
@@ -186,7 +192,9 @@ module ReVIEW
     end
 
     def list_body(_id, lines, _lang)
-      lines.each { |line| puts '-' + detab(line) }
+      lines.each do |line|
+        puts '-' + detab(line)
+      end
     end
 
     def base_block(_type, lines, caption = nil)
@@ -213,7 +221,9 @@ module ReVIEW
       lang ||= 'none'
       puts ".. code-block:: #{lang}"
       blank
-      lines.each { |line| puts '   ' + detab(line) }
+      lines.each do |line|
+        puts '   ' + detab(line)
+      end
       blank
     end
 
@@ -227,18 +237,24 @@ module ReVIEW
       puts ".. code-block:: #{lang}"
       puts '   :linenos:'
       blank
-      lines.each { |line| puts '   ' + detab(line) }
+      lines.each do |line|
+        puts '   ' + detab(line)
+      end
       blank
     end
 
     def listnum_body(lines, _lang)
-      lines.each_with_index { |line, i| puts(i + 1).to_s.rjust(2) + ": #{line}" }
+      lines.each_with_index do |line, i|
+        puts(i + 1).to_s.rjust(2) + ": #{line}"
+      end
       blank
     end
 
     def cmd(lines, _caption = nil)
       puts '.. code-block:: bash'
-      lines.each { |line| puts '   ' + detab(line) }
+      lines.each do |line|
+        puts '   ' + detab(line)
+      end
     end
 
     def quote(lines)
@@ -257,7 +273,9 @@ module ReVIEW
 
     def image_image(id, caption, metric)
       chapter, id = extract_chapter_id(id)
-      scale = metric.split('=')[1].to_f * 100 if metric
+      if metric
+        scale = metric.split('=')[1].to_f * 100
+      end
 
       puts ".. _#{id}:"
       blank
@@ -353,7 +371,9 @@ module ReVIEW
     end
 
     def compile_href(url, label)
-      label = url if label.blank?
+      if label.blank?
+        label = url
+      end
       " `#{label} <#{url}>`_ "
     end
 

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -13,7 +13,9 @@ module ReVIEW
   class TOPBuilder < Builder
     include TextUtils
 
-    %i[ttbold hint maru keytop labelref ref balloon strong].each { |e| Compiler.definline(e) }
+    %i[ttbold hint maru keytop labelref ref balloon strong].each do |e|
+      Compiler.definline(e)
+    end
     Compiler.defsingle(:dtp, 1)
 
     Compiler.defblock(:insn, 1)
@@ -156,7 +158,9 @@ module ReVIEW
     end
 
     def dd(lines)
-      split_paragraph(lines).each { |paragraph| puts "\t#{paragraph.gsub(/\n/, '')}" }
+      split_paragraph(lines).each do |paragraph|
+        puts "\t#{paragraph.gsub(/\n/, '')}"
+      end
     end
 
     def dl_end
@@ -197,7 +201,9 @@ module ReVIEW
     end
 
     def list_body(_id, lines, _lang)
-      lines.each { |line| puts detab(line) }
+      lines.each do |line|
+        puts detab(line)
+      end
       puts "◆→終了:#{@titles['list']}←◆"
       blank
     end
@@ -228,13 +234,17 @@ module ReVIEW
       blank
       puts "◆→開始:#{@titles['emlist']}←◆"
       puts "■#{compile_inline(caption)}" if caption.present?
-      lines.each_with_index { |line, i| puts((i + 1).to_s.rjust(2) + ": #{line}") }
+      lines.each_with_index do |line, i|
+        puts((i + 1).to_s.rjust(2) + ": #{line}")
+      end
       puts "◆→終了:#{@titles['emlist']}←◆"
       blank
     end
 
     def listnum_body(lines, _lang)
-      lines.each_with_index { |line, i| puts((i + 1).to_s.rjust(2) + ": #{line}") }
+      lines.each_with_index do |line, i|
+        puts((i + 1).to_s.rjust(2) + ": #{line}")
+      end
       puts "◆→終了:#{@titles['list']}←◆"
       blank
     end
@@ -288,7 +298,9 @@ module ReVIEW
         puts "◆→#{@chapter.image(id).path}#{metrics}←◆"
       else
         warn "image not bound: #{id}"
-        lines.each { |line| puts line }
+        lines.each do |line|
+          puts line
+        end
       end
       puts "◆→終了:#{@titles['image']}←◆"
       blank
@@ -326,8 +338,12 @@ module ReVIEW
       return if rows.empty?
       table_begin rows.first.size
       if sepidx
-        sepidx.times { tr(rows.shift.map { |s| th(s) }) }
-        rows.each { |cols| tr(cols.map { |s| td(s) }) }
+        sepidx.times do
+          tr(rows.shift.map { |s| th(s) })
+        end
+        rows.each do |cols|
+          tr(cols.map { |s| td(s) })
+        end
       else
         rows.each do |cols|
           h, *cs = *cols
@@ -371,7 +387,9 @@ module ReVIEW
     def comment(lines, comment = nil)
       return unless @book.config['draft']
       lines ||= []
-      lines.unshift comment unless comment.blank?
+      unless comment.blank?
+        lines.unshift comment
+      end
       str = lines.join
       puts "◆→#{str}←◆"
     end


### PR DESCRIPTION
revert some changes of b2f2aa5a in `lib/review/*builder.rb`

rubocop対応用に突っ込んだ（そして結局不要になった）修正が`*builder.rb`に衝突しまくって辛いので、一部元の形に戻してみます。`do...end`を`{...}`に変更したり、ifやunlessを後置の修飾子にしたりしてるやつです。

ちなみにbuilder.rbの`Dir.mkdir(dir) unless File.exist?(dir)`は単にunless修飾子をやめるだけではなく、`FileUtils.mkdir_p(dir) `にしてunlessを不要にしています。
