### PR TITLE
epubmakerとwebmakerの大扉で出版社を表示すべきところが印刷所のままっぽい

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -435,7 +435,7 @@ module ReVIEW
         @body << %Q(<h1 class="tp-title">#{CGI.escapeHTML(@config.name_of('booktitle'))}</h1>\n)
         @body << %Q(<h2 class="tp-subtitle">#{CGI.escapeHTML(@config.name_of('subtitle'))}</h2>\n) if @config['subtitle']
         @body << %Q(<h2 class="tp-author">#{CGI.escapeHTML(@config.names_of('aut').join(ReVIEW::I18n.t('names_splitter')))}</h2>\n) if @config['aut']
-        @body << %Q(<h3 class="tp-publisher">#{CGI.escapeHTML(@config.names_of('prt').join(ReVIEW::I18n.t('names_splitter')))}</h3>\n) if @config['prt']
+        @body << %Q(<h3 class="tp-publisher">#{CGI.escapeHTML(@config.names_of('pbl').join(ReVIEW::I18n.t('names_splitter')))}</h3>\n) if @config['pbl']
         @body << '</div>'
 
         @language = @producer.config['language']

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -240,7 +240,7 @@ module ReVIEW
         @body << %Q(<div class="titlepage">)
         @body << %Q(<h1 class="tp-title">#{CGI.escapeHTML(@config.name_of('booktitle'))}</h1>)
         @body << %Q(<h2 class="tp-author">#{join_with_separator(@config.names_of('aut'), ReVIEW::I18n.t('names_splitter'))}</h2>) if @config['aut']
-        @body << %Q(<h3 class="tp-publisher">#{join_with_separator(@config.names_of('prt'), ReVIEW::I18n.t('names_splitter'))}</h3>) if @config['prt']
+        @body << %Q(<h3 class="tp-publisher">#{join_with_separator(@config.names_of('pbl'), ReVIEW::I18n.t('names_splitter'))}</h3>) if @config['pbl']
         @body << '</div>'
 
         @language = @config['language']


### PR DESCRIPTION
#654 に関連してる変更です。

titlepageのpublisherが印刷所だったので出版社に変更したほうがよさそうというIssueです

#546 で後方互換は廃止されてますが、この変更で出力が変わってしまうので注意したほうがよさそう。