### PR TITLE
check yaml existence and parse error. Closes #958

### DIFF
--- a/bin/review-compile
+++ b/bin/review-compile
@@ -99,25 +99,19 @@ def _main
   end
 
   begin
+    loader = ReVIEW::YAMLLoader.new
     if config['yaml']
-      unless File.exist?(config['yaml'])
-        @logger.error "#{config['yaml']} not found."
-        exit 1
-      end
+      error "#{config['yaml']} not found." unless File.exist?(config['yaml'])
       begin
-        config.deep_merge!(YAML.load_file(config['yaml']))
+        config.deep_merge!(loader.load_file(config['yaml']))
       rescue => e
-        @logger.error 'yaml error'
-        @logger.error e.message
-        exit 1
+        error "yaml error #{e.message}"
       end
     elsif File.exist?(DEFAULT_CONFIG_FILENAME)
       begin
-        config.deep_merge!(YAML.load_file(DEFAULT_CONFIG_FILENAME))
+        config.deep_merge!(loader.load_file(DEFAULT_CONFIG_FILENAME))
       rescue => e
-        @logger.error 'yaml error'
-        @logger.error e.message
-        exit 1
+        error "yaml error #{e.message}"
       end
     end
 
@@ -126,7 +120,7 @@ def _main
     begin
       config.check_version(ReVIEW::VERSION)
     rescue ReVIEW::ConfigError => e
-      @logger.warn e.message
+      warn e.message
     end
 
     mode = :dir if ARGV.blank?
@@ -134,7 +128,7 @@ def _main
     case mode
     when :files
       if ARGV.empty?
-        @logger.error('no input')
+        error('no input')
         exit 1
       end
 
@@ -170,9 +164,18 @@ def _main
     end
   rescue ReVIEW::ApplicationError => err
     raise if $DEBUG
-    @logger.error(err.message)
+    error(err.message)
     exit 1
   end
+end
+
+def error(msg)
+  @logger.error "#{File.basename($PROGRAM_NAME, '.*')}: #{msg}"
+  exit 1
+end
+
+def warn(msg)
+  @logger.warn "#{File.basename($PROGRAM_NAME, '.*')}: #{msg}"
 end
 
 def load_strategy_class(target, strict)

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -99,11 +99,26 @@ def _main
   end
 
   begin
-    loader = ReVIEW::YAMLLoader.new
     if config['yaml']
-      config.deep_merge!(loader.load_file(config['yaml']))
+      unless File.exist?(config['yaml'])
+        @logger.error "#{config['yaml']} not found."
+        exit 1
+      end
+      begin
+        config.deep_merge!(YAML.load_file(config['yaml']))
+      rescue => e
+        @logger.error 'yaml error'
+        @logger.error e.message
+        exit 1
+      end
     elsif File.exist?(DEFAULT_CONFIG_FILENAME)
-      config.deep_merge!(loader.load_file(DEFAULT_CONFIG_FILENAME))
+      begin
+        config.deep_merge!(YAML.load_file(DEFAULT_CONFIG_FILENAME))
+      rescue => e
+        @logger.error 'yaml error'
+        @logger.error e.message
+        exit 1
+      end
     end
 
     config['builder'] = target

--- a/bin/review-epubmaker
+++ b/bin/review-epubmaker
@@ -39,7 +39,7 @@ if ARGV.size < 1
 end
 
 unless File.exist?(ARGV[0])
-  @logger.error "#{ARGV[0]} not found."
+  @logger.error "#{File.basename($PROGRAM_NAME, '.*')}: #{ARGV[0]} not found."
   exit 1
 end
 

--- a/bin/review-epubmaker
+++ b/bin/review-epubmaker
@@ -33,8 +33,13 @@ rescue OptionParser::ParseError => err
   exit 1
 end
 
-if ARGV.size < 1 || !File.exist?(ARGV[0])
+if ARGV.size < 1
   puts opts.help
