### PR TITLE
インライン参照系で、見つからないIDが示されたときのメッセージを妥当なものにする

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -209,35 +209,30 @@ module ReVIEW
       compile_inline @book.chapter_index.display_string(id)
     rescue KeyError
       error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
     end
 
     def inline_chap(id)
       @book.chapter_index.number(id)
     rescue KeyError
       error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
     end
 
     def inline_title(id)
       compile_inline @book.chapter_index.title(id)
     rescue KeyError
       error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
     end
 
     def inline_list(id)
       "#{I18n.t('list')}#{@chapter.list(id).number}"
     rescue KeyError
       error "unknown list: #{id}"
-      nofunc_text("[UnknownList:#{id}]")
     end
 
     def inline_img(id)
       "#{I18n.t('image')}#{@chapter.image(id).number}"
     rescue KeyError
       error "unknown image: #{id}"
-      nofunc_text("[UnknownImage:#{id}]")
     end
 
     def inline_imgref(id)
@@ -254,14 +249,12 @@ module ReVIEW
       "#{I18n.t('table')}#{@chapter.table(id).number}"
     rescue KeyError
       error "unknown table: #{id}"
-      nofunc_text("[UnknownTable:#{id}]")
     end
 
     def inline_fn(id)
       @chapter.footnote(id).content
     rescue KeyError
       error "unknown footnote: #{id}"
-      nofunc_text("[UnknownFootnote:#{id}]")
     end
 
     def inline_bou(str)
@@ -317,8 +310,7 @@ module ReVIEW
         inline_hd_chap(@chapter, id)
       end
     rescue KeyError
-      error "unknown hd: #{id}"
-      nofunc_text("[UnknownHeader:#{id}]")
+      error "unknown headline: #{id}"
     end
 
     def inline_column(id)
@@ -333,7 +325,6 @@ module ReVIEW
       end
     rescue KeyError
       error "unknown column: #{id}"
-      nofunc_text("[UnknownColumn:#{id}]")
     end
 
     def inline_column_chap(chapter, id)

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -799,7 +799,6 @@ module ReVIEW
       end
     rescue KeyError
       error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
     end
 
     def inline_chap(id)
@@ -810,7 +809,6 @@ module ReVIEW
       end
     rescue KeyError
       error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
     end
 
     def inline_title(id)
@@ -822,7 +820,6 @@ module ReVIEW
       end
     rescue KeyError
       error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
     end
 
     def inline_fn(id)
