### PR TITLE
raise an error when file not found. Closes #953

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -43,6 +43,7 @@ module ReVIEW
     attr_reader :strategy
 
     def compile(chap)
+      raise FileNotFound, "#{chap.path} is not found" if chap.path.present? && !File.exist?(chap.path)
       @chapter = chap
       do_compile
       @strategy.result


### PR DESCRIPTION
#953 の修正。
ただ、エラーがあってもWARNで進んでしまうのはよくない感じ…
これ直そうとするとだいぶ大変かも

```
% rake pdf
review-pdfmaker config.yml
compiling a.tex
W, [2018-02-26T00:33:23.610815 #7741]  WARN -- : review-pdfmaker: compile error in a.tex (ReVIEW::CompileError)
W, [2018-02-26T00:33:23.610853 #7741]  WARN -- : review-pdfmaker: ./a.re is not found
compiling p1.tex
compiling ch1.tex
compiling p2.tex
compiling ch2.tex
E, [2018-02-26T00:33:23.611820 #7741] ERROR -- : review-pdfmaker: compile error, No PDF file output.
rake aborted!
Command failed with status (1): [review-pdfmaker config.yml...]
lib/tasks/review.rake:71:in `block in <top (required)>'
/var/lib/gems/2.3.0/gems/rake-12.1.0/exe/rake:27:in `<top (required)>'
Tasks: TOP => pdf => book.pdf
(See full trace by running task with --trace)
```