### PR TITLE
graphメソッドでgnuplotのinvalid commandエラーを修正した

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -444,7 +444,7 @@ module ReVIEW
         graphviz: "echo '#{line}' | dot -T#{image_ext} -o#{file_path}",
         gnuplot: %Q(echo 'set terminal ) +
         "#{image_ext == 'eps' ? 'postscript eps' : image_ext}\n" +
-        %Q(" set output "#{file_path}"\n#{line}' | gnuplot),
+        %Q( set output "#{file_path}"\n#{line}' | gnuplot),
         blockdiag: "echo '#{line}' " +
         "| blockdiag -a -T #{image_ext} -o #{file_path} /dev/stdin",
         aafigure: "echo '#{line}' | aafigure -t#{image_ext} -o#{file_path}"


### PR DESCRIPTION
## :sparkles: 目的

gnuplotを用いたグラフ描画を行う際に`invalid command`エラーが発生する。これに対応する。

## 🙅‍♂️ 原因

#827 にてRubocop向けにリファクタを行った際に、`"`で囲まれた文字列を`%Q()`に修正していたが、片方の`"`が残っていたため。

## 💪  方針

不要な`"`を削除する。

## :white_check_mark: テスト

```
//graph[gnuplot_test][gnuplot]{
plot sin(x)
//}
```
のようなgnuplotを用いたグラフ描画を含むコードをビルドした際にエラーが発生しないことを確認した。

テストが通ることを確認した。