### PR TITLE
remove unused variables in Builder#builder_init

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -41,16 +41,13 @@ module ReVIEW
       ".#{@book.config['htmlext']}"
     end
 
-    def builder_init(no_error = false)
-      @no_error = no_error
-      @noindent = nil
-      @ol_num = nil
-      @error_messages = nil
-      @warning_messages = nil
+    def builder_init
     end
     private :builder_init
 
     def builder_init_file
+      @noindent = nil
+      @ol_num = nil
       @warns = []
       @errors = []
       @chapter.book.image_types = %w[.png .jpg .jpeg .gif .svg]

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -44,8 +44,7 @@ module ReVIEW
       '.xml'
     end
 
-    def builder_init(no_error = false)
-      @no_error = no_error
+    def builder_init
     end
     private :builder_init
 

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -436,8 +436,7 @@ EOS
   end
 
   def test_noindent
-    @builder.noindent
-    actual = compile_block("foo\nbar\n\nfoo2\nbar2\n")
+    actual = compile_block("//noindent\nfoo\nbar\n\nfoo2\nbar2\n")
     assert_equal %Q(<p class="noindent">foobar</p>\n<p>foo2bar2</p>\n), actual
   end
 


### PR DESCRIPTION
remove `@no_error`, `@error_messages` and `@warning_messages`
`@ol_num` and `@noindent` are moved into builder_init_file, because they are initialized per files.

Builder#builder_init is now empty...