### PR TITLE
rouge時の処理のエラー対応

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -390,10 +390,9 @@ module ReVIEW
       end
     end
 
-    def list_body(id, lines, lang)
-      id ||= ''
+    def list_body(_id, lines, lang)
       class_names = ['list']
-      lexer = lang || File.extname(id).gsub('.', '')
+      lexer = lang
       class_names.push("language-#{lexer}") unless lexer.blank?
       class_names.push('highlight') if highlight?
       print %Q(<pre class="#{class_names.join(' ')}">)
@@ -415,11 +414,10 @@ module ReVIEW
       end
     end
 
-    def source_body(id, lines, lang)
-      id ||= ''
+    def source_body(_id, lines, lang)
       print %Q(<pre class="source">)
       body = lines.inject('') { |i, j| i + detab(j) + "\n" }
-      lexer = lang || File.extname(id).gsub('.', '')
+      lexer = lang
       puts highlight(body: body, lexer: lexer, format: 'html')
       puts '</pre>'
     end

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -112,7 +112,10 @@ module ReVIEW
 
       require 'rouge'
       lexer = Rouge::Lexer.find(lexer)
-      raise "unknown lexer #{lexer}" unless lexer
+
+      unless lexer
+        return body
+      end
 
       formatter = Rouge::Formatters::HTML.new(css_class: 'highlight')
       if ops[:linenum]
@@ -120,7 +123,10 @@ module ReVIEW
                                                      table_class: 'highlight rouge-table',
                                                      start_line: first_line_num)
       end
-      raise "unknown formatter #{formatter}" unless formatter
+
+      unless formatter
+        return body
+      end
 
       text = unescape(body)
       formatter.format(lexer.lex(text))

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -748,14 +748,6 @@ EOS
     assert_equal %Q(<div id="samplelist" class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list highlight">def foo(a1, a2=:test)\n  (1..3).times{|i| a.include?(:foo)}\n  return true\nend\n\n</pre>\n</div>\n), actual
   end
 
-  def test_list_ext
-    def @chapter.list(_id)
-      Book::ListIndex::Item.new('samplelist.rb', 1)
-    end
-    actual = compile_block("//list[samplelist.rb][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<div id="samplelist.rb" class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list language-rb">test1\ntest1.5\n\ntest<i>2</i>\n</pre>\n</div>\n), actual
-  end
-
   def test_listnum
     def @chapter.list(_id)
       Book::ListIndex::Item.new('samplelist', 1)


### PR DESCRIPTION
#1016 の修正

- 識別子IDによるlexer自動判定をやめる（HTMLビルダのみ、かつ//list、//listnumしか使えない）。各リストタグのlangオプションを使うべき
- 上記に伴い自動判定テストを1つ削除
- rougeの処理でlexerおよびformatterの判定に失敗したときにraiseせず、pygmentsと同様にハイライト前のbodyをただ返すようにする（そもそも前のコードだとnilの内容を`#{}`で表示しようとしていて意味がない）
