### PR TITLE
sty/*.erbを解析利用するようにする

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -149,7 +149,6 @@ module ReVIEW
     end
 
     def build_pdf
-      erb_config
       template = template_content
       Dir.chdir(@path) do
         File.open('./book.tex', 'wb') { |f| f.write(template) }
@@ -207,6 +206,7 @@ module ReVIEW
 
     def generate_pdf(yamlfile)
       remove_old_file
+      erb_config
       @path = build_path
       begin
         @compile_errors = nil
@@ -224,6 +224,7 @@ module ReVIEW
         copy_sty(File.join(Dir.pwd, 'sty'), @path, 'fd')
         copy_sty(File.join(Dir.pwd, 'sty'), @path, 'cls')
         copy_sty(File.join(Dir.pwd, 'sty'), @path, 'erb')
+        copy_sty(File.join(Dir.pwd, 'sty'), @path, 'tex')
         copy_sty(Dir.pwd, @path, 'tex')
 
         build_pdf
@@ -388,6 +389,7 @@ module ReVIEW
       layout_file = File.join(@basedir, 'layouts', 'layout.tex.erb')
       template = layout_file if File.exist?(layout_file)
       erb = ReVIEW::Template.load(template, '-')
+      puts 'erb processes layout.tex.erb' if @config['debug']
       erb.result(binding)
     end
 
@@ -403,6 +405,7 @@ module ReVIEW
           FileUtils.mkdir_p(copybase) unless Dir.exist?(copybase)
           if extname == 'erb'
             erb = ReVIEW::Template.load(File.join(dirname, fname), '-')
+            puts "erb processes #{fname}" if @config['debug']
             File.open(File.join(copybase, fname.sub(/\.erb\Z/, '')), 'w') { |f| f.print erb.result(binding) }
           else
             FileUtils.cp File.join(dirname, fname), copybase

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -141,6 +141,7 @@ class PDFMakerTest < Test::Unit::TestCase
   def test_template_content
     Dir.mktmpdir do
       @maker.basedir = Dir.pwd
+      @maker.erb_config
       tmpl = @maker.template_content
       expect = File.read(File.join(assets_dir, 'test_template.tex'))
       assert_equal(expect, tmpl)
@@ -165,6 +166,7 @@ class PDFMakerTest < Test::Unit::TestCase
         expect = File.read(File.join(assets_dir, 'test_template_backmatter.tex'))
 
         @maker.basedir = Dir.pwd
+        @maker.erb_config
         tmpl = @maker.template_content
         tmpl.gsub!(/\A.*%% backmatter begins\n/m, '')
         assert_equal(expect, tmpl)


### PR DESCRIPTION
layout.tex.erbの簡素化とsty/*への委託の方針に伴い、sty側にもerbを実行する必要が生じる。
sty/*.erbの読み込み・実行・一時フォルダへの書き込み を実装する。

なお、「セーフモード」はもうこの機構だと作ることは難しいので諦める（config.ymlのパラメータを渡すにもerb経由にしていく必要があるので）。

すべてのパラメータをTeXで…というのは美しくはあるものの、書式が定まりきらないほか、クラスファイル側の対応も必要なので、既存制作物の互換性を主眼とした。