### PR TITLE
escape/unescapeのビルダ共通化

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -522,5 +522,13 @@ module ReVIEW
         super(str)
       end
     end
+
+    def escape(str)
+      str
+    end
+
+    def unescape(str)
+      str
+    end
   end
 end # module ReVIEW

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -546,9 +546,9 @@ module ReVIEW
         require 'math_ml'
         require 'math_ml/symbol/character_reference'
         p = MathML::LaTeX::Parser.new(symbol: MathML::Symbol::CharacterReference)
-        puts p.parse(unescape_html(lines.join("\n")), true)
+        puts p.parse(unescape(lines.join("\n")), true)
       elsif @book.config['imgmath']
-        math_str = "\\begin{equation*}\n" + unescape_html(lines.join("\n")) + "\n\\end{equation*}\n"
+        math_str = "\\begin{equation*}\n" + unescape(lines.join("\n")) + "\n\\end{equation*}\n"
         key = Digest::SHA256.hexdigest(math_str)
         math_dir = "./#{@book.config['imagedir']}/_review_math"
         Dir.mkdir(math_dir) unless Dir.exist?(math_dir)
@@ -588,7 +588,7 @@ module ReVIEW
     def image_image(id, caption, metric)
       metrics = parse_metric('html', metric)
       puts %Q(<div id="#{normalize_id(id)}" class="image">)
