### PR TITLE
suppress rubocop

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,7 @@ Lint/UselessAssignment:
 #### Performance
 
 Performance/RegexpMatch:
-  Enabled: true
+  Enabled: false
 
 Performance/ReverseEach:
   Enabled: true


### PR DESCRIPTION
`Regexp#match?` is supported only `>= Ruby 2.4`.