### PR TITLE
PLAINTEXTBuilderの導入

### DIFF
--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -207,14 +207,14 @@ module ReVIEW
       blank
     end
 
-    def base_block(type, lines, caption = nil)
+    def base_block(_type, lines, caption = nil)
       blank
       puts compile_inline(caption) if caption.present?
       puts lines.join("\n")
       blank
     end
 
-    def base_parablock(type, lines, caption = nil)
+    def base_parablock(_type, lines, caption = nil)
       blank
       puts compile_inline(caption) if caption.present?
       puts split_paragraph(lines).join("\n")
@@ -275,9 +275,7 @@ module ReVIEW
       array.join(',')
     end
 
-    def image(lines, id, caption, metric = nil)
-      metrics = parse_metric('top', metric)
-      metrics = " #{metrics}" if metrics.present?
+    def image(_lines, id, caption, _metric = nil)
       blank
       if get_chap
         puts "#{I18n.t('image')}#{I18n.t('format_number', [get_chap, @chapter.image(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
@@ -344,7 +342,7 @@ module ReVIEW
     def table_begin(ncols)
     end
 
-    def imgtable(lines, id, caption = nil, metric = nil)
+    def imgtable(_lines, id, caption = nil, _metric = nil)
       blank
       table_header id, caption if caption.present?
       blank
@@ -377,7 +375,7 @@ module ReVIEW
       " 注#{@chapter.footnote(id).number} "
     end
 
-    def compile_ruby(base, ruby)
+    def compile_ruby(base, _ruby)
       base
     end
 
@@ -420,7 +418,7 @@ module ReVIEW
       str
     end
 
-    def inline_hidx(str)
+    def inline_hidx(_str)
       ''
     end
 
@@ -460,7 +458,7 @@ module ReVIEW
       str
     end
 
-    def inline_icon(id)
+    def inline_icon(_id)
       ''
     end
 
@@ -480,7 +478,7 @@ module ReVIEW
       [str.to_i(16)].pack('U')
     end
 
-    def inline_comment(str)
+    def inline_comment(_str)
       ''
     end
 
@@ -517,14 +515,14 @@ module ReVIEW
     def noindent
     end
 
-    def nonum_begin(level, _label, caption)
+    def nonum_begin(_level, _label, caption)
       puts compile_inline(caption)
     end
 
-    def nonum_end(level)
+    def nonum_end(_level)
     end
 
-    def notoc_begin(level, _label, caption)
+    def notoc_begin(_level, _label, caption)
       puts compile_inline(caption)
     end
 
@@ -538,12 +536,12 @@ module ReVIEW
     def nodisp_end(level)
     end
 
-    def common_column_begin(type, caption)
+    def common_column_begin(_type, caption)
       blank
       puts compile_inline(caption)
     end
 
-    def common_column_end(type)
+    def common_column_end(_type)
       blank
     end
 
@@ -697,9 +695,7 @@ module ReVIEW
 
     alias_method :box, :insn
 
-    def indepimage(_lines, id, caption = nil, metric = nil)
-      metrics = parse_metric('top', metric)
-      metrics = " #{metrics}" if metrics.present?
+    def indepimage(_lines, _id, caption = nil, _metric = nil)
       blank
       puts "図　#{compile_inline(caption)}" if caption.present?
       blank
@@ -769,14 +765,14 @@ module ReVIEW
       str
     end
 
-    def inline_labelref(idref)
+    def inline_labelref(_idref)
       '●'
     end
 
     alias_method :inline_ref, :inline_labelref
 
-    def inline_pageref(idref)
-      "●ページ" # ページ番号を参照
+    def inline_pageref(_idref)
+      '●ページ' # ページ番号を参照
     end
 
     def circle_begin(_level, _label, caption)

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -48,50 +48,6 @@ module ReVIEW
       @subsubsubsection = 0
       @blank_seen = true
       @sec_counter = SecCounter.new(5, @chapter)
-
-      @titles = {
-        'emlist' => 'インラインリスト',
-        'cmd' => 'コマンド',
-        'quote' => '引用',
-        'centering' => '中央揃え',
-        'flushright' => '右寄せ',
-        'note' => 'ノート',
-        'memo' => 'メモ',
-        'important' => '重要',
-        'info' => '情報',
-        'planning' => 'プランニング',
-        'shoot' => 'トラブルシュート',
-        'term' => '用語解説',
-        'notice' => '注意',
-        'caution' => '警告',
-        'warning' => '危険',
-        'point' => 'ここがポイント',
-        'reference' => '参考',
-        'link' => 'リンク',
-        'best' => 'ベストプラクティス',
-        'practice' => '練習問題',
-        'security' => 'セキュリティ',
-        'expert' => 'エキスパートに訊け',
-        'tip' => 'TIP',
-        'box' => '書式',
-        'insn' => '書式',
-        'column' => 'コラム',
-        'xcolumn' => 'コラムパターン2',
-        'world' => 'Worldコラム',
-        'hood' => 'Under The Hoodコラム',
-        'edition' => 'Editionコラム',
-        'insideout' => 'InSideOutコラム',
-        'ref' => '参照',
-        'sup' => '補足',
-        'read' => 'リード',
-        'lead' => 'リード',
-        'list' => 'リスト',
-        'image' => '図',
-        'texequation' => 'TeX式',
-        'table' => '表',
-        'bpo' => 'bpo',
-        'source' => 'ソースコードリスト'
-      }
     end
     private :builder_init_file
 
@@ -267,14 +223,6 @@ module ReVIEW
       end
     end
 
-    def handle_metric(str)
-      str
-    end
-
-    def result_metric(array)
-      array.join(',')
-    end
-
     def image(_lines, id, caption, _metric = nil)
       blank
       if get_chap
@@ -339,7 +287,7 @@ module ReVIEW
       blank
     end
 
-    def table_begin(ncols)
+    def table_begin(_ncols)
     end
 
     def imgtable(_lines, id, caption = nil, _metric = nil)
@@ -350,14 +298,6 @@ module ReVIEW
 
     def tr(rows)
       puts rows.join("\t")
-    end
-
-    def th(str)
-      str
-    end
-
-    def td(str)
-      str
     end
 
     def table_end
@@ -381,8 +321,9 @@ module ReVIEW
 
     def compile_kw(word, alt)
       if alt
-      then "#{word}（#{alt.strip}）"
-      else word
+        "#{word}（#{alt.strip}）"
+      else
+        word
       end
     end
 
@@ -394,80 +335,16 @@ module ReVIEW
       end
     end
 
-    def inline_sup(str)
-      str
-    end
-
-    def inline_sub(str)
-      str
-    end
-
     def inline_raw(str)
       super(str).gsub('\\n', "\n")
-    end
-
-    def inline_hint(str)
-      str
-    end
-
-    def inline_maru(str)
-      str
-    end
-
-    def inline_idx(str)
-      str
     end
 
     def inline_hidx(_str)
       ''
     end
 
