### PR TITLE
奥付での

### DIFF
--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -360,7 +360,7 @@
 <%- if @config["subtitle"] -%>
 {\noindent\reviewtitlefont\large <%= escape_latex(@config.name_of("subtitle")) %>} \\
 <%- end -%>
-\rule[8pt]{14cm}{1pt} \\
+\rule[8pt]{\textwidth}{1pt} \\
 {\noindent
 <%= @config["pubhistory"].to_s.gsub(/\n/){"\n\n\\noindent\n"} %>
 }
@@ -369,7 +369,7 @@
 <%= @okuduke %>
 \end{tabular}
 　\\
-\rule[0pt]{14cm}{1pt} \\
+\rule[0pt]{\textwidth}{1pt} \\
 <%-     if @config["rights"] -%>
 <%= @config.names_of("rights").map{|s| escape_latex(s)}.join('\\' + '\\') %> \\
 <%-     end -%>


### PR DESCRIPTION
LaTeXにおいて、奥付の横線が14cm固定なので、たとえば用紙サイズがA5だと長すぎる。

修正前スクリーンショット
https://imgur.com/aJusqfh

長さを`\textwidth`にすると、ちょうどよい長さになる。

修正後スクリーンショット
https://imgur.com/mNEs2Cf