### PR TITLE
refactor(Book::Base): Book#contentdir should not be ""

### DIFF
--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -82,9 +82,9 @@ module ReVIEW
 
       def contentdir
         if !config['contentdir'].present? || config['contentdir'] == '.'
-          ''
+          @basedir
         else
-          config['contentdir']
+          File.join(@basedir, config['contentdir'])
         end
       end
 
@@ -316,12 +316,12 @@ module ReVIEW
           return catalog.parts_with_chaps.map do |entry|
             if entry.is_a?(Hash)
               chaps = entry.values.first.map do |chap|
-                chap = Chapter.new(self, num += 1, chap, File.join(@basedir, contentdir, chap))
+                chap = Chapter.new(self, num += 1, chap, File.join(contentdir, chap))
                 chap
               end
               Part.new(self, part += 1, chaps, read_part.split("\n")[part - 1])
             else
-              chap = Chapter.new(self, num += 1, entry, File.join(@basedir, contentdir, entry))
+              chap = Chapter.new(self, num += 1, entry, File.join(contentdir, entry))
               if chap.number
                 num = chap.number
               else
@@ -335,7 +335,7 @@ module ReVIEW
         chap = read_chaps.
                strip.lines.map(&:strip).join("\n").split(/\n{2,}/).
                map do |part_chunk|
-          chaps = part_chunk.split.map { |chapid| Chapter.new(self, num += 1, chapid, File.join(@basedir, contentdir, chapid)) }
+          chaps = part_chunk.split.map { |chapid| Chapter.new(self, num += 1, chapid, File.join(contentdir, chapid)) }
           if part_exist? && read_part.split("\n").size > part
             Part.new(self, part += 1, chaps, read_part.split("\n")[part - 1])
           else
@@ -367,14 +367,14 @@ module ReVIEW
 
       def mkchap(name, number = nil)
         name += ext if File.extname(name).empty?
-        path = File.join(@basedir, contentdir, name)
+        path = File.join(contentdir, name)
         raise FileNotFound, "file not exist: #{path}" unless File.file?(path)
         Chapter.new(self, number, name, path)
       end
 
       def mkchap_ifexist(name, idx = nil)
         name += ext if File.extname(name).empty?
-        path = File.join(@basedir, contentdir, name)
+        path = File.join(contentdir, name)
         if File.file?(path)
           idx += 1 if idx
           Chapter.new(self, idx, name, path)


### PR DESCRIPTION
ディレクトリが空文字になるのは違和感があったので、@basedirと合わせてパスを返すようにしてみました。