-    def inline_ami(str)
-      str
-    end
-
-    def inline_i(str)
-      str
-    end
-
-    def inline_em(str)
-      str
-    end
-
-    def inline_b(str)
-      str
-    end
-
-    alias_method :inline_strong, :inline_b
-
-    def inline_tt(str)
-      str
-    end
-
-    def inline_ttb(str)
-      str
-    end
-
-    alias_method :inline_ttbold, :inline_ttb
-
-    def inline_tti(str)
-      str
-    end
-
-    def inline_u(str)
-      str
-    end
-
     def inline_icon(_id)
       ''
-    end
-
-    def inline_bou(str)
-      str
-    end
-
-    def inline_keytop(str)
-      str
     end
 
     def inline_balloon(str)
@@ -482,17 +359,13 @@ module ReVIEW
       ''
     end
 
-    def inline_m(str)
-      str
-    end
-
     def bibpaper(lines, id, caption)
       bibpaper_header id, caption
       bibpaper_bibpaper id, caption, lines unless lines.empty?
     end
 
     def bibpaper_header(id, caption)
-      print "[#{@chapter.bibpaper(id).number}]"
+      print @chapter.bibpaper(id).number
       puts " #{compile_inline(caption)}"
     end
 
@@ -501,7 +374,7 @@ module ReVIEW
     end
 
     def inline_bib(id)