-      puts %Q(<img src="#{@chapter.image(id).path.sub(%r{\A\./}, '')}" alt="#{escape_html(compile_inline(caption))}"#{metrics} />)
+      puts %Q(<img src="#{@chapter.image(id).path.sub(%r{\A\./}, '')}" alt="#{escape(compile_inline(caption))}"#{metrics} />)
       image_header id, caption
       puts '</div>'
     end
@@ -713,7 +713,7 @@ module ReVIEW
 
     def imgtable_image(id, caption, metric)
       metrics = parse_metric('html', metric)
-      puts %Q(<img src="#{@chapter.image(id).path.sub(%r{\A\./}, '')}" alt="#{escape_html(compile_inline(caption))}"#{metrics} />)
+      puts %Q(<img src="#{@chapter.image(id).path.sub(%r{\A\./}, '')}" alt="#{escape(compile_inline(caption))}"#{metrics} />)
     end
 
     def emtable(lines, caption = nil)
@@ -725,7 +725,7 @@ module ReVIEW
       lines.unshift comment unless comment.blank?
       return unless @book.config['draft']
       str = lines.join('<br />')
-      puts %Q(<div class="draft-comment">#{escape_html(str)}</div>)
+      puts %Q(<div class="draft-comment">#{escape(str)}</div>)
     end
 
     def footnote(id, str)
@@ -741,7 +741,7 @@ module ReVIEW
       caption = '' unless caption.present?
       puts %Q(<div id="#{normalize_id(id)}" class="image">)
       begin
-        puts %Q(<img src="#{@chapter.image(id).path.sub(%r{\A\./}, '')}" alt="#{escape_html(compile_inline(caption))}"#{metrics} />)
+        puts %Q(<img src="#{@chapter.image(id).path.sub(%r{\A\./}, '')}" alt="#{escape(compile_inline(caption))}"#{metrics} />)
       rescue
         warn "image not bound: #{id}"
         if lines
@@ -792,7 +792,7 @@ module ReVIEW
     end
 
     def inline_labelref(idref)
-      %Q(<a target='#{escape_html(idref)}'>「#{I18n.t('label_marker')}#{escape_html(idref)}」</a>)
+      %Q(<a target='#{escape(idref)}'>「#{I18n.t('label_marker')}#{escape(idref)}」</a>)
     end
 
     alias_method :inline_ref, :inline_labelref
@@ -845,50 +845,50 @@ module ReVIEW
 
     def compile_ruby(base, ruby)
       if @book.htmlversion == 5
-        %Q(<ruby>#{escape_html(base)}<rp>#{I18n.t('ruby_prefix')}</rp><rt>#{escape_html(ruby)}</rt><rp>#{I18n.t('ruby_postfix')}</rp></ruby>)
+        %Q(<ruby>#{escape(base)}<rp>#{I18n.t('ruby_prefix')}</rp><rt>#{escape(ruby)}</rt><rp>#{I18n.t('ruby_postfix')}</rp></ruby>)
       else
-        %Q(<ruby><rb>#{escape_html(base)}</rb><rp>#{I18n.t('ruby_prefix')}</rp><rt>#{ruby}</rt><rp>#{I18n.t('ruby_postfix')}</rp></ruby>)
+        %Q(<ruby><rb>#{escape(base)}</rb><rp>#{I18n.t('ruby_prefix')}</rp><rt>#{ruby}</rt><rp>#{I18n.t('ruby_postfix')}</rp></ruby>)
       end
     end
 
     def compile_kw(word, alt)
       %Q(<b class="kw">) +
         if alt
-        then escape_html(word + " (#{alt.strip})")
-        else escape_html(word)
+        then escape(word + " (#{alt.strip})")
+        else escape(word)
         end +
-        "</b><!-- IDX:#{escape_comment(escape_html(word))} -->"
+        "</b><!-- IDX:#{escape_comment(escape(word))} -->"
     end
 
     def inline_i(str)
-      %Q(<i>#{escape_html(str)}</i>)
+      %Q(<i>#{escape(str)}</i>)
     end
 
     def inline_b(str)
-      %Q(<b>#{escape_html(str)}</b>)
+      %Q(<b>#{escape(str)}</b>)
     end
 
     def inline_ami(str)
-      %Q(<span class="ami">#{escape_html(str)}</span>)
+      %Q(<span class="ami">#{escape(str)}</span>)
     end
 
     def inline_bou(str)
-      %Q(<span class="bou">#{escape_html(str)}</span>)
+      %Q(<span class="bou">#{escape(str)}</span>)
     end
 
     def inline_tti(str)
       if @book.htmlversion == 5
-        %Q(<code class="tt"><i>#{escape_html(str)}</i></code>)
+        %Q(<code class="tt"><i>#{escape(str)}</i></code>)
       else
-        %Q(<tt><i>#{escape_html(str)}</i></tt>)
+        %Q(<tt><i>#{escape(str)}</i></tt>)
       end
     end
 
     def inline_ttb(str)
       if @book.htmlversion == 5
-        %Q(<code class="tt"><b>#{escape_html(str)}</b></code>)
+        %Q(<code class="tt"><b>#{escape(str)}</b></code>)
       else
-        %Q(<tt><b>#{escape_html(str)}</b></tt>)
+        %Q(<tt><b>#{escape(str)}</b></tt>)
       end
     end
 
@@ -898,18 +898,18 @@ module ReVIEW
 
     def inline_code(str)
       if @book.htmlversion == 5
-        %Q(<code class="inline-code tt">#{escape_html(str)}</code>)
+        %Q(<code class="inline-code tt">#{escape(str)}</code>)
       else
-        %Q(<tt class="inline-code">#{escape_html(str)}</tt>)
+        %Q(<tt class="inline-code">#{escape(str)}</tt>)
       end
     end
 
     def inline_idx(str)
-      %Q(#{escape_html(str)}<!-- IDX:#{escape_comment(escape_html(str))} -->)
+      %Q(#{escape(str)}<!-- IDX:#{escape_comment(escape(str))} -->)
     end
 
     def inline_hidx(str)
-      %Q(<!-- IDX:#{escape_comment(escape_html(str))} -->)
+      %Q(<!-- IDX:#{escape_comment(escape(str))} -->)
     end
 
     def inline_br(_str)
@@ -931,7 +931,7 @@ module ReVIEW
         make_math_image(math_str, img_path)
         %Q(<span class="equation"><img src="#{img_path}" /></span>)
       else
-        %Q(<span class="equation">#{escape_html(str)}</span>)
+        %Q(<span class="equation">#{escape(str)}</span>)
       end
     end
 
@@ -1048,7 +1048,7 @@ module ReVIEW
     end
 
     def inline_asis(str, tag)
-      %Q(<#{tag}>#{escape_html(str)}</#{tag}>)
+      %Q(<#{tag}>#{escape(str)}</#{tag}>)
     end
 
     def inline_abbr(str)
@@ -1105,9 +1105,9 @@ module ReVIEW
 
     def inline_tt(str)
       if @book.htmlversion == 5
-        %Q(<code class="tt">#{escape_html(str)}</code>)
+        %Q(<code class="tt">#{escape(str)}</code>)
       else
-        %Q(<tt>#{escape_html(str)}</tt>)
+        %Q(<tt>#{escape(str)}</tt>)
       end
     end
 
@@ -1120,11 +1120,11 @@ module ReVIEW
     end
 
     def inline_u(str)
-      %Q(<u>#{escape_html(str)}</u>)
+      %Q(<u>#{escape(str)}</u>)
     end
 
     def inline_recipe(str)
-      %Q(<span class="recipe">「#{escape_html(str)}」</span>)
+      %Q(<span class="recipe">「#{escape(str)}」</span>)
     end
 
     def inline_icon(id)
@@ -1142,7 +1142,7 @@ module ReVIEW
 
     def inline_comment(str)
       if @book.config['draft']
-        %Q(<span class="draft-comment">#{escape_html(str)}</span>)
+        %Q(<span class="draft-comment">#{escape(str)}</span>)
       else
         ''
       end
@@ -1154,7 +1154,7 @@ module ReVIEW
       if str.size == 1 && str.match(/[[:ascii:]]/)
         style = 'upright'
       end
-      %Q(<span class="#{style}">#{escape_html(str)}</span>)
+      %Q(<span class="#{style}">#{escape(str)}</span>)
     end
 
     def inline_raw(str)
@@ -1162,14 +1162,14 @@ module ReVIEW
     end
 
     def nofunc_text(str)
-      escape_html(str)
+      escape(str)
     end
 
     def compile_href(url, label)
       if @book.config['externallink']
-        %Q(<a href="#{escape_html(url)}" class="link">#{label.nil? ? escape_html(url) : escape_html(label)}</a>)
+        %Q(<a href="#{escape(url)}" class="link">#{label.nil? ? escape(url) : escape(label)}</a>)
       else
-        label.nil? ? escape_html(url) : I18n.t('external_link', [escape_html(label), escape_html(url)])
+        label.nil? ? escape(url) : I18n.t('external_link', [escape(label), escape(url)])
       end
     end
 

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2006-2017 Minero Aoki, Kenshi Muto
+# Copyright (c) 2006-2018 Minero Aoki, Kenshi Muto
 #               2002-2006 Minero Aoki
 #
 # This program is free software.
@@ -17,20 +17,20 @@ module ReVIEW
       '"' => '&quot;'
     } # .freeze
 
-    def escape_html(str)
+    def escape(str)
       t = ESC
       str.gsub(/[&"<>]/) { |c| t[c] }
     end
 
-    alias_method :escape, :escape_html
-    alias_method :h, :escape_html
+    alias_method :escape_html, :escape # for backward compatibility
+    alias_method :h, :escape
 
-    def unescape_html(str)
+    def unescape(str)
       # FIXME: better code
       str.gsub('&quot;', '"').gsub('&gt;', '>').gsub('&lt;', '<').gsub('&amp;', '&')
     end
 
-    alias_method :unescape, :unescape_html
+    alias_method :unescape_html, :unescape # for backward compatibility
 
     def strip_html(str)
       str.gsub(%r{</?[^>]*>}, '')
@@ -82,7 +82,7 @@ module ReVIEW
       begin
         require 'pygments'
         begin
-          Pygments.highlight(unescape_html(body),
+          Pygments.highlight(unescape(body),
                              options: options,
                              formatter: format,
                              lexer: lexer)
@@ -122,7 +122,7 @@ module ReVIEW
       end
       raise "unknown formatter #{formatter}" unless formatter
 
-      text = unescape_html(body)
+      text = unescape(body)
       formatter.format(lexer.lex(text))
     end
 

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -153,7 +153,7 @@ module ReVIEW
       prefix, _anchor = headline_prefix(level)
 
       label = label.nil? ? '' : %Q( id="#{label}")
-      toccaption = escape_html(compile_inline(caption.gsub(/@<fn>\{.+?\}/, '')).gsub(/<[^>]+>/, ''))
+      toccaption = escape(compile_inline(caption.gsub(/@<fn>\{.+?\}/, '')).gsub(/<[^>]+>/, ''))
       puts %Q(<title#{label} aid:pstyle="h#{level}">#{prefix}#{compile_inline(caption)}</title><?dtp level="#{level}" section="#{prefix}#{toccaption}"?>)
     end
 
@@ -589,12 +589,12 @@ module ReVIEW
       lines ||= []
       lines.unshift comment unless comment.blank?
       str = lines.join("\n")
-      print "<msg>#{escape_html(str)}</msg>"
+      print "<msg>#{escape(str)}</msg>"
     end
 
     def inline_comment(str)
       if @book.config['draft']
-        %Q(<msg>#{escape_html(str)}</msg>)
+        %Q(<msg>#{escape(str)}</msg>)
       else
         ''
       end
@@ -611,34 +611,34 @@ module ReVIEW
     end
 
     def compile_ruby(base, ruby)
-      %Q(<GroupRuby><aid:ruby xmlns:aid="http://ns.adobe.com/AdobeInDesign/3.0/"><aid:rb>#{escape_html(base.strip)}</aid:rb><aid:rt>#{escape_html(ruby.strip)}</aid:rt></aid:ruby></GroupRuby>)
+      %Q(<GroupRuby><aid:ruby xmlns:aid="http://ns.adobe.com/AdobeInDesign/3.0/"><aid:rb>#{escape(base.strip)}</aid:rb><aid:rt>#{escape(ruby.strip)}</aid:rt></aid:ruby></GroupRuby>)
     end
 
     def compile_kw(word, alt)
       '<keyword>' +
         if alt
-        then escape_html("#{word}（#{alt.strip}）")
-        else escape_html(word)
+        then escape("#{word}（#{alt.strip}）")
+        else escape(word)
         end +
       '</keyword>' +
-        %Q(<index value="#{escape_html(word)}" />) +
+        %Q(<index value="#{escape(word)}" />) +
         if alt
-          alt.split(/\s*,\s*/).collect! { |e| %Q(<index value="#{escape_html(e.strip)}" />) }.join
+          alt.split(/\s*,\s*/).collect! { |e| %Q(<index value="#{escape(e.strip)}" />) }.join
         else
           ''
         end
     end
 
     def compile_href(url, label)
-      %Q(<a linkurl='#{escape_html(url)}'>#{label.nil? ? escape_html(url) : escape_html(label)}</a>)
+      %Q(<a linkurl='#{escape(url)}'>#{label.nil? ? escape(url) : escape(label)}</a>)
     end
 
     def inline_sup(str)
-      %Q(<sup>#{escape_html(str)}</sup>)
+      %Q(<sup>#{escape(str)}</sup>)
     end
 
     def inline_sub(str)
-      %Q(<sub>#{escape_html(str)}</sub>)
+      %Q(<sub>#{escape(str)}</sub>)
     end
 
     def inline_raw(str)
@@ -647,9 +647,9 @@ module ReVIEW
 
     def inline_hint(str)
       if @book.config['nolf']
-        %Q(<hint>#{escape_html(str)}</hint>)
+        %Q(<hint>#{escape(str)}</hint>)
       else
-        %Q(\n<hint>#{escape_html(str)}</hint>)
+        %Q(\n<hint>#{escape(str)}</hint>)
       end
     end
 
@@ -674,41 +674,41 @@ module ReVIEW
     end
 
     def inline_idx(str)
-      %Q(#{escape_html(str)}<index value="#{escape_html(str)}" />)
+      %Q(#{escape(str)}<index value="#{escape(str)}" />)
     end
 
     def inline_hidx(str)
-      %Q(<index value="#{escape_html(str)}" />)
+      %Q(<index value="#{escape(str)}" />)
     end
 
     def inline_ami(str)
-      %Q(<ami>#{escape_html(str)}</ami>)
+      %Q(<ami>#{escape(str)}</ami>)
     end
 
     def inline_i(str)
-      %Q(<i>#{escape_html(str)}</i>)
+      %Q(<i>#{escape(str)}</i>)
     end
 
     def inline_b(str)
-      %Q(<b>#{escape_html(str)}</b>)
+      %Q(<b>#{escape(str)}</b>)
     end
 
     def inline_tt(str)
-      %Q(<tt>#{escape_html(str)}</tt>)
+      %Q(<tt>#{escape(str)}</tt>)
     end
 
     def inline_ttb(str)
-      %Q(<tt style='bold'>#{escape_html(str)}</tt>)
+      %Q(<tt style='bold'>#{escape(str)}</tt>)
     end
 
     alias_method :inline_ttbold, :inline_ttb
 
     def inline_tti(str)
-      %Q(<tt style='italic'>#{escape_html(str)}</tt>)
+      %Q(<tt style='italic'>#{escape(str)}</tt>)
     end
 
     def inline_u(str)
-      %Q(<underline>#{escape_html(str)}</underline>)
+      %Q(<underline>#{escape(str)}</underline>)
     end
 
     def inline_icon(id)
@@ -721,25 +721,25 @@ module ReVIEW
     end
 
     def inline_bou(str)
-      %Q(<bou>#{escape_html(str)}</bou>)
+      %Q(<bou>#{escape(str)}</bou>)
     end
 
     def inline_keytop(str)
-      %Q(<keytop>#{escape_html(str)}</keytop>)
+      %Q(<keytop>#{escape(str)}</keytop>)
     end
 
     def inline_labelref(idref)
-      %Q(<ref idref='#{escape_html(idref)}'>「#{I18n.t('label_marker')}#{escape_html(idref)}」</ref>) # FIXME: 節名とタイトルも込みで要出力
+      %Q(<ref idref='#{escape(idref)}'>「#{I18n.t('label_marker')}#{escape(idref)}」</ref>) # FIXME: 節名とタイトルも込みで要出力
     end
 
     alias_method :inline_ref, :inline_labelref
 
     def inline_pageref(idref)
-      %Q(<pageref idref='#{escape_html(idref)}'>●●</pageref>) # ページ番号を参照
+      %Q(<pageref idref='#{escape(idref)}'>●●</pageref>) # ページ番号を参照
     end
 
     def inline_balloon(str)
-      %Q(<balloon>#{escape_html(str).gsub(/@maru\[(\d+)\]/) { inline_maru($1) }}</balloon>)
+      %Q(<balloon>#{escape(str).gsub(/@maru\[(\d+)\]/) { inline_maru($1) }}</balloon>)
     end
 
     def inline_uchar(str)
@@ -748,7 +748,7 @@ module ReVIEW
 
     def inline_m(str)
       @texinlineequation += 1
-      %Q(<replace idref="texinline-#{@texinlineequation}"><pre>#{escape_html(str)}</pre></replace>)
+      %Q(<replace idref="texinline-#{@texinlineequation}"><pre>#{escape(str)}</pre></replace>)
     end
 
     def noindent
@@ -764,7 +764,7 @@ module ReVIEW
     end
 
     def nonum_begin(level, _label, caption)
-      puts %Q(<title aid:pstyle="h#{level}">#{compile_inline(caption)}</title><?dtp level="#{level}" section="#{escape_html(compile_inline(caption))}"?>)
+      puts %Q(<title aid:pstyle="h#{level}">#{compile_inline(caption)}</title><?dtp level="#{level}" section="#{escape(compile_inline(caption))}"?>)
     end
 
     def nonum_end(level)
@@ -781,7 +781,7 @@ module ReVIEW
       @column += 1
       a_id = %Q(id="column-#{@column}")
       print "<#{type}column #{a_id}>"
-      puts %Q(<title aid:pstyle="#{type}column-title">#{compile_inline(caption)}</title><?dtp level="9" section="#{escape_html(compile_inline(caption))}"?>)
+      puts %Q(<title aid:pstyle="#{type}column-title">#{compile_inline(caption)}</title><?dtp level="9" section="#{escape(compile_inline(caption))}"?>)
     end
 
     def common_column_end(type)
@@ -1033,7 +1033,7 @@ module ReVIEW
     end
 
     def inline_code(str)
-      %Q(<tt type='inline-code'>#{escape_html(str)}</tt>)
+      %Q(<tt type='inline-code'>#{escape(str)}</tt>)
     end
 
     def inline_br(_str)
@@ -1140,11 +1140,11 @@ module ReVIEW
 
     def inline_recipe(id)
       # FIXME
-      %Q(<recipe idref="#{escape_html(id)}">[XXX]「#{escape_html(id)}」　p.XX</recipe>)
+      %Q(<recipe idref="#{escape(id)}">[XXX]「#{escape(id)}」　p.XX</recipe>)
     end
 
     def nofunc_text(str)
-      escape_html(str)
+      escape(str)
     end
 
     def image_ext

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -365,7 +365,7 @@ module ReVIEW
       if title == 'title' && caption.blank?
         print '\vspace{-1.5em}'
       end
-      body = lines.inject('') { |i, j| i + detab(unescape_latex(j)) + "\n" }
+      body = lines.inject('') { |i, j| i + detab(unescape(j)) + "\n" }
       args = make_code_block_args(title, caption, lang, first_line_num: first_line_num)
       puts %Q(\\begin{#{command}}[#{args}])
       print body
@@ -688,7 +688,7 @@ module ReVIEW
       blank
       puts macro('begin', 'equation*')
       lines.each do |line|
-        puts unescape_latex(line)
+        puts unescape(line)
       end
       puts macro('end', 'equation*')
       blank
@@ -1008,10 +1008,10 @@ module ReVIEW
 
       sa.map! do |item|
         if @index_db[item]
-          escape_index(escape_latex(@index_db[item])) + '@' + escape_index(escape_latex(item))
+          escape_index(escape(@index_db[item])) + '@' + escape_index(escape(item))
         else
           if item =~ /\A[[:ascii:]]+\Z/ || @index_mecab.nil?
-            esc_item = escape_index(escape_latex(item))
+            esc_item = escape_index(escape(item))
             if esc_item != item
               "#{escape_index(item)}@#{esc_item}"
             else
@@ -1019,7 +1019,7 @@ module ReVIEW
             end
           else
             yomi = NKF.nkf('-w --hiragana', @index_mecab.parse(item).force_encoding('UTF-8').chomp)
-            escape_index(escape_latex(yomi)) + '@' + escape_index(escape_latex(item))
+            escape_index(escape(yomi)) + '@' + escape_index(escape(item))
           end
         end
       end

--- a/lib/review/latexutils.rb
+++ b/lib/review/latexutils.rb
@@ -1,5 +1,5 @@
 # Copyright (c) 2002-2006 Minero Aoki
-# Copyright (c) 2006-2017 Minero Aoki, Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2006-2018 Minero Aoki, Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -64,18 +64,18 @@ module ReVIEW
       @metachars_invert = @metachars.invert
     end
 
-    def escape_latex(str)
+    def escape(str)
       str.gsub(@metachars_re) { |s| @metachars[s] or raise "unknown trans char: #{s}" }
     end
 
-    alias_method :escape, :escape_latex
+    alias_method :escape_latex, :escape # backward compatibility
 
-    def unescape_latex(str)
+    def unescape(str)
       metachars_invert_re = Regexp.new(@metachars_invert.keys.collect { |key| Regexp.escape(key) }.join('|'))
       str.gsub(metachars_invert_re) { |s| @metachars_invert[s] or raise "unknown trans char: #{s}" }
     end
 
-    alias_method :unescape, :unescape_latex
+    alias_method :unescape_latex, :unescape # backward compatibility
 
     def escape_index(str)
       str.gsub(/[@!|"]/) { |s| '"' + s }

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -293,9 +293,9 @@ module ReVIEW
 
     def compile_ruby(base, ruby)
       if @book.htmlversion == 5
-        %Q(<ruby>#{escape_html(base)}<rp>#{I18n.t('ruby_prefix')}</rp><rt>#{escape_html(ruby)}</rt><rp>#{I18n.t('ruby_postfix')}</rp></ruby>)
+        %Q(<ruby>#{escape(base)}<rp>#{I18n.t('ruby_prefix')}</rp><rt>#{escape(ruby)}</rt><rp>#{I18n.t('ruby_postfix')}</rp></ruby>)
       else
-        %Q(<ruby><rb>#{escape_html(base)}</rb><rp>#{I18n.t('ruby_prefix')}</rp><rt>#{ruby}</rt><rp>#{I18n.t('ruby_postfix')}</rp></ruby>)
+        %Q(<ruby><rb>#{escape(base)}</rb><rp>#{I18n.t('ruby_prefix')}</rp><rt>#{ruby}</rt><rp>#{I18n.t('ruby_postfix')}</rp></ruby>)
       end
     end
 
@@ -306,12 +306,12 @@ module ReVIEW
         lines.unshift comment
       end
       str = lines.join('<br />')
-      puts %Q(<div class="red">#{escape_html(str)}</div>)
+      puts %Q(<div class="red">#{escape(str)}</div>)
     end
 
     def inline_comment(str)
       if @book.config['draft']
-        %Q(<span class="red">#{escape_html(str)}</span>)
+        %Q(<span class="red">#{escape(str)}</span>)
       else
         ''
       end

--- a/lib/review/md2inaobuilder.rb
+++ b/lib/review/md2inaobuilder.rb
@@ -44,9 +44,9 @@ module ReVIEW
 
     def compile_ruby(base, ruby)
       if base.length == 1
-        %Q[<span class='monoruby'>#{escape_html(base)}(#{escape_html(ruby)})</span>]
+        %Q[<span class='monoruby'>#{escape(base)}(#{escape(ruby)})</span>]
       else
-        %Q[<span class='groupruby'>#{escape_html(base)}(#{escape_html(ruby)})</span>]
+        %Q[<span class='groupruby'>#{escape(base)}(#{escape(ruby)})</span>]
       end
     end
   end

--- a/test/test_htmlutils.rb
+++ b/test/test_htmlutils.rb
@@ -5,9 +5,16 @@ class HTMLUtilsTest < Test::Unit::TestCase
   include ReVIEW::HTMLUtils
 
   def test_escape_html
-    assert_equal '&lt;', escape_html('<')
-    assert_equal '&lt;&lt;', escape_html('<<')
-    assert_equal '_&lt;_&lt;_', escape_html('_<_<_')
+    assert_equal '&lt;', escape('<')
+    assert_equal '&lt;&lt;', escape('<<')
+    assert_equal '_&lt;_&lt;_', escape('_<_<_')
+  end
+
+  def test_unescape_html
+    assert_equal '<', unescape('&lt;')
+    assert_equal '>', unescape('&gt;')
+    assert_equal '&', unescape('&amp;')
+    assert_equal '&amp;', unescape('&amp;amp;')
   end
 
   def test_escape_html_ex
@@ -15,9 +22,9 @@ class HTMLUtilsTest < Test::Unit::TestCase
     ESC['.'] = 'X'
     ESC.each_pair do |ch, ref|
       if keys.include?(ch)
-        assert_equal ref, escape_html(ch)
+        assert_equal ref, escape(ch)
       else
-        assert_equal ch, escape_html(ch)
+        assert_equal ch, escape(ch)
       end
     end
   end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -27,6 +27,16 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     I18n.setup('ja')
   end
 
+  def test_escape
+    actual = @builder.escape('<>&_')
+    assert_equal %Q(\\textless{}\\textgreater{}\\&\\textunderscore{}), actual
+  end
+
+  def test_unescape
+    actual = @builder.unescape(%Q(\\textless{}\\textgreater{}\\&\\textunderscore{}))
+    assert_equal '<>&_', actual
+  end
+
   def test_headline_level1
     actual = compile_block("={test} this is test.\n")
     assert_equal %Q(\\chapter{this is test.}\n\\label{chap:chap1}\n), actual


### PR DESCRIPTION
#1007 の前段階として、Builderでescape/unescapeメソッドを提供します（Builderでは実質何も加工せずそのまま文字列を返します）。

html, latexはもともとaliasで提供していましたので、正をescape/unescapeとし、escape_latex/escape_htmlをエイリアスとしています（既存のreview-ext.rb互換用）。
