### PR TITLE
空キャプションを無視する

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -185,7 +185,7 @@ module ReVIEW
     def captionblock(_type, lines, caption)
       puts "\\begin{reviewminicolumn}\n"
       @doc_status[:caption] = true
-      puts "\\reviewminicolumntitle{#{compile_inline(caption)}}\n" if caption
+      puts "\\reviewminicolumntitle{#{compile_inline(caption)}}\n" if caption.present?
 
       @doc_status[:caption] = nil
       blocked_lines = split_paragraph(lines)
@@ -196,7 +196,7 @@ module ReVIEW
 
     def box(lines, caption = nil)
       blank
-      puts macro('reviewboxcaption', compile_inline(caption)) if caption
+      puts macro('reviewboxcaption', compile_inline(caption)) if caption.present?
       puts '\begin{reviewbox}'
       lines.each do |line|
         puts detab(line)
@@ -332,7 +332,7 @@ module ReVIEW
 
     def common_code_block(id, lines, command, caption, _lang)
       @doc_status[:caption] = true
-      if caption
+      if caption.present?
         if command =~ /emlist/ || command =~ /cmd/ || command =~ /source/
           puts macro(command + 'caption', compile_inline(caption))
         else
@@ -527,7 +527,7 @@ module ReVIEW
       rows = adjust_n_cols(rows)
 
       begin
-        table_header id, caption unless caption.nil?
+        table_header id, caption if caption.present?
       rescue KeyError
         error "no such table: #{id}"
       end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -303,6 +303,11 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(\n\\reviewemlistcaption{cap1}\n\\begin{reviewemlist}\nfoo\nbar\n\nbuz\n\\end{reviewemlist}\n), actual
   end
 
+  def test_emlist_empty_caption
+    actual = compile_block("//emlist[]{\nfoo\nbar\n\nbuz\n//}\n")
+    assert_equal %Q(\n\\begin{reviewemlist}\nfoo\nbar\n\nbuz\n\\end{reviewemlist}\n), actual
+  end
+
   def test_emlist_with_tab
     actual = compile_block("//emlist{\n\tfoo\n\t\tbar\n\n\tbuz\n//}\n")
     assert_equal %Q(\n\\begin{reviewemlist}\n        foo\n                bar\n\n        buz\n\\end{reviewemlist}\n), actual
@@ -366,6 +371,11 @@ class LATEXBuidlerTest < Test::Unit::TestCase
   def test_source
     actual = compile_block("//source[foo/bar/test.rb]{\nfoo\nbar\n\nbuz\n//}\n")
     assert_equal %Q(\\reviewsourcecaption{foo/bar/test.rb}\n\\begin{reviewsource}\nfoo\nbar\n\nbuz\n\\end{reviewsource}\n), actual
+  end
+
+  def test_source_empty_caption
+    actual = compile_block("//source[]{\nfoo\nbar\n\nbuz\n//}\n")
+    assert_equal %Q(\\begin{reviewsource}\nfoo\nbar\n\nbuz\n\\end{reviewsource}\n), actual
   end
 
   def test_source_lst


### PR DESCRIPTION
#913 については、`//emlist[]`と空にしておいても（空の）キャプションができてしまうことが原因。
（emlistの基本的書式は`//emlist{`なので発覚しづらかった）

`caption.present?`の判定によりnilおよびemptyをスキップするようにする。
ほかにもいくつかcaptionのnil判定しかしていなかった箇所があったので同様にpresent判定にする。