### PR TITLE
Preprocessor::Strip should be used only in review-preproc

### DIFF
--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -51,7 +51,7 @@ module ReVIEW
       end
 
       def find_first_header_option
-        f = LineInput.new(Preprocessor::Strip.new(StringIO.new(@content)))
+        f = LineInput.new(StringIO.new(@content))
         while f.next?
           case f.peek
           when /\A=+[\[\s\{]/

--- a/lib/review/preprocessor.rb
+++ b/lib/review/preprocessor.rb
@@ -43,12 +43,6 @@ module ReVIEW
   class Preprocessor
     include ErrorUtils
 
-    def self.strip(f)
-      buf = ''
-      Strip.new(f).each { |line| buf << line.rstrip << "\n" }
-      buf
-    end
-
     class Strip
       def initialize(f)
         @f = f
@@ -68,12 +62,6 @@ module ReVIEW
           return line
         end
         nil
-      end
-
-      def each
-        @f.each do |line|
-          yield line unless /\A\#@/ =~ line
-        end
       end
     end
 

--- a/lib/review/tocparser.rb
+++ b/lib/review/tocparser.rb
@@ -15,8 +15,7 @@ require 'review/textbuilder'
 module ReVIEW
   class TOCParser
     def self.parse(chap)
-      f = StringIO.new(chap.content, 'r:BOM|utf-8')
-      stream = Preprocessor::Strip.new(f)
+      stream = StringIO.new(chap.content, 'r:BOM|utf-8')
       new.parse(stream, chap).map do |root|
         root.number = chap.number
         root


### PR DESCRIPTION
We usually have no need to use Strip class.  review-preproc's --strip option is special case.
In other cases, we should remove comment line `#@...`  without Strip class.

In addition, both Strip#each and Preprocessor.strip are not used.