### PR TITLE
-zオプションをconfig.ymlのサンプルに記載

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -291,7 +291,7 @@ epubmaker:
 # dvicommand: "dvipdfmx"
 #
 # LaTeX用のdvi変換コマンドのオプションを指定する
-# dvioptions: "-d 5"
+# dvioptions: "-d 5 -z 9"
 
 # 以下のパラメータを有効にするときには、
 # pdfmaker:

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -69,7 +69,7 @@ module ReVIEW
         'texcommand' => 'uplatex',
         'texdocumentclass' => ['jsbook', 'uplatex,oneside'],
         'dvicommand' => 'dvipdfmx',
-        'dvioptions' => '-d 5',
+        'dvioptions' => '-d 5 -z 9',
         # for PDFMaker
         'pdfmaker' => {
           'makeindex' => nil, # Make index page


### PR DESCRIPTION
#919 の代わり。
デフォルトである `-z 9` を明記で入れた。

カスタマイズTipsはpdfmaker.ja.mdで書くことなのか、どこかに書いたのをWikiからポインティングする程度にすべきか…。
