### PR TITLE
pdfmakerでの実行コマンドをinfoレべルで表示する

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -36,6 +36,7 @@ module ReVIEW
     end
 
     def system_or_raise(*args)
+      @logger.info *args
       Kernel.system(*args) or raise("failed to run command: #{args.join(' ')}")
     end
 

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -35,8 +35,13 @@ module ReVIEW
       @input_files = Hash.new { |h, key| h[key] = '' }
     end
 
+    def system_with_info(*args)
+      @logger.info args.join(' ')
+      Kernel.system(*args)
+    end
+
     def system_or_raise(*args)
-      @logger.info *args
+      @logger.info args.join(' ')
       Kernel.system(*args) or raise("failed to run command: #{args.join(' ')}")
     end
 
@@ -266,10 +271,10 @@ module ReVIEW
         images = Dir.glob('**/*').find_all { |f| File.file?(f) and f =~ /\.(jpg|jpeg|png|pdf|ai|eps|tif)\z/ }
         break if images.empty?
         if @config['pdfmaker']['bbox']
-          system('extractbb', '-B', @config['pdfmaker']['bbox'], *images)
+          system_with_info('extractbb', '-B', @config['pdfmaker']['bbox'], *images)
           system_or_raise('ebb', '-B', @config['pdfmaker']['bbox'], *images) unless system('extractbb', '-B', @config['pdfmaker']['bbox'], '-m', *images)
         else
-          system('extractbb', *images)
+          system_with_info('extractbb', *images)
           system_or_raise('ebb', *images) unless system('extractbb', '-m', *images)
         end
       end


### PR DESCRIPTION
#962 のシンプルな対応

ただ、copy_imagesで
```
          system('extractbb', '-B', @config['pdfmaker']['bbox'], *images)
          system_or_raise('ebb', '-B', @config['pdfmaker']['bbox'], *images) unless system('extractbb', '-B', @config['pdfmaker']['bbox'], '-m', *images)
```
とsystemを使ってるところがあって、そこはまだ入れていない。system_or_raiseと似た、raiseしないメソッドを作る必要がある?