### PR TITLE
boundingboxの取り方を変えるパラメータ pdfmaker/bbox

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -314,8 +314,13 @@ pdfmaker:
   # 渡される引数1=作業用展開ディレクトリ、引数2=呼び出しを実行したディレクトリ
   # hook_afterdvipdf: null
   #
-  # 画像のscale=X.Xという指定を画像拡大縮小率からページ最大幅の相対倍率に変換します。
+  # 画像のscale=X.Xという指定を画像拡大縮小率からページ最大幅の相対倍率に変換する
   # image_scale2width: true
+  #
+  # PDFやIllustratorファイル(.ai)の画像のBoudingBoxの抽出に指定のボックスを採用する
+  # cropbox(デフォルト), mediabox, artbox, trimbox, bleedboxから選択する。
+  # Illustrator CC以降のIllustratorファイルに対してはmediaboxを指定する必要がある
+  # bbox: mediabox
   #
   # 奥付を作成するか。trueを指定するとデフォルトの奥付、ファイル名を指定するとそれがcolophon.htmlとしてコピーされる
   colophon: true

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -252,8 +252,13 @@ module ReVIEW
       Dir.chdir(to) do
         images = Dir.glob('**/*').find_all { |f| File.file?(f) and f =~ /\.(jpg|jpeg|png|pdf|ai|eps|tif)\z/ }
         break if images.empty?
-        system('extractbb', *images)
-        system_or_raise('ebb', *images) unless system('extractbb', '-m', *images)
+        if @config['pdfmaker']['bbox']
+          system('extractbb', '-B', @config['pdfmaker']['bbox'], *images)
+          system_or_raise('ebb', '-B', @config['pdfmaker']['bbox'], *images) unless system('extractbb', '-B', @config['pdfmaker']['bbox'], '-m', *images)
+        else
+          system('extractbb', *images)
+          system_or_raise('ebb', *images) unless system('extractbb', '-m', *images)
+        end
       end
     end
 


### PR DESCRIPTION
https://qiita.com/zr_tex8r/items/a0516f211831a3fc2c0e の影響

Illustrator CCで作成したAIファイルを取り込むと、boundingboxが意図したものより一回り大きなものとなり、結果として左下にずれたものになる。

- TeX graphicsxのincludegraphics、およびbboxを作るextractbb, ebbはcropboxをデフォルトで取る
- 本来cropbox=mediaboxのはずだが、Illustrator CCで作ったものはcropboxがmediaboxよりも一回り大きいものが生成されることがある（新規のでも100％そうなった）
- 結果としてずれる。

修正方法は2種類。

- 修正パターン1： extractbb/ebbでPDFとAIにはかけないようにする。かつbuilder側のincludegraphicsを作るところで[pagebox=mediabox]や[pagebox=artbox]のようにすれば直る。ただし、毎回bboxの解析に入ってコンパイル速度が著しく遅くなる。
- 修正パターン2： extractbb/ebbで-B パラメータにより、指定のbboxを使うようにする。

後者のほうがシンプルかつコンパイル速度が速いため、後者で実装してみた。config.ymlでの指定は次のようになる。bboxを指定しなければ、extractbb/ebbのデフォルト（たぶんcropbox）になる。

```
pdfmaker:
  bbox: mediabox
```