-      %Q([#{@chapter.bibpaper(id).number}])
+      %Q(#{@chapter.bibpaper(id).number} )
     end
 
     def inline_hd_chap(chap, id)
@@ -530,7 +403,6 @@ module ReVIEW
     end
 
     def nodisp_begin(level, label, caption)
-      # return empty
     end
 
     def nodisp_end(level)
@@ -704,12 +576,10 @@ module ReVIEW
     alias_method :numberlessimage, :indepimage
 
     def label(_id)
-      # FIXME
       ''
     end
 
     def dtp(str)
-      # FIXME
     end
 
     def bpo(lines)
@@ -717,17 +587,11 @@ module ReVIEW
     end
 
     def inline_dtp(_str)
-      # FIXME
       ''
     end
 
     def inline_del(_str)
-      # FIXME
       ''
-    end
-
-    def inline_code(str)
-      str
     end
 
     def inline_br(_str)
@@ -761,10 +625,6 @@ module ReVIEW
       base_block 'source', lines, caption
     end
 
-    def inline_ttibold(str)
-      str
-    end
-
     def inline_labelref(_idref)
       '●'
     end
@@ -785,5 +645,28 @@ module ReVIEW
     def nofunc_text(str)
       str
     end
+
+    alias_method :th, :nofunc_text
+    alias_method :td, :nofunc_text
+    alias_method :inline_sup, :nofunc_text
+    alias_method :inline_sub, :nofunc_text
+    alias_method :inline_hint, :nofunc_text
+    alias_method :inline_maru, :nofunc_text
+    alias_method :inline_idx, :nofunc_text
+    alias_method :inline_ami, :nofunc_text
+    alias_method :inline_i, :nofunc_text
+    alias_method :inline_em, :nofunc_text
+    alias_method :inline_b, :nofunc_text
+    alias_method :inline_strong, :nofunc_text
+    alias_method :inline_tt, :nofunc_text
+    alias_method :inline_code, :nofunc_text
+    alias_method :inline_ttb, :nofunc_text
+    alias_method :inline_ttbold, :nofunc_text
+    alias_method :inline_tti, :nofunc_text
+    alias_method :inline_ttibold, :nofunc_text
+    alias_method :inline_u, :nofunc_text
+    alias_method :inline_bou, :nofunc_text
+    alias_method :inline_keytop, :nofunc_text
+    alias_method :inline_m, :nofunc_text
   end
 end # module ReVIEW

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -1,0 +1,793 @@
+# Copyright (c) 2018 Kenshi Muto
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+#
+
+require 'review/builder'
+require 'review/textutils'
+
+module ReVIEW
+  class PLAINTEXTBuilder < Builder
+    include TextUtils
+
+    %i[ttbold hint maru keytop labelref ref balloon strong].each do |e|
+      Compiler.definline(e)
+    end
+    Compiler.defsingle(:dtp, 1)
+
+    Compiler.defblock(:insn, 1)
+    Compiler.defblock(:planning, 0..1)
+    Compiler.defblock(:best, 0..1)
+    Compiler.defblock(:securty, 0..1)
+    Compiler.defblock(:point, 0..1)
+    Compiler.defblock(:reference, 0)
+    Compiler.defblock(:term, 0)
+    Compiler.defblock(:practice, 0)
+    Compiler.defblock(:expert, 0)
+    Compiler.defblock(:link, 0..1)
+    Compiler.defblock(:shoot, 0..1)
+
+    def pre_paragraph
+      ''
+    end
+
+    def post_paragraph
+      ''
+    end
+
+    def extname
+      '.txt'
+    end
+
+    def builder_init_file
+      @section = 0
+      @subsection = 0
+      @subsubsection = 0
+      @subsubsubsection = 0
+      @blank_seen = true
+      @sec_counter = SecCounter.new(5, @chapter)
+
+      @titles = {
+        'emlist' => 'インラインリスト',
+        'cmd' => 'コマンド',
+        'quote' => '引用',
+        'centering' => '中央揃え',
+        'flushright' => '右寄せ',
+        'note' => 'ノート',
+        'memo' => 'メモ',
+        'important' => '重要',
+        'info' => '情報',
+        'planning' => 'プランニング',
+        'shoot' => 'トラブルシュート',
+        'term' => '用語解説',
+        'notice' => '注意',
+        'caution' => '警告',
+        'warning' => '危険',
+        'point' => 'ここがポイント',
+        'reference' => '参考',
+        'link' => 'リンク',
+        'best' => 'ベストプラクティス',
+        'practice' => '練習問題',
+        'security' => 'セキュリティ',
+        'expert' => 'エキスパートに訊け',
+        'tip' => 'TIP',
+        'box' => '書式',
+        'insn' => '書式',
+        'column' => 'コラム',
+        'xcolumn' => 'コラムパターン2',
+        'world' => 'Worldコラム',
+        'hood' => 'Under The Hoodコラム',
+        'edition' => 'Editionコラム',
+        'insideout' => 'InSideOutコラム',
+        'ref' => '参照',
+        'sup' => '補足',
+        'read' => 'リード',
+        'lead' => 'リード',
+        'list' => 'リスト',
+        'image' => '図',
+        'texequation' => 'TeX式',
+        'table' => '表',
+        'bpo' => 'bpo',
+        'source' => 'ソースコードリスト'
+      }
+    end
+    private :builder_init_file
+
+    def olnum(num)
+      @ol_num = num.to_i
+    end
+
+    def print(s)
+      @blank_seen = false
+      super
+    end
+    private :print
+
+    def puts(s)
+      @blank_seen = false
+      super
+    end
+    private :puts
+
+    def blank
+      @output.puts unless @blank_seen
+      @blank_seen = true
+    end
+    private :blank
+
+    def result
+      @output.string
+    end
+
+    def headline(level, _label, caption)
+      prefix, _anchor = headline_prefix(level)
+      puts %Q(#{prefix}#{compile_inline(caption)})
+    end
+
+    def ul_begin
+      blank
+    end
+
+    def ul_item(lines)
+      puts lines.join
+    end
+
+    def ul_end
+      blank
+    end
+
+    def ol_begin
+      blank
+      @olitem = 0
+    end
+
+    def ol_item(lines, num)
+      puts "#{num}　#{lines.join}"
+    end
+
+    def ol_end
+      blank
+      @olitem = nil
+    end
+
+    def dl_begin
+      blank
+    end
+
+    def dt(line)
+      puts line
+    end
+
+    def dd(lines)
+      split_paragraph(lines).each do |paragraph|
+        puts paragraph.gsub(/\n/, '')
+      end
+    end
+
+    def dl_end
+      blank
+    end
+
+    def paragraph(lines)
+      puts lines.join
+    end
+
+    def read(lines)
+      puts split_paragraph(lines).join("\n")
+      blank
+    end
+
+    alias_method :lead, :read
+
+    def inline_list(id)
+      chapter, id = extract_chapter_id(id)
+      if get_chap(chapter)
+        %Q(#{I18n.t('list')}#{I18n.t('format_number', [get_chap(chapter), chapter.list(id).number])})
+      else
+        %Q(#{I18n.t('list')}#{I18n.t('format_number_without_chapter', [chapter.list(id).number])})
+      end
+    end
+
+    def list_header(id, caption, _lang)
+      blank
+      if get_chap
+        puts %Q(#{I18n.t('list')}#{I18n.t('format_number', [get_chap, @chapter.list(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)})
+      else
+        puts %Q(#{I18n.t('list')}#{I18n.t('format_number_without_chapter', [@chapter.list(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)})
+      end
+      blank
+    end
+
+    def list_body(_id, lines, _lang)
+      lines.each do |line|
+        puts detab(line)
+      end
+      blank
+    end
+
+    def base_block(type, lines, caption = nil)
+      blank
+      puts compile_inline(caption) if caption.present?
+      puts lines.join("\n")
+      blank
+    end
+
+    def base_parablock(type, lines, caption = nil)
+      blank
+      puts compile_inline(caption) if caption.present?
+      puts split_paragraph(lines).join("\n")
+      blank
+    end
+
+    def emlist(lines, caption = nil, _lang = nil)
+      base_block 'emlist', lines, caption
+    end
+
+    def emlistnum(lines, caption = nil, _lang = nil)
+      blank
+      puts compile_inline(caption) if caption.present?
+      lines.each_with_index do |line, i|
+        puts((i + 1).to_s.rjust(2) + ": #{line}")
+      end
+      blank
+    end
+
+    def listnum_body(lines, _lang)
+      lines.each_with_index do |line, i|
+        puts((i + 1).to_s.rjust(2) + ": #{line}")
+      end
+      blank
+    end
+
+    def cmd(lines, caption = nil)
+      base_block 'cmd', lines, caption
+    end
+
+    def quote(lines)
+      base_parablock 'quote', lines, nil
+    end
+
+    def inline_table(id)
+      chapter, id = extract_chapter_id(id)
+      if get_chap(chapter)
+        "#{I18n.t('table')}#{I18n.t('format_number', [get_chap(chapter), chapter.table(id).number])}"
+      else
+        "#{I18n.t('table')}#{I18n.t('format_number_without_chapter', [chapter.table(id).number])}"
+      end
+    end
+
+    def inline_img(id)
+      chapter, id = extract_chapter_id(id)
+      if get_chap(chapter)
+        "#{I18n.t('image')}#{I18n.t('format_number', [get_chap(chapter), chapter.image(id).number])}"
+      else
+        "#{I18n.t('image')}#{I18n.t('format_number_without_chapter', [chapter.image(id).number])}"
+      end
+    end
+
+    def handle_metric(str)
+      str
+    end
+
+    def result_metric(array)
+      array.join(',')
+    end
+
+    def image(lines, id, caption, metric = nil)
+      metrics = parse_metric('top', metric)
+      metrics = " #{metrics}" if metrics.present?
+      blank
+      if get_chap
+        puts "#{I18n.t('image')}#{I18n.t('format_number', [get_chap, @chapter.image(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
+      else
+        puts "#{I18n.t('image')}#{I18n.t('format_number_without_chapter', [@chapter.image(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
+      end
+      blank
+    end
+
+    def texequation(lines)
+      puts lines.join("\n")
+      blank
+    end
+
+    def table(lines, id = nil, caption = nil)
+      blank
+      rows = []
+      sepidx = nil
+      lines.each_with_index do |line, idx|
+        if /\A[\=\-]{12}/ =~ line
+          # just ignore
+          # error "too many table separator" if sepidx
+          sepidx ||= idx
+          next
+        end
+        rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
+      end
+      rows = adjust_n_cols(rows)
+
+      begin
+        table_header id, caption if caption.present?
+      rescue KeyError
+        error "no such table: #{id}"
+      end
+      return if rows.empty?
+      table_begin rows.first.size
+      if sepidx
+        sepidx.times do
+          tr(rows.shift.map { |s| th(s) })
+        end
+        rows.each do |cols|
+          tr(cols.map { |s| td(s) })
+        end
+      else
+        rows.each do |cols|
+          h, *cs = *cols
+          tr([th(h)] + cs.map { |s| td(s) })
+        end
+      end
+      table_end
+    end
+
+    def table_header(id, caption)
+      if id.nil?
+        puts compile_inline(caption)
+      elsif get_chap
+        puts "#{I18n.t('table')}#{I18n.t('format_number', [get_chap, @chapter.table(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
+      else
+        puts "#{I18n.t('table')}#{I18n.t('format_number_without_chapter', [@chapter.table(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
+      end
+      blank
+    end
+
+    def table_begin(ncols)
+    end
+
+    def imgtable(lines, id, caption = nil, metric = nil)
+      blank
+      table_header id, caption if caption.present?
+      blank
+    end
+
+    def tr(rows)
+      puts rows.join("\t")
+    end
+
+    def th(str)
+      str
+    end
+
+    def td(str)
+      str
+    end
+
+    def table_end
+      blank
+    end
+
+    def comment(lines, comment = nil)
+    end
+
+    def footnote(id, str)
+      puts "注#{@chapter.footnote(id).number} #{compile_inline(str)}"
+    end
+
+    def inline_fn(id)
+      " 注#{@chapter.footnote(id).number} "
+    end
+
+    def compile_ruby(base, ruby)
+      base
+    end
+
+    def compile_kw(word, alt)
+      if alt
+      then "#{word}（#{alt.strip}）"
+      else word
+      end
+    end
+
+    def compile_href(url, label)
+      if label
+        "#{label}（#{url}）"
+      else
+        url
+      end
+    end
+
+    def inline_sup(str)
+      str
+    end
+
+    def inline_sub(str)
+      str
+    end
+
+    def inline_raw(str)
+      super(str).gsub('\\n', "\n")
+    end
+
+    def inline_hint(str)
+      str
+    end
+
+    def inline_maru(str)
+      str
+    end
+
+    def inline_idx(str)
+      str
+    end
+
+    def inline_hidx(str)
+      ''
+    end
+
+    def inline_ami(str)
+      str
+    end
+
+    def inline_i(str)
+      str
+    end
+
+    def inline_em(str)
+      str
+    end
+
+    def inline_b(str)
+      str
+    end
+
+    alias_method :inline_strong, :inline_b
+
+    def inline_tt(str)
+      str
+    end
+
+    def inline_ttb(str)
+      str
+    end
+
+    alias_method :inline_ttbold, :inline_ttb
+
+    def inline_tti(str)
+      str
+    end
+
+    def inline_u(str)
+      str
+    end
+
+    def inline_icon(id)
+      ''
+    end
+
+    def inline_bou(str)
+      str
+    end
+
+    def inline_keytop(str)
+      str
+    end
+
+    def inline_balloon(str)
+      %Q(←#{str.gsub(/@maru\[(\d+)\]/, inline_maru('\1'))})
+    end
+
+    def inline_uchar(str)
+      [str.to_i(16)].pack('U')
+    end
+
+    def inline_comment(str)
+      ''
+    end
+
+    def inline_m(str)
+      str
+    end
+
+    def bibpaper(lines, id, caption)
+      bibpaper_header id, caption
+      bibpaper_bibpaper id, caption, lines unless lines.empty?
+    end
+
+    def bibpaper_header(id, caption)
+      print "[#{@chapter.bibpaper(id).number}]"
+      puts " #{compile_inline(caption)}"
+    end
+
+    def bibpaper_bibpaper(_id, _caption, lines)
+      print split_paragraph(lines).join
+    end
+
+    def inline_bib(id)
+      %Q([#{@chapter.bibpaper(id).number}])
+    end
+
+    def inline_hd_chap(chap, id)
+      if chap.number
+        n = chap.headline_index.number(id)
+        return I18n.t('chapter_quote', "#{n}　#{compile_inline(chap.headline(id).caption)}") if @book.config['secnolevel'] >= n.split('.').size
+      end
+      I18n.t('chapter_quote', compile_inline(chap.headline(id).caption))
+    end
+
+    def noindent
+    end
+
+    def nonum_begin(level, _label, caption)
+      puts compile_inline(caption)
+    end
+
+    def nonum_end(level)
+    end
+
+    def notoc_begin(level, _label, caption)
+      puts compile_inline(caption)
+    end
+
+    def notoc_end(level)
+    end
+
+    def nodisp_begin(level, label, caption)
+      # return empty
+    end
+
+    def nodisp_end(level)
+    end
+
+    def common_column_begin(type, caption)
+      blank
+      puts compile_inline(caption)
+    end
+
+    def common_column_end(type)
+      blank
+    end
+
+    def column_begin(_level, _label, caption)
+      common_column_begin('column', caption)
+    end
+
+    def column_end(_level)
+      common_column_end('column')
+    end
+
+    def xcolumn_begin(_level, _label, caption)
+      common_column_begin('xcolumn', caption)
+    end
+
+    def xcolumn_end(_level)
+      common_column_end('xcolumn')
+    end
+
+    def world_begin(_level, _label, caption)
+      common_column_begin('world', caption)
+    end
+
+    def world_end(_level)
+      common_column_end('world')
+    end
+
+    def hood_begin(_level, _label, caption)
+      common_column_begin('hood', caption)
+    end
+
+    def hood_end(_level)
+      common_column_end('hood')
+    end
+
+    def edition_begin(_level, _label, caption)
+      common_column_begin('edition', caption)
+    end
+
+    def edition_end(_level)
+      common_column_end('edition')
+    end
+
+    def insideout_begin(_level, _label, caption)
+      common_column_begin('insideout', caption)
+    end
+
+    def insideout_end(_level)
+      common_column_end('insideout')
+    end
+
+    def ref_begin(_level, _label, caption)
+      common_column_begin('ref', caption)
+    end
+
+    def ref_end(_level)
+      common_column_end('ref')
+    end
+
+    def sup_begin(_level, _label, caption)
+      common_column_begin('sup', caption)
+    end
+
+    def sup_end(_level)
+      common_column_end('sup')
+    end
+
+    def flushright(lines)
+      base_parablock 'flushright', lines, nil
+    end
+
+    def centering(lines)
+      base_parablock 'centering', lines, nil
+    end
+
+    def note(lines, caption = nil)
+      base_parablock 'note', lines, caption
+    end
+
+    def memo(lines, caption = nil)
+      base_parablock 'memo', lines, caption
+    end
+
+    def tip(lines, caption = nil)
+      base_parablock 'tip', lines, caption
+    end
+
+    def info(lines, caption = nil)
+      base_parablock 'info', lines, caption
+    end
+
+    def planning(lines, caption = nil)
+      base_parablock 'planning', lines, caption
+    end
+
+    def best(lines, caption = nil)
+      base_parablock 'best', lines, caption
+    end
+
+    def important(lines, caption = nil)
+      base_parablock 'important', lines, caption
+    end
+
+    def security(lines, caption = nil)
+      base_parablock 'security', lines, caption
+    end
+
+    def caution(lines, caption = nil)
+      base_parablock 'caution', lines, caption
+    end
+
+    def term(lines)
+      base_parablock 'term', lines, nil
+    end
+
+    def link(lines, caption = nil)
+      base_parablock 'link', lines, caption
+    end
+
+    def notice(lines, caption = nil)
+      base_parablock 'notice', lines, caption
+    end
+
+    def point(lines, caption = nil)
+      base_parablock 'point', lines, caption
+    end
+
+    def shoot(lines, caption = nil)
+      base_parablock 'shoot', lines, caption
+    end
+
+    def reference(lines)
+      base_parablock 'reference', lines, nil
+    end
+
+    def practice(lines)
+      base_parablock 'practice', lines, nil
+    end
+
+    def expert(lines)
+      base_parablock 'expert', lines, nil
+    end
+
+    def insn(lines, caption = nil)
+      base_block 'insn', lines, caption
+    end
+
+    def warning(lines, caption = nil)
+      base_parablock 'warning', lines, caption
+    end
+
+    alias_method :box, :insn
+
+    def indepimage(_lines, id, caption = nil, metric = nil)
+      metrics = parse_metric('top', metric)
+      metrics = " #{metrics}" if metrics.present?
+      blank
+      puts "図　#{compile_inline(caption)}" if caption.present?
+      blank
+    end
+
+    alias_method :numberlessimage, :indepimage
+
+    def label(_id)
+      # FIXME
+      ''
+    end
+
+    def dtp(str)
+      # FIXME
+    end
+
+    def bpo(lines)
+      base_block 'bpo', lines, nil
+    end
+
+    def inline_dtp(_str)
+      # FIXME
+      ''
+    end
+
+    def inline_del(_str)
+      # FIXME
+      ''
+    end
+
+    def inline_code(str)
+      str
+    end
+
+    def inline_br(_str)
+      "\n"
+    end
+
+    def text(str)
+      str
+    end
+
+    def inline_chap(id)
+      # "「第#{super}章　#{inline_title(id)}」"
+      # "第#{super}章"
+      super
+    end
+
+    def inline_chapref(id)
+      chs = ['', '「', '」']
+      if @book.config['chapref']
+        chs2 = @book.config['chapref'].split(',')
+        error '--chapsplitter must have exactly 3 parameters with comma.' if chs2.size != 3
+        chs = chs2
+      end
+      "#{chs[0]}#{@book.chapter_index.number(id)}#{chs[1]}#{@book.chapter_index.title(id)}#{chs[2]}"
+    rescue KeyError
+      error "unknown chapter: #{id}"
+      nofunc_text("[UnknownChapter:#{id}]")
+    end
+
+    def source(lines, caption = nil, _lang = nil)
+      base_block 'source', lines, caption
+    end
+
+    def inline_ttibold(str)
+      str
+    end
+
+    def inline_labelref(idref)
+      '●'
+    end
+
+    alias_method :inline_ref, :inline_labelref
+
+    def inline_pageref(idref)
+      "●ページ" # ページ番号を参照
+    end
+
+    def circle_begin(_level, _label, caption)
+      puts "・#{caption}"
+    end
+
+    def circle_end(level)
+    end
+
+    def nofunc_text(str)
+      str
+    end
+  end
+end # module ReVIEW

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2017 Minero Aoki, Kenshi Muto
+# Copyright (c) 2008-2018 Minero Aoki, Kenshi Muto
 #               2002-2006 Minero Aoki
 #
 # This program is free software.
@@ -6,49 +6,12 @@
 # the GNU LGPL, Lesser General Public License version 2.1.
 #
 
-require 'review/builder'
-require 'review/textutils'
+require 'review/plaintextbuilder'
 
 module ReVIEW
-  class TOPBuilder < Builder
-    include TextUtils
-
-    %i[ttbold hint maru keytop labelref ref balloon strong].each do |e|
-      Compiler.definline(e)
-    end
-    Compiler.defsingle(:dtp, 1)
-
-    Compiler.defblock(:insn, 1)
-    Compiler.defblock(:planning, 0..1)
-    Compiler.defblock(:best, 0..1)
-    Compiler.defblock(:securty, 0..1)
-    Compiler.defblock(:point, 0..1)
-    Compiler.defblock(:reference, 0)
-    Compiler.defblock(:term, 0)
-    Compiler.defblock(:practice, 0)
-    Compiler.defblock(:expert, 0)
-    Compiler.defblock(:link, 0..1)
-    Compiler.defblock(:shoot, 0..1)
-
-    def pre_paragraph
-      ''
-    end
-
-    def post_paragraph
-      ''
-    end
-
-    def extname
-      '.txt'
-    end
-
+  class TOPBuilder < PLAINTEXTBuilder
     def builder_init_file
-      @section = 0
-      @subsection = 0
-      @subsubsection = 0
-      @subsubsubsection = 0
-      @blank_seen = true
-      @sec_counter = SecCounter.new(5, @chapter)
+      super
 
       @titles = {
         'emlist' => 'インラインリスト',
@@ -96,61 +59,17 @@ module ReVIEW
     end
     private :builder_init_file
 
-    def print(s)
-      @blank_seen = false
-      super
-    end
-    private :print
-
-    def puts(s)
-      @blank_seen = false
-      super
-    end
-    private :puts
-
-    def blank
-      @output.puts unless @blank_seen
-      @blank_seen = true
-    end
-    private :blank
-
-    def result
-      @output.string
-    end
-
     def headline(level, _label, caption)
       prefix, _anchor = headline_prefix(level)
       puts %Q(■H#{level}■#{prefix}#{compile_inline(caption)})
-    end
-
-    def ul_begin
-      blank
     end
 
     def ul_item(lines)
       puts "●\t#{lines.join}"
     end
 
-    def ul_end
-      blank
-    end
-
-    def ol_begin
-      blank
-      @olitem = 0
-    end
-
     def ol_item(lines, num)
       puts "#{num}\t#{lines.join}"
-    end
-
-    def ol_end
-      blank
-      @olitem = nil
-    end
-
-    def dl_begin
-      blank
     end
 
     def dt(line)
@@ -163,14 +82,6 @@ module ReVIEW
       end
     end
 
-    def dl_end
-      blank
-    end
-
-    def paragraph(lines)
-      puts lines.join
-    end
-
     def read(lines)
       puts "◆→開始:#{@titles['lead']}←◆"
       puts split_paragraph(lines).join("\n")
@@ -179,15 +90,6 @@ module ReVIEW
     end
 
     alias_method :lead, :read
-
-    def inline_list(id)
-      chapter, id = extract_chapter_id(id)
-      if get_chap(chapter)
-        %Q(#{I18n.t('list')}#{I18n.t('format_number', [get_chap(chapter), chapter.list(id).number])})
-      else
-        %Q(#{I18n.t('list')}#{I18n.t('format_number_without_chapter', [chapter.list(id).number])})
-      end
-    end
 
     def list_header(id, caption, _lang)
       blank
@@ -226,10 +128,6 @@ module ReVIEW
       blank
     end
 
-    def emlist(lines, caption = nil, _lang = nil)
-      base_block 'emlist', lines, caption
-    end
-
     def emlistnum(lines, caption = nil, _lang = nil)
       blank
       puts "◆→開始:#{@titles['emlist']}←◆"
@@ -247,40 +145,6 @@ module ReVIEW
       end
       puts "◆→終了:#{@titles['list']}←◆"
       blank
-    end
-
-    def cmd(lines, caption = nil)
-      base_block 'cmd', lines, caption
-    end
-
-    def quote(lines)
-      base_parablock 'quote', lines, nil
-    end
-
-    def inline_table(id)
-      chapter, id = extract_chapter_id(id)
-      if get_chap(chapter)
-        "#{I18n.t('table')}#{I18n.t('format_number', [get_chap(chapter), chapter.table(id).number])}"
-      else
-        "#{I18n.t('table')}#{I18n.t('format_number_without_chapter', [chapter.table(id).number])}"
-      end
-    end
-
-    def inline_img(id)
-      chapter, id = extract_chapter_id(id)
-      if get_chap(chapter)
-        "#{I18n.t('image')}#{I18n.t('format_number', [get_chap(chapter), chapter.image(id).number])}"
-      else
-        "#{I18n.t('image')}#{I18n.t('format_number_without_chapter', [chapter.image(id).number])}"
-      end
-    end
-
-    def handle_metric(str)
-      str
-    end
-
-    def result_metric(array)
-      array.join(',')
     end
 
     def image(lines, id, caption, metric = nil)
@@ -353,30 +217,8 @@ module ReVIEW
       table_end
     end
 
-    def table_header(id, caption)
-      if id.nil?
-        puts compile_inline(caption)
-      elsif get_chap
-        puts "#{I18n.t('table')}#{I18n.t('format_number', [get_chap, @chapter.table(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
-      else
-        puts "#{I18n.t('table')}#{I18n.t('format_number_without_chapter', [@chapter.table(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
-      end
-      blank
-    end
-
-    def table_begin(ncols)
-    end
-
-    def tr(rows)
-      puts rows.join("\t")
-    end
-
     def th(str)
       "★#{str}☆"
-    end
-
-    def td(str)
-      str
     end
 
     def table_end
@@ -427,10 +269,6 @@ module ReVIEW
 
     def inline_sub(str)
       "#{str}◆→DTP連絡:「#{str}」は下付き←◆"
-    end
-
-    def inline_raw(str)
-      super(str).gsub('\\n', "\n")
     end
 
     def inline_hint(str)
@@ -502,10 +340,6 @@ module ReVIEW
       %Q(\t←#{str.gsub(/@maru\[(\d+)\]/, inline_maru('\1'))})
     end
 
-    def inline_uchar(str)
-      [str.to_i(16)].pack('U')
-    end
-
     def inline_comment(str)
       if @book.config['draft']
         "◆→#{str}←◆"
@@ -518,30 +352,13 @@ module ReVIEW
       %Q(◆→TeX式ここから←◆#{str}◆→TeX式ここまで←◆)
     end
 
-    def bibpaper(lines, id, caption)
-      bibpaper_header id, caption
-      bibpaper_bibpaper id, caption, lines unless lines.empty?
-    end
-
     def bibpaper_header(id, caption)
       print "[#{@chapter.bibpaper(id).number}]"
       puts " #{compile_inline(caption)}"
     end
 
-    def bibpaper_bibpaper(_id, _caption, lines)
-      print split_paragraph(lines).join
-    end
-
     def inline_bib(id)
       %Q([#{@chapter.bibpaper(id).number}])
-    end
-
-    def inline_hd_chap(chap, id)
-      if chap.number
-        n = chap.headline_index.number(id)
-        return I18n.t('chapter_quote', "#{n}　#{compile_inline(chap.headline(id).caption)}") if @book.config['secnolevel'] >= n.split('.').size
-      end
-      I18n.t('chapter_quote', compile_inline(chap.headline(id).caption))
     end
 
     def noindent
@@ -552,21 +369,8 @@ module ReVIEW
       puts "■H#{level}■#{compile_inline(caption)}"
     end
 
-    def nonum_end(level)
-    end
-
     def notoc_begin(level, _label, caption)
       puts "■H#{level}■#{compile_inline(caption)}◆→DTP連絡:目次に掲載しない←◆"
-    end
-
-    def notoc_end(level)
-    end
-
-    def nodisp_begin(level, label, caption)
-      # return empty
-    end
-
-    def nodisp_end(level)
     end
 
     def common_column_begin(type, caption)
@@ -579,156 +383,6 @@ module ReVIEW
       puts "◆→終了:#{@titles[type]}←◆"
       blank
     end
-
-    def column_begin(_level, _label, caption)
-      common_column_begin('column', caption)
-    end
-
-    def column_end(_level)
-      common_column_end('column')
-    end
-
-    def xcolumn_begin(_level, _label, caption)
-      common_column_begin('xcolumn', caption)
-    end
-
-    def xcolumn_end(_level)
-      common_column_end('xcolumn')
-    end
-
-    def world_begin(_level, _label, caption)
-      common_column_begin('world', caption)
-    end
-
-    def world_end(_level)
-      common_column_end('world')
-    end
-
-    def hood_begin(_level, _label, caption)
-      common_column_begin('hood', caption)
-    end
-
-    def hood_end(_level)
-      common_column_end('hood')
-    end
-
-    def edition_begin(_level, _label, caption)
-      common_column_begin('edition', caption)
-    end
-
-    def edition_end(_level)
-      common_column_end('edition')
-    end
-
-    def insideout_begin(_level, _label, caption)
-      common_column_begin('insideout', caption)
-    end
-
-    def insideout_end(_level)
-      common_column_end('insideout')
-    end
-
-    def ref_begin(_level, _label, caption)
-      common_column_begin('ref', caption)
-    end
-
-    def ref_end(_level)
-      common_column_end('ref')
-    end
-
-    def sup_begin(_level, _label, caption)
-      common_column_begin('sup', caption)
-    end
-
-    def sup_end(_level)
-      common_column_end('sup')
-    end
-
-    def flushright(lines)
-      base_parablock 'flushright', lines, nil
-    end
-
-    def centering(lines)
-      base_parablock 'centering', lines, nil
-    end
-
-    def note(lines, caption = nil)
-      base_parablock 'note', lines, caption
-    end
-
-    def memo(lines, caption = nil)
-      base_parablock 'memo', lines, caption
-    end
-
-    def tip(lines, caption = nil)
-      base_parablock 'tip', lines, caption
-    end
-
-    def info(lines, caption = nil)
-      base_parablock 'info', lines, caption
-    end
-
-    def planning(lines, caption = nil)
-      base_parablock 'planning', lines, caption
-    end
-
-    def best(lines, caption = nil)
-      base_parablock 'best', lines, caption
-    end
-
-    def important(lines, caption = nil)
-      base_parablock 'important', lines, caption
-    end
-
-    def security(lines, caption = nil)
-      base_parablock 'security', lines, caption
-    end
-
-    def caution(lines, caption = nil)
-      base_parablock 'caution', lines, caption
-    end
-
-    def term(lines)
-      base_parablock 'term', lines, nil
-    end
-
-    def link(lines, caption = nil)
-      base_parablock 'link', lines, caption
-    end
-
-    def notice(lines, caption = nil)
-      base_parablock 'notice', lines, caption
-    end
-
-    def point(lines, caption = nil)
-      base_parablock 'point', lines, caption
-    end
-
-    def shoot(lines, caption = nil)
-      base_parablock 'shoot', lines, caption
-    end
-
-    def reference(lines)
-      base_parablock 'reference', lines, nil
-    end
-
-    def practice(lines)
-      base_parablock 'practice', lines, nil
-    end
-
-    def expert(lines)
-      base_parablock 'expert', lines, nil
-    end
-
-    def insn(lines, caption = nil)
-      base_block 'insn', lines, caption
-    end
-
-    def warning(lines, caption = nil)
-      base_parablock 'warning', lines, caption
-    end
-
-    alias_method :box, :insn
 
     def indepimage(_lines, id, caption = nil, metric = nil)
       metrics = parse_metric('top', metric)
@@ -746,62 +400,8 @@ module ReVIEW
 
     alias_method :numberlessimage, :indepimage
 
-    def label(_id)
-      # FIXME
-      ''
-    end
-
-    def dtp(str)
-      # FIXME
-    end
-
-    def bpo(lines)
-      base_block 'bpo', lines, nil
-    end
-
-    def inline_dtp(_str)
-      # FIXME
-      ''
-    end
-
-    def inline_del(_str)
-      # FIXME
-      ''
-    end
-
     def inline_code(str)
       "△#{str}☆"
-    end
-
-    def inline_br(_str)
-      "\n"
-    end
-
-    def text(str)
-      str
-    end
-
-    def inline_chap(id)
-      # "「第#{super}章　#{inline_title(id)}」"
-      # "第#{super}章"
-      super
-    end
-
-    def inline_chapref(id)
-      chs = ['', '「', '」']
-      if @book.config['chapref']
-        chs2 = @book.config['chapref'].split(',')
-        error '--chapsplitter must have exactly 3 parameters with comma.' if chs2.size != 3
-        chs = chs2
-      end
-      "#{chs[0]}#{@book.chapter_index.number(id)}#{chs[1]}#{@book.chapter_index.title(id)}#{chs[2]}"
-    rescue KeyError
-      error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
-    end
-
-    def source(lines, caption = nil, _lang = nil)
-      base_block 'source', lines, caption
     end
 
     def inline_ttibold(str)
@@ -820,13 +420,6 @@ module ReVIEW
 
     def circle_begin(_level, _label, caption)
       puts "・\t#{caption}"
-    end
-
-    def circle_end(level)
-    end
-
-    def nofunc_text(str)
-      str
     end
   end
 end # module ReVIEW

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -1,0 +1,373 @@
+require 'test_helper'
+require 'review/compiler'
+require 'review/book'
+require 'review/plaintextbuilder'
+require 'review/i18n'
+
+class PLAINTEXTBuidlerTest < Test::Unit::TestCase
+  include ReVIEW
+
+  def setup
+    @builder = PLAINTEXTBuilder.new
+    @config = ReVIEW::Configure.values
+    @config['secnolevel'] = 2
+    @config['language'] = 'ja'
+    @book = Book::Base.new(nil)
+    @book.config = @config
+    @compiler = ReVIEW::Compiler.new(@builder)
+    @chapter = Book::Chapter.new(@book, 1, '-', nil, StringIO.new)
+    location = Location.new(nil, nil)
+    @builder.bind(@compiler, @chapter, location)
+
+    @builder.instance_eval do
+      # to ignore lineno in original method
+      def warn(msg)
+        puts msg
+      end
+    end
+    I18n.setup(@config['language'])
+  end
+
+  def test_headline_level1
+    actual = compile_block("={test} this is test.\n")
+    assert_equal %Q(第1章　this is test.\n), actual
+  end
+
+  def test_headline_level1_without_secno
+    @config['secnolevel'] = 0
+    actual = compile_block("={test} this is test.\n")
+    assert_equal %Q(this is test.\n), actual
+  end
+
+  def test_headline_level2
+    actual = compile_block("=={test} this is test.\n")
+    assert_equal %Q(1.1　this is test.\n), actual
+  end
+
+  def test_headline_level3
+    actual = compile_block("==={test} this is test.\n")
+    assert_equal %Q(this is test.\n), actual
+  end
+
+  def test_headline_level3_with_secno
+    @config['secnolevel'] = 3
+    actual = compile_block("==={test} this is test.\n")
+    assert_equal %Q(1.0.1　this is test.\n), actual
+  end
+
+  def test_href
+    actual = compile_inline('@<href>{http://github.com, GitHub}')
+    assert_equal 'GitHub（http://github.com）', actual
+  end
+
+  def test_href_without_label
+    actual = compile_inline('@<href>{http://github.com}')
+    assert_equal 'http://github.com', actual
+  end
+
+  def test_inline_raw
+    actual = compile_inline('@<raw>{@<tt>{inline\}}')
+    assert_equal '@<tt>{inline}', actual
+  end
+
+  def test_inline_ruby
+    actual = compile_inline('@<ruby>{coffin,bed}')
+    assert_equal 'coffin', actual
+  end
+
+  def test_inline_kw
+    actual = compile_inline('@<kw>{ISO, International Organization for Standardization } @<kw>{Ruby<>}')
+    assert_equal 'ISO（International Organization for Standardization） Ruby<>', actual
+  end
+
+  def test_inline_maru
+    actual = compile_inline('@<maru>{1}@<maru>{20}@<maru>{A}@<maru>{z}')
+    assert_equal '120Az', actual
+  end
+
+  def test_inline_br
+    actual = compile_inline('@<br>{}')
+    assert_equal "\n", actual
+  end
+
+  def test_inline_i
+    actual = compile_inline('test @<i>{inline test} test2')
+    assert_equal 'test inline test test2', actual
+  end
+
+  def test_inline_i_and_escape
+    actual = compile_inline('test @<i>{inline<&;\\ test} test2')
+    assert_equal 'test inline<&;\\ test test2', actual
+  end
+
+  def test_inline_b
+    actual = compile_inline('test @<b>{inline test} test2')
+    assert_equal 'test inline test test2', actual
+  end
+
+  def test_inline_b_and_escape
+    actual = compile_inline('test @<b>{inline<&;\\ test} test2')
+    assert_equal 'test inline<&;\\ test test2', actual
+  end
+
+  def test_inline_tt
+    actual = compile_inline('test @<tt>{inline test} test2@<tt>{\\}}')
+    assert_equal 'test inline test test2}', actual
+  end
+
+  def test_inline_tti
+    actual = compile_inline('test @<tti>{inline test} test2')
+    assert_equal 'test inline test test2', actual
+  end
+
+  def test_inline_ttb
+    actual = compile_inline('test @<ttb>{inline test} test2')
+    assert_equal 'test inline test test2', actual
+  end
+
+  def test_inline_uchar
+    actual = compile_inline('test @<uchar>{2460} test2')
+    assert_equal 'test ① test2', actual
+  end
+
+  def test_inline_comment
+    actual = compile_inline('test @<comment>{コメント} test2')
+    assert_equal 'test  test2', actual
+  end
+
+  def test_inline_comment_for_draft
+    @config['draft'] = true
+    actual = compile_inline('test @<comment>{コメント} test2')
+    assert_equal 'test  test2', actual
+  end
+
+  def test_inline_in_table
+    actual = compile_block("//table{\n★1☆\t▲2☆\n------------\n★3☆\t▲4☆<>&\n//}\n")
+    assert_equal %Q(★1☆\t▲2☆\n★3☆\t▲4☆<>&\n\n), actual
+  end
+
+  def test_dlist_beforeulol
+    actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")
+    assert_equal %Q(foo\nfoo.\n\npara\n\nfoo\nfoo.\n\n1　bar\n\nfoo\nfoo.\n\nbar\n\n), actual
+  end
+
+  def test_paragraph
+    actual = compile_block("foo\nbar\n")
+    assert_equal %Q(foobar\n), actual
+  end
+
+  def test_tabbed_paragraph
+    actual = compile_block("\tfoo\nbar\n")
+    assert_equal %Q(\tfoobar\n), actual
+  end
+
+  def test_flushright
+    actual = compile_block("//flushright{\nfoo\nbar\n\nbuz\n//}\n")
+    assert_equal %Q(foobar\nbuz\n\n), actual
+  end
+
+  def test_noindent
+    actual = compile_block("//noindent\nfoo\nbar\n\nfoo2\nbar2\n")
+    assert_equal %Q(foobar\nfoo2bar2\n), actual
+  end
+
+  def test_comment
+    actual = compile_block('//comment[コメント]')
+    assert_equal '', actual
+  end
+
+  def test_comment_for_draft
+    @config['draft'] = true
+    actual = compile_block('//comment[コメント]')
+    assert_equal '', actual
+  end
+
+  def test_list
+    def @chapter.list(_id)
+      Book::ListIndex::Item.new('test', 1)
+    end
+    actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
+    assert_equal %Q(リスト1.1　this is test<&>_\n\nfoo\nbar\n\n), actual
+  end
+
+  def test_listnum
+    def @chapter.list(_id)
+      Book::ListIndex::Item.new('test', 1)
+    end
+    actual = compile_block("//listnum[test][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
+    assert_equal %Q(リスト1.1　this is test<&>_\n\n 1: foo\n 2: bar\n\n), actual
+  end
+
+  def test_emlistnum
+    actual = compile_block("//emlistnum[this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
+    assert_equal %Q(this is test<&>_\n 1: foo\n 2: bar\n\n), actual
+  end
+
+  def test_bib
+    def @chapter.bibpaper(_id)
+      Book::BibpaperIndex::Item.new('samplebib', 1, 'sample bib')
+    end
+
+    assert_equal '1 ', compile_inline('@<bib>{samplebib}')
+  end
+
+  def test_table
+    actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    assert_equal %Q(aaa\tbbb\nccc\tddd<>&\n\n),
+                 actual
+  end
+
+  def test_inline_table
+    def @chapter.table(_id)
+      Book::TableIndex::Item.new('sampletable', 1)
+    end
+    actual = compile_block("@<table>{sampletest}\n")
+    assert_equal "表1.1\n", actual
+  end
+
+  def test_emtable
+    actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    assert_equal %Q(foo\n\naaa\tbbb\nccc\tddd<>&\n\naaa\tbbb\nccc\tddd<>&\n\n),
+                 actual
+  end
+
+  def test_major_blocks
+    actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
+    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
+    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
+    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
+    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
+    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
+    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
+    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    assert_equal expected, actual
+
+    actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
+    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    assert_equal expected, actual
+  end
+
+  def test_image
+    def @chapter.image(_id)
+      item = Book::ImageIndex::Item.new('sampleimg', 1)
+      item.instance_eval { @path = './images/chap1-sampleimg.png' }
+      item
+    end
+
+    actual = compile_block("//image[sampleimg][sample photo]{\nfoo\n//}\n")
+    assert_equal %Q(図1.1　sample photo\n\n), actual
+  end
+
+  def test_image_with_metric
+    def @chapter.image(_id)
+      item = Book::ImageIndex::Item.new('sampleimg', 1)
+      item.instance_eval { @path = './images/chap1-sampleimg.png' }
+      item
+    end
+
+    actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\nfoo\n//}\n")
+    assert_equal %Q(図1.1　sample photo\n\n), actual
+  end
+
+  def test_texequation
+    actual = compile_block("//texequation{\n\\sin\n1^{2}\n//}\n")
+    assert_equal %Q(\\sin\n1^{2}\n\n), actual
+  end
+
+  def test_inline_raw0
+    assert_equal 'normal', compile_inline('@<raw>{normal}')
+  end
+
+  def test_inline_raw1
+    assert_equal 'body', compile_inline('@<raw>{|plaintext|body}')
+  end
+
+  def test_inline_raw2
+    assert_equal 'body', compile_inline('@<raw>{|plaintext, latex|body}')
+  end
+
+  def test_inline_raw3
+    assert_equal '', compile_inline('@<raw>{|idgxml, html|body}')
+  end
+
+  def test_inline_raw4
+    assert_equal '|plaintext body', compile_inline('@<raw>{|plaintext body}')
+  end
+
+  def test_inline_raw5
+    assert_equal "nor\nmal", compile_inline('@<raw>{|plaintext|nor\\nmal}')
+  end
+
+  def test_block_raw0
+    actual = compile_block(%Q(//raw[<>!"\\n& ]\n))
+    expected = %Q(<>!"\n& )
+    assert_equal expected.chomp, actual
+  end
+
+  def test_block_raw1
+    actual = compile_block(%Q(//raw[|plaintext|<>!"\\n& ]\n))
+    expected = %Q(<>!"\n& )
+    assert_equal expected.chomp, actual
+  end
+
+  def test_block_raw2
+    actual = compile_block(%Q(//raw[|plaintext, latex|<>!"\\n& ]\n))
+    expected = %Q(<>!"\n& )
+    assert_equal expected.chomp, actual
+  end
+
+  def test_block_raw3
+    actual = compile_block(%Q(//raw[|latex, idgxml|<>!"\\n& ]\n))
+    expected = ''
+    assert_equal expected.chomp, actual
+  end
+
+  def test_block_raw4
+    actual = compile_block(%Q(//raw[|plaintext <>!"\\n& ]\n))
+    expected = %Q(|plaintext <>!"\n& )
+    assert_equal expected.chomp, actual
+  end
+
+  def column_helper(review)
+    compile_block(review)
+  end
+
+  def test_column_ref
+    review = <<-EOS
+===[column]{foo} test
+
+inside column
+
+=== next level
+
+this is @<column>{foo}.
+EOS
+    expected = <<-EOS
+test
+inside column
+
+next level
+this is test.
+EOS
+
+    assert_equal expected, column_helper(review)
+  end
+end


### PR DESCRIPTION
下準備として装飾をつけないプレインテキストビルダを用意する。

TOPBuilderはPLAINTEXTBuilderを継承して拡張する。