### PR TITLE
「//emlist」でキャプションがない場合のスペースを狭くする

### DIFF
--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -150,8 +150,15 @@
 \newcommand{\reviewlistcaption}[1]{%
   \medskip{\small\noindent #1}\vspace*{-1.3zw}}
 
+\def \ifempty#1{\def\temp{#1} \ifx\temp\empty }
+
 \newcommand{\reviewemlistcaption}[1]{%
-  \medskip{\small\noindent #1}\vspace*{-1.3zw}}
+  \ifempty{#1}
+    \vspace*{-1.0zw}
+  \else
+    \medskip{\small\noindent #1}\vspace*{-1.3zw}
+  \fi
+}
 
 \newcommand{\reviewsourcecaption}[1]{%
   \medskip{\small\noindent #1}\vspace*{-1.3zw}}


### PR DESCRIPTION
連番なしのリスト `//emlist[]{ ... //}` を使ったときに、キャプションがある場合は本文との間のスペースが適切だが、キャプションがないとスペースが空きすぎる。

スクリーンショット： https://imgur.com/4rttY8q

なので、キャプションがある場合とない場合とでスペースを変えるよう変更する。

修正後スクリーンショット： https://imgur.com/3osgEKf

（なお空文字列かどうかの判定には以下のサイトを参考にした。
https://tex.stackexchange.com/questions/179964/how-to-test-if-a-string-is-empty ）