### PR TITLE
インライン数式前後のスペースを削除

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -831,7 +831,11 @@ module ReVIEW
 
     # math
     def inline_m(str)
-      "$#{str}$"
+      if @book.config['review_version'].nil? || @book.config['review_version'].to_f > 2
+        "$#{str}$"
+      else
+        " $#{str}$ "
+      end
     end
 
     # hidden index

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -831,7 +831,7 @@ module ReVIEW
 
     # math
     def inline_m(str)
-      " $#{str}$ "
+      "$#{str}$"
     end
 
     # hidden index

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -15,7 +15,8 @@ class LATEXBuidlerTest < Test::Unit::TestCase
       'toclevel' => 2,
       'stylesheet' => nil, # for EPUBBuilder
       'image_scale2width' => false,
-      'texcommand' => 'uplatex'
+      'texcommand' => 'uplatex',
+      'review_version' => '3'
     )
     @book = Book::Base.new(nil)
     @book.config = @config
@@ -161,6 +162,10 @@ class LATEXBuidlerTest < Test::Unit::TestCase
   def test_inline_m
     actual = compile_inline('abc@<m>{\\alpha^n = \\inf < 2}ghi')
     assert_equal 'abc$\\alpha^n = \\inf < 2$ghi', actual
+
+    @config['review_version'] = '2.0'
+    actual = compile_inline('abc@<m>{\\alpha^n = \\inf < 2}ghi')
+    assert_equal 'abc $\\alpha^n = \\inf < 2$ ghi', actual
   end
 
   def test_inline_m2
@@ -168,6 +173,11 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     actual = compile_inline('@<m>{X = \\{ {x_1\\},{x_2\\}, \\cdots ,{x_n\\} \\\\\\}}')
     ## expected text: $X = \{ {x_1},{x_2}, \cdots ,{x_n} \}$
     assert_equal '$X = \\{ {x_1},{x_2}, \\cdots ,{x_n} \\}$', actual
+
+    @config['review_version'] = '2.0'
+    actual = compile_inline('@<m>{X = \\{ {x_1\\},{x_2\\}, \\cdots ,{x_n\\} \\\\\\}}')
+    ## expected text: $X = \{ {x_1},{x_2}, \cdots ,{x_n} \}$
+    assert_equal ' $X = \\{ {x_1},{x_2}, \\cdots ,{x_n} \\}$ ', actual
   end
 
   def test_inline_tt

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -160,14 +160,14 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def test_inline_m
     actual = compile_inline('abc@<m>{\\alpha^n = \\inf < 2}ghi')
-    assert_equal 'abc $\\alpha^n = \\inf < 2$ ghi', actual
+    assert_equal 'abc$\\alpha^n = \\inf < 2$ghi', actual
   end
 
   def test_inline_m2
     ## target text: @<m>{X = \{ {x_1\},{x_2\}, \cdots ,{x_n\} \\\}}
     actual = compile_inline('@<m>{X = \\{ {x_1\\},{x_2\\}, \\cdots ,{x_n\\} \\\\\\}}')
     ## expected text: $X = \{ {x_1},{x_2}, \cdots ,{x_n} \}$
-    assert_equal ' $X = \\{ {x_1},{x_2}, \\cdots ,{x_n} \\}$ ', actual
+    assert_equal '$X = \\{ {x_1},{x_2}, \\cdots ,{x_n} \\}$', actual
   end
 
   def test_inline_tt


### PR DESCRIPTION
#925 
旧来のデータに影響する可能性があります。