@@ -831,6 +828,8 @@ module ReVIEW
       else
         %Q(<a id="fnb-#{normalize_id(id)}" href="#fn-#{normalize_id(id)}" class="noteref">*#{@chapter.footnote(id).number}</a>)
       end
+    rescue KeyError
+      error "unknown footnote: #{id}"
     end
 
     def compile_ruby(base, ruby)
@@ -949,6 +948,8 @@ module ReVIEW
 
     def inline_bib(id)
       %Q(<a href="#{@book.bib_file.gsub(/\.re\Z/, ".#{@book.config['htmlext']}")}#bib-#{normalize_id(id)}">[#{@chapter.bibpaper(id).number}]</a>)
+    rescue KeyError
+      error "unknown bib: #{id}"
     end
 
     def inline_hd_chap(chap, id)
@@ -964,6 +965,8 @@ module ReVIEW
       else
         str
       end
+    rescue KeyError
+      error "unknown headline: #{id}"
     end
 
     def column_label(id, chapter = @chapter)
@@ -978,6 +981,8 @@ module ReVIEW
       else
         I18n.t('column', compile_inline(chapter.column(id).caption))
       end
+    rescue KeyError
+      error "unknown column: #{id}"
     end
 
     def inline_list(id)
@@ -995,7 +1000,6 @@ module ReVIEW
       end
     rescue KeyError
       error "unknown list: #{id}"
-      nofunc_text("[UnknownList:#{id}]")
     end
 
     def inline_table(id)
@@ -1013,7 +1017,6 @@ module ReVIEW
       end
     rescue KeyError
       error "unknown table: #{id}"
-      nofunc_text("[UnknownTable:#{id}]")
     end
 
     def inline_img(id)
@@ -1031,7 +1034,6 @@ module ReVIEW
       end
     rescue KeyError
       error "unknown image: #{id}"
-      nofunc_text("[UnknownImage:#{id}]")
     end
 
     def inline_asis(str, tag)

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -261,6 +261,8 @@ module ReVIEW
       else
         I18n.t('column', compile_inline(chapter.column(id).caption))
       end
+    rescue KeyError
+      error "unknown column: #{id}"
     end
 
     def inline_list(id)
@@ -270,6 +272,8 @@ module ReVIEW
       else
         "<span type='list'>#{I18n.t('list')}#{I18n.t('format_number', [get_chap(chapter), chapter.list(id).number])}</span>"
       end
+    rescue KeyError
+      error "unknown list: #{id}"
     end
 
     def list_header(id, caption, _lang)
@@ -373,6 +377,8 @@ module ReVIEW
       else
         "<span type='table'>#{I18n.t('table')}#{I18n.t('format_number', [get_chap(chapter), chapter.table(id).number])}</span>"
       end
+    rescue KeyError
+      error "unknown table: #{id}"
     end
 
     def inline_img(id)
@@ -382,6 +388,8 @@ module ReVIEW
       else
         "<span type='image'>#{I18n.t('image')}#{I18n.t('format_number', [get_chap(chapter), chapter.image(id).number])}</span>"
       end
+    rescue KeyError
+      error "unknown image: #{id}"
     end
 
     def inline_imgref(id)
@@ -600,6 +608,8 @@ module ReVIEW
 
     def inline_fn(id)
       %Q(<footnote>#{compile_inline(@chapter.footnote(id).content.strip)}</footnote>)
+    rescue KeyError
+      error "unknown footnote: #{id}"
     end
 
     def compile_ruby(base, ruby)
@@ -1063,7 +1073,6 @@ module ReVIEW
       end
     rescue KeyError
       error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
     end
 
     def inline_chap(id)
@@ -1074,7 +1083,6 @@ module ReVIEW
       end
     rescue KeyError
       error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
     end
 
     def inline_title(id)
@@ -1086,7 +1094,6 @@ module ReVIEW
       end
     rescue KeyError
       error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
     end
 
     def source_header(caption)
@@ -1117,6 +1124,8 @@ module ReVIEW
 
     def inline_bib(id)
       %Q(<span type='bibref' idref='#{id}'>[#{@chapter.bibpaper(id).number}]</span>)
+    rescue KeyError
+      error "unknown bib: #{id}"
     end
 
     def inline_hd_chap(chap, id)
@@ -1127,6 +1136,8 @@ module ReVIEW
         end
       end
       I18n.t('chapter_quote', compile_inline(chap.headline(id).caption))
+    rescue KeyError
+      error "unknown headline: #{id}"
     end
 
     def inline_recipe(id)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -782,6 +782,8 @@ module ReVIEW
       else
         macro('reviewlistref', I18n.t('format_number', [get_chap(chapter), chapter.list(id).number]))
       end
+    rescue KeyError
+      error "unknown list: #{id}"
     end
 
     def inline_table(id)
@@ -791,6 +793,8 @@ module ReVIEW
       else
         macro('reviewtableref', I18n.t('format_number', [get_chap(chapter), chapter.table(id).number]), table_label(id, chapter))
       end
+    rescue KeyError
+      error "unknown table: #{id}"
     end
 
     def inline_img(id)
@@ -800,6 +804,8 @@ module ReVIEW
       else
         macro('reviewimageref', I18n.t('format_number', [get_chap(chapter), chapter.image(id).number]), image_label(id, chapter))
       end
+    rescue KeyError
+      error "unknown image: #{id}"
     end
 
     def footnote(id, content)
@@ -817,6 +823,8 @@ module ReVIEW
       else
         macro('footnote', compile_inline(@chapter.footnote(id).content.strip))
       end
+    rescue KeyError
+      error "unknown footnote: #{id}"
     end
 
     BOUTEN = '・'.freeze
@@ -917,6 +925,8 @@ module ReVIEW
       macro('reviewcolumnref',
             I18n.t('chapter_quote', compile_inline(chapter.column(id).caption)),
             column_label(id, chapter))
+    rescue KeyError
+      error "unknown column: #{id}"
     end
 
     def inline_raw(str)

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -178,7 +178,6 @@ module ReVIEW
       "#{I18n.t('image')}#{@chapter.image(id).number}"
     rescue KeyError
       error "unknown image: #{id}"
-      nofunc_text("[UnknownImage:#{id}]")
     end
 
     def indepimage(_lines, id, caption = '', _metric = nil)

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -144,6 +144,8 @@ module ReVIEW
       else
         %Q(#{I18n.t('list')}#{I18n.t('format_number_without_chapter', [chapter.list(id).number])})
       end
+    rescue KeyError
+      error "unknown list: #{id}"
     end
 
     def list_header(id, caption, _lang)
@@ -212,6 +214,8 @@ module ReVIEW
       else
         "#{I18n.t('table')}#{I18n.t('format_number_without_chapter', [chapter.table(id).number])}"
       end
+    rescue KeyError
+      error "unknown table: #{id}"
     end
 
     def inline_img(id)
@@ -221,6 +225,8 @@ module ReVIEW
       else
         "#{I18n.t('image')}#{I18n.t('format_number_without_chapter', [chapter.image(id).number])}"
       end
+    rescue KeyError
+      error "unknown image: #{id}"
     end
 
     def image(_lines, id, caption, _metric = nil)
@@ -313,6 +319,8 @@ module ReVIEW
 
     def inline_fn(id)
       " 注#{@chapter.footnote(id).number} "
+    rescue KeyError
+      error "unknown footnote: #{id}"
     end
 
     def compile_ruby(base, _ruby)
@@ -375,6 +383,8 @@ module ReVIEW
 
     def inline_bib(id)
       %Q(#{@chapter.bibpaper(id).number} )
+    rescue KeyError
+      error "unknown bib: #{id}"
     end
 
     def inline_hd_chap(chap, id)
@@ -383,6 +393,8 @@ module ReVIEW
         return I18n.t('chapter_quote', "#{n}　#{compile_inline(chap.headline(id).caption)}") if @book.config['secnolevel'] >= n.split('.').size
       end
       I18n.t('chapter_quote', compile_inline(chap.headline(id).caption))
+    rescue KeyError
+      error "unknown headline: #{id}"
     end
 
     def noindent
@@ -618,7 +630,6 @@ module ReVIEW
       "#{chs[0]}#{@book.chapter_index.number(id)}#{chs[1]}#{@book.chapter_index.title(id)}#{chs[2]}"
     rescue KeyError
       error "unknown chapter: #{id}"
-      nofunc_text("[UnknownChapter:#{id}]")
     end
 
     def source(lines, caption = nil, _lang = nil)

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -242,6 +242,8 @@ module ReVIEW
 
     def inline_fn(id)
       "【注#{@chapter.footnote(id).number}】"
+    rescue KeyError
+      error "unknown footnote: #{id}"
     end
 
     def compile_ruby(base, ruby)
@@ -359,6 +361,8 @@ module ReVIEW
 
     def inline_bib(id)
       %Q([#{@chapter.bibpaper(id).number}])
+    rescue KeyError
+      error "unknown bib: #{id}"
     end
 
     def noindent

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1691,4 +1691,21 @@ EOS
     actual = compile_inline('test @<code>|@<code>{$サンプル$}|')
     assert_equal 'test <code class="inline-code tt">@&lt;code&gt;{$サンプル$}</code>', actual
   end
+
+  def test_inline_unknown
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<img>{n}\n" }
+    assert_equal ':1: error: unknown image: n', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<fn>{n}\n" }
+    assert_equal ':1: error: unknown footnote: n', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<hd>{n}\n" }
+    assert_equal ':1: error: unknown headline: n', e.message
+    %w[list table column].each do |name|
+      e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<#{name}>{n}\n" }
+      assert_equal ":1: error: unknown #{name}: n", e.message
+    end
+    %w[chap chapref title].each do |name|
+      e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<#{name}>{n}\n" }
+      assert_equal ':1: error: key not found: "n"', e.message
+    end
+  end
 end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -619,6 +619,23 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_inline_unknown
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<img>{n}\n" }
+    assert_equal ':1: error: unknown image: n', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<fn>{n}\n" }
+    assert_equal ':1: error: unknown footnote: n', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<hd>{n}\n" }
+    assert_equal ':1: error: unknown headline: n', e.message
+    %w[list table column].each do |name|
+      e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<#{name}>{n}\n" }
+      assert_equal ":1: error: unknown #{name}: n", e.message
+    end
+    %w[chap chapref title].each do |name|
+      e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<#{name}>{n}\n" }
+      assert_equal ':1: error: key not found: "n"', e.message
+    end
+  end
+
   def test_inline_raw0
     assert_equal 'normal', compile_inline('@<raw>{normal}')
   end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -973,6 +973,23 @@ EOS
     assert_equal 'test \\texttt{@\\textless{}code\\textgreater{}\\{\\textdollar{}サンプル\\textdollar{}\\}}', actual
   end
 
+  def test_inline_unknown
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<img>{n}\n" }
+    assert_equal ':1: error: unknown image: n', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<fn>{n}\n" }
+    assert_equal ':1: error: unknown footnote: n', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<hd>{n}\n" }
+    assert_equal ':1: error: unknown headline: n', e.message
+    %w[list table column].each do |name|
+      e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<#{name}>{n}\n" }
+      assert_equal ":1: error: unknown #{name}: n", e.message
+    end
+    %w[chap chapref title].each do |name|
+      e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<#{name}>{n}\n" }
+      assert_equal ':1: error: key not found: "n"', e.message
+    end
+  end
+
   def test_appendix_list
     @chapter.instance_eval do
       def on_appendix?

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -292,6 +292,23 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(\\sin\n1^{2}\n\n), actual
   end
 
+  def test_inline_unknown
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<img>{n}\n" }
+    assert_equal ':1: error: unknown image: n', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<fn>{n}\n" }
+    assert_equal ':1: error: unknown footnote: n', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<hd>{n}\n" }
+    assert_equal ':1: error: unknown headline: n', e.message
+    %w[list table column].each do |name|
+      e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<#{name}>{n}\n" }
+      assert_equal ":1: error: unknown #{name}: n", e.message
+    end
+    %w[chap chapref title].each do |name|
+      e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<#{name}>{n}\n" }
+      assert_equal ':1: error: key not found: "n"', e.message
+    end
+  end
+
   def test_inline_raw0
     assert_equal 'normal', compile_inline('@<raw>{normal}')
   end

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -297,6 +297,23 @@ class TOPBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(◆→開始:TeX式←◆\n\\sin\n1^{2}\n◆→終了:TeX式←◆\n\n), actual
   end
 
+  def test_inline_unknown
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<img>{n}\n" }
+    assert_equal ':1: error: unknown image: n', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<fn>{n}\n" }
+    assert_equal ':1: error: unknown footnote: n', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<hd>{n}\n" }
+    assert_equal ':1: error: unknown headline: n', e.message
+    %w[list table column].each do |name|
+      e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<#{name}>{n}\n" }
+      assert_equal ":1: error: unknown #{name}: n", e.message
+    end
+    %w[chap chapref title].each do |name|
+      e = assert_raises(ReVIEW::ApplicationError) { compile_block "@<#{name}>{n}\n" }
+      assert_equal ':1: error: key not found: "n"', e.message
+    end
+  end
+
   def test_inline_raw0
     assert_equal 'normal', compile_inline('@<raw>{normal}')
   end


### PR DESCRIPTION
#954 の対応。
メッセージは`unknown <ID>`で統一した。
