### PR TITLE
ローカルbasetmpdirが未設定

### DIFF
--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -278,7 +278,7 @@ module ReVIEW
     def copy_file_with_param(name, target_file = nil)
       return if @config[name].nil? || !File.exist?(@config[name])
       target_file ||= File.basename(@config[name])
-      FileUtils.cp(@config[name], File.join(basetmpdir, target_file))
+      FileUtils.cp(@config[name], File.join(@path, target_file))
     end
 
     def join_with_separator(value, sep)


### PR DESCRIPTION
webmakerでテストしていたところ、copy_file_with_paramメソッド内でbasetmpdirが渡されずnilになっていました。
呼び出し側が複雑になっているのですが、結局basetmpdirはいらなくて`@path`があればいいのでは…？というロジックだったので無理に引数を増やすよりは`@path`を使うようにしています。