+  exit 1
+end
+
+unless File.exist?(ARGV[0])
+  @logger.error "#{ARGV[0]} not found."
   exit 1
 end
 

--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -369,7 +369,7 @@ module ReVIEW
       def read_file(filename)
         unless @warn_old_files[filename]
           @warn_old_files[filename] = true
-          warn "!!! #{filename} is obsoleted. please use catalog.yml." if caller.none? { |item| item =~ %r{/review/test/test_} }
+          ReVIEW.logger.warn "!!! #{filename} is obsoleted. please use catalog.yml." if caller.none? { |item| item =~ %r{/review/test/test_} }
         end
         res = ''
         File.open("#{@basedir}/#{filename}", 'r:BOM|utf-8') do |f|

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -49,13 +49,12 @@ module ReVIEW
     end
 
     def load_yaml(yamlfile)
+      loader = ReVIEW::YAMLLoader.new
       @config = ReVIEW::Configure.values
       begin
-        @config.deep_merge!(YAML.load_file(yamlfile))
+        @config.deep_merge!(loader.load_file(yamlfile))
       rescue => e
-        @logger.error 'yaml error'
-        @logger.error e.message
-        exit 1
+        error "yaml error #{e.message}"
       end
 
       @producer = Producer.new(@config)

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -49,8 +49,15 @@ module ReVIEW
     end
 
     def load_yaml(yamlfile)
-      loader = ReVIEW::YAMLLoader.new
-      @config = ReVIEW::Configure.values.deep_merge(loader.load_file(yamlfile))
+      @config = ReVIEW::Configure.values
+      begin
+        @config.deep_merge!(YAML.load_file(yamlfile))
+      rescue => e
+        @logger.error 'yaml error'
+        @logger.error e.message
+        exit 1
+      end
+
       @producer = Producer.new(@config)
       @producer.load(yamlfile)
       @config = @producer.config

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -107,17 +107,13 @@ module ReVIEW
       @config = ReVIEW::Configure.values
       @config.maker = 'pdfmaker'
       cmd_config, yamlfile = parse_opts(args)
-      unless File.exist?(yamlfile)
-        @logger.error "#{yamlfile} not found."
-        exit 1
-      end
+      error "#{yamlfile} not found." unless File.exist?(yamlfile)
 
       begin
-        @config.deep_merge!(YAML.load_file(yamlfile))
+        loader = ReVIEW::YAMLLoader.new
+        @config.deep_merge!(loader.load_file(yamlfile))
       rescue => e
-        @logger.error 'yaml error'
-        @logger.error e.message
-        exit 1
+        error "yaml error #{e.message}"
       end
       # YAML configs will be overridden by command line options.
       @config.deep_merge!(cmd_config)

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -107,10 +107,20 @@ module ReVIEW
       @config = ReVIEW::Configure.values
       @config.maker = 'pdfmaker'
       cmd_config, yamlfile = parse_opts(args)
-      loader = ReVIEW::YAMLLoader.new
-      @config.deep_merge!(loader.load_file(yamlfile))
+      unless File.exist?(yamlfile)
+        @logger.error "#{yamlfile} not found."
+        exit 1
+      end
+
+      begin
+        @config.deep_merge!(YAML.load_file(yamlfile))
+      rescue => e
+        @logger.error 'yaml error'
+        @logger.error e.message
+        exit 1
+      end
       # YAML configs will be overridden by command line options.
-      @config.merge!(cmd_config)
+      @config.deep_merge!(cmd_config)
       I18n.setup(@config['language'])
       @basedir = File.dirname(yamlfile)
       @basehookdir = File.absolute_path(File.dirname(yamlfile))

--- a/lib/review/textmaker.rb
+++ b/lib/review/textmaker.rb
@@ -62,10 +62,20 @@ module ReVIEW
       @config = ReVIEW::Configure.values
       @config.maker = 'textmaker'
       cmd_config, yamlfile = parse_opts(args)
