### PR TITLE
fix: Compilable#open was deprecated; use Compilable#content

### DIFF
--- a/lib/review/book/compilable.rb
+++ b/lib/review/book/compilable.rb
@@ -14,6 +14,7 @@ module ReVIEW
       include TextUtils
       attr_reader :book
       attr_reader :path
+      attr_accessor :content
 
       def env
         @book
@@ -62,19 +63,6 @@ module ReVIEW
         @volume
       end
 
-      # XXX deprecated; use content()
-      def open(&_block)
-        if @io
-          return (block_given? ? yield(@io) : @io)
-        end
-        StringIO.new(content)
-      end
-
-      attr_writer :content
-
-      def content
-        @content
-      end
 
       def lines
         # FIXME: we cannot duplicate Enumerator on ruby 1.9 HEAD

--- a/lib/review/book/compilable.rb
+++ b/lib/review/book/compilable.rb
@@ -63,7 +63,6 @@ module ReVIEW
         @volume
       end
 
-
       def lines
         # FIXME: we cannot duplicate Enumerator on ruby 1.9 HEAD
         (@lines ||= content.lines.to_a).dup

--- a/test/test_book_chapter.rb
+++ b/test/test_book_chapter.rb
@@ -35,12 +35,6 @@ class ChapterTest < Test::Unit::TestCase
     # assert_raises(TypeError) { ch.name } # XXX: OK?
   end
 
-  def test_open
-    ch = Book::Chapter.new(nil, nil, nil, __FILE__, :io)
-    assert_equal :io, ch.open
-    assert_equal [:io], (ch.open { |io| [io] })
-  end
-
   def test_size
     ch = Book::Chapter.new(nil, nil, nil, __FILE__, :io)
     assert_equal File.size(__FILE__), ch.size


### PR DESCRIPTION
Now we don't use `chatpter#open` or `part#open` anyway.
