### PR TITLE
rename version-depend method name

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -104,9 +104,13 @@ module ReVIEW
       nil
     end
 
-    def check_version(version)
+    def check_version(version, exception: true)
       unless self.key?('review_version')
-        raise ReVIEW::ConfigError, 'configuration file has no review_version property.'
+        if exception
+          raise ReVIEW::ConfigError, 'configuration file has no review_version property.'
+        else
+          return false
+        end
       end
 
       if self['review_version'].blank?
@@ -114,10 +118,19 @@ module ReVIEW
       end
 
       if self['review_version'].to_i != version.to_i ## major version
-        raise ReVIEW::ConfigError, 'major version of configuration file is different.'
+        if exception
+          raise ReVIEW::ConfigError, 'major version of configuration file is different.'
+        else
+          return false
+        end
       elsif self['review_version'].to_f > version.to_f ## minor version
-        raise ReVIEW::ConfigError, "Re:VIEW version '#{version}' is older than configuration file's version '#{self['review_version']}'."
+        if exception
+          raise ReVIEW::ConfigError, "Re:VIEW version '#{version}' is older than configuration file's version '#{self['review_version']}'."
+        else
+          return false
+        end
       end
+      return true
     end
 
     def name_of(key)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -845,7 +845,7 @@ module ReVIEW
 
     # math
     def inline_m(str)
-      if is_r2?
+      if @book.config.check_version('2', exception: false)
         "$#{str}$"
       else
         " $#{str}$ "
@@ -859,7 +859,7 @@ module ReVIEW
 
     # index -> italic
     def inline_i(str)
-      if is_r2?
+      if @book.config.check_version('2', exception: false)
         macro('textit', escape(str))
       else
         macro('reviewit', escape(str))
@@ -878,7 +878,7 @@ module ReVIEW
 
     # bold
     def inline_b(str)
-      if is_r2?
+      if @book.config.check_version('2', exception: false)
         macro('textbf', escape(str))
       else
         macro('reviewbold', escape(str))
@@ -897,7 +897,7 @@ module ReVIEW
 
     ## @<code> is same as @<tt>
     def inline_code(str)
-      if is_r2?
+      if @book.config.check_version('2', exception: false)
         macro('texttt', escape(str))
       else
         macro('reviewcode', escape(str))
@@ -909,7 +909,7 @@ module ReVIEW
     end
 
     def inline_tt(str)
-      if is_r2?
+      if @book.config.check_version('2', exception: false)
         macro('texttt', escape(str))
       else
         macro('reviewtt', escape(str))
@@ -921,7 +921,7 @@ module ReVIEW
     end
 
     def inline_tti(str)
-      if is_r2?
+      if @book.config.check_version('2', exception: false)
         macro('texttt', macro('textit', escape(str)))
       else
         macro('reviewtti', escape(str))
@@ -929,7 +929,7 @@ module ReVIEW
     end
 
     def inline_ttb(str)
-      if is_r2?
+      if @book.config.check_version('2', exception: false)
         macro('texttt', macro('textbf', escape(str)))
       else
         macro('reviewttb', escape(str))

--- a/lib/review/latexutils.rb
+++ b/lib/review/latexutils.rb
@@ -88,13 +88,5 @@ module ReVIEW
     def macro(name, *args)
       "\\#{name}" + args.map { |a| "{#{a}}" }.join
     end
-
-    def is_r2?
-      if @book.config['review_version'] && @book.config['review_version'].to_f < 3
-        true
-      else
-        false
-      end
-    end
   end
 end


### PR DESCRIPTION
`is_r2?`はさすがにバージョン番号を陽に書くのはいかがなものか…ということで、Configure#check_versionの例外を挙げないやつを作ってみました。