### PR TITLE
複数のTeXスタイルファイルをサポート

### DIFF
--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -249,8 +249,10 @@
 }
 \makeatother
 
-<%- if @config["usepackage"] -%>
-<%= @config["usepackage"] %>
+<%- if @config["texstyle"] -%>
+<%-   [@config["texstyle"]].flatten.each do |x| -%>
+\usepackage{<%= x %>}
+<%-   end -%>
 <%- end -%>
 <%- if @config["makeindex"] -%>
 \usepackage{makeidx}


### PR DESCRIPTION
config.ymlにおいて、texstyleオプションはスタイルファイル名を1つしか指定できない。

```
texstyle: reviewmacro
```

これを、複数のスタイルファイルをサポートするように変更する。

```
texstyle: [reviewmacro, mystyle]
```

こうすることで、sty/reviewmacro.styを変更するかわりに、新しいスタイルファイルsty/mystyle.styを追加してそこにカスタムのマクロを定義できるようになる。

これにより、sty/reviewmacro.styに変更を加えなくて済むので、Re:VIEWのバージョンアップがとてもしやすくなる。