### PR TITLE
dvipdfmxのzlib-levelを3に変更

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -69,7 +69,7 @@ module ReVIEW
         'texcommand' => 'uplatex',
         'texdocumentclass' => ['jsbook', 'uplatex,oneside'],
         'dvicommand' => 'dvipdfmx',
-        'dvioptions' => '-d 5',
+        'dvioptions' => '-d 5 -z 3',
         # for PDFMaker
         'pdfmaker' => {
           'makeindex' => nil, # Make index page


### PR DESCRIPTION
とあるRe:VIEWによる書籍プロジェクトでは、非スカラー画像形式 JPEG 形式で大量に図版が作成されていました。これを製作途中段階で pdfmaker にそのままかけると、dvipdfmxコマンドで該当図版を埋め込む処理の際に zlib-level が9（最大圧縮）のため大幅に時間がかかり、全体としてPDF生成時間がかかってしまいます。一方、zlib-levelを0（無圧縮）にすると、PDFファイルが大幅に増えてしまいます。

案外、商業印刷以外のRe:VIEWによる書籍製作では、PNGやJPEGをそのまま pdfmaker にかけていたりしないでしょうか？

そこで、書籍製作段階の生成効率を上げるべく、「PDF生成時間を大幅に短縮しつつ、PDFファイルサイズを増やしすぎない」ほどよさが必要だと思いまして、 zlib-levelを3ぐらいにしておくのでどうでしょうか？

以下に、とある書籍プロジェクトでbook.pdfを生成したときの例を上げます。

`dvipdfmx` デフォルト（`-z 9`最大圧縮）
----------

1分ぐらいで39M

```
real	1m2.891s
user	1m0.354s
sys	0m1.527s
 39M	book.pdf
```

`dvipdfmx -z 0` （無圧縮）
----------

12秒で418M
```
real	0m12.704s
user	0m9.153s
sys	0m2.115s

418M	book.pdf
```


`dvipdfmx -z 3` （ちょっと圧縮）
----------
17秒で43M
```
real	0m17.305s
user	0m15.478s
sys	0m1.395s

 43M	book.pdf
```
