### PR TITLE
use here document for readability

### DIFF
--- a/test/test_compiler.rb
+++ b/test/test_compiler.rb
@@ -42,7 +42,13 @@ class CompilerTest < Test::Unit::TestCase
   end
 
   def test_replace_fence
-    actual = @c.__send__(:replace_fence, '@<m>${}\\}|$, @<m>|{}\\}\\$|, @<m>|\\{\\a\\}|, @<tt>|}|, @<tt>|\\|, @<tt>|\\\\|, @<tt>|\\\\\\|')
-    assert_equal '@<m>{{\\}\\\\\\}|}, @<m>{{\\}\\\\\\}\\$}, @<m>{\\{\\a\\\\\\}}, @<tt>{\\}}, @<tt>{\\\\}, @<tt>{\\\\\\\\}, @<tt>{\\\\\\\\\\\\}', actual
+    source_str = <<-'EOB'
+@<m>${}\}|$, @<m>|{}\}\$|, @<m>|\{\a\}|, @<tt>|}|, @<tt>|\|, @<tt>|\\|, @<tt>|\\\|
+    EOB
+    expected = <<-'EOB'
+@<m>{{\}\\\}|}, @<m>{{\}\\\}\$}, @<m>{\{\a\\\}}, @<tt>{\}}, @<tt>{\\}, @<tt>{\\\\}, @<tt>{\\\\\\}
+    EOB
+    actual = @c.__send__(:replace_fence, source_str)
+    assert_equal expected, actual
   end
 end


### PR DESCRIPTION
エスケープ(`\`)の可読性が私の限界を超えていたので、ヒアドキュメントを使うようにしてみました。

今日のRuby豆知識: `'...'`つきのヒアドキュメントを使うと完全に書いたままの文字列を表現できて便利です。 https://docs.ruby-lang.org/ja/latest/doc/spec=2fliteral.html#here