### PR TITLE
@config['usepackage']の設定を戻す

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2017 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2018 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -239,6 +239,10 @@ module ReVIEW
         @input_files = make_input_files(book, yamlfile)
 
         check_compile_status(@config['ignore-errors'])
+
+        # for backward compatibility
+        @config['usepackage'] = ''
+        @config['usepackage'] = "\\usepackage{#{@config['texstyle']}}" if @config['texstyle']
 
         copy_images(@config['imagedir'], File.join(@path, @config['imagedir']))
         copy_sty(File.join(Dir.pwd, 'sty'), @path)


### PR DESCRIPTION
a54217 で入れていただいた削除変更ですが、カスタムのlayout.tex.erbを使い続けていた場合にusepackageパラメータが空になってしまってまずいことになります。

後方互換性のために戻したい（ただし新しいレイアウトファイルからこのパラメータを使うことはない）と思います。