+      unless File.exist?(yamlfile)
+        @logger.error "#{yamlfile} not found."
+        exit 1
+      end
 
-      @config.merge!(YAML.load_file(yamlfile))
+      begin
+        @config.deep_merge!(YAML.load_file(yamlfile))
+      rescue => e
+        @logger.error 'yaml error'
+        @logger.error e.message
+        exit 1
+      end
       # YAML configs will be overridden by command line options.
-      @config.merge!(cmd_config)
+      @config.deep_merge!(cmd_config)
       I18n.setup(@config['language'])
       generate_text_files(yamlfile)
     end

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -13,6 +13,7 @@ require 'review/converter'
 require 'review/configure'
 require 'review/book'
 require 'review/htmlbuilder'
+require 'review/yamlloader'
 require 'review/template'
 require 'review/tocprinter'
 require 'review/version'
@@ -27,6 +28,15 @@ module ReVIEW
     def initialize
       @basedir = nil
       @logger = ReVIEW.logger
+    end
+
+    def error(msg)
+      @logger.error "#{File.basename($PROGRAM_NAME, '.*')}: #{msg}"
+      exit 1
+    end
+
+    def warn(msg)
+      @logger.warn "#{File.basename($PROGRAM_NAME, '.*')}: #{msg}"
     end
 
     def self.execute(*args)
@@ -68,17 +78,13 @@ module ReVIEW
       @config = ReVIEW::Configure.values
       @config.maker = 'webmaker'
       cmd_config, yamlfile = parse_opts(args)
-      unless File.exist?(yamlfile)
-        @logger.error "#{yamlfile} not found."
-        exit 1
-      end
+      error "#{yamlfile} not found." unless File.exist?(yamlfile)
 
       begin
-        @config.deep_merge!(YAML.load_file(yamlfile))
+        loader = ReVIEW::YAMLLoader.new
+        @config.deep_merge!(loader.load_file(yamlfile))
       rescue => e
-        @logger.error 'yaml error'
-        @logger.error e.message
-        exit 1
+        error "yaml error #{e.message}"
       end
       # YAML configs will be overridden by command line options.
       @config.deep_merge!(cmd_config)
@@ -164,14 +170,14 @@ module ReVIEW
       htmlfile = "#{id}.#{@config['htmlext']}"
 
       if @config['params'].present?
-        @logger.warn %Q('params:' in config.yml is obsoleted.)
+        warn %Q('params:' in config.yml is obsoleted.)
       end
 
       begin
         @converter.convert(filename, File.join(basetmpdir, htmlfile))
       rescue => e
-        @logger.warn "compile error in #{filename} (#{e.class})"
-        @logger.warn e.message
+        warn "compile error in #{filename} (#{e.class})"
+        warn e.message
       end
     end
 

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -68,10 +68,20 @@ module ReVIEW
       @config = ReVIEW::Configure.values
       @config.maker = 'webmaker'
       cmd_config, yamlfile = parse_opts(args)
+      unless File.exist?(yamlfile)
+        @logger.error "#{yamlfile} not found."
+        exit 1
+      end
 
-      @config.merge!(YAML.load_file(yamlfile))
+      begin
+        @config.deep_merge!(YAML.load_file(yamlfile))
+      rescue => e
+        @logger.error 'yaml error'
+        @logger.error e.message
+        exit 1
+      end
       # YAML configs will be overridden by command line options.
-      @config.merge!(cmd_config)
+      @config.deep_merge!(cmd_config)
       @config['htmlext'] = 'html'
       I18n.setup(@config['language'])
       generate_html_files(yamlfile)


### PR DESCRIPTION
- yamlファイル指定で存在しなかったときはnot foundエラーで即終了させる
- deep_merge時にエラーが発生したらyaml errorで終了させる。エラーの種類からより妥当なメッセージへと判断するのはyamlライブラリ側にそういうのはなくて難しそう。

_mainが長くなりすぎるようだ…
