### PR TITLE
suppress warning of `@<w>{}` in tests

### DIFF
--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1721,9 +1721,11 @@ EOS
 EOB
       end
       @book.config['words_file'] = File.join(dir, 'words.csv')
-
+      io = StringIO.new
+      @builder.instance_eval{ @logger = ReVIEW::Logger.new(io) }
       actual = compile_block('@<w>{F} @<w>{B} @<wb>{B} @<w>{N}')
       assert_equal %Q(<p>foo bar&quot;\\&lt;&gt;_@&lt;b&gt;{BAZ} <b>bar&quot;\\&lt;&gt;_@&lt;b&gt;{BAZ}</b> [missing word: N]</p>\n), actual
+      assert_match(/WARN -- : :1: word not bound: N/, io.string)
     end
   end
 

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1005,12 +1005,15 @@ EOB
       end
       @book.config['words_file'] = File.join(dir, 'words.csv')
 
+      io = StringIO.new
+      @builder.instance_eval{ @logger = ReVIEW::Logger.new(io) }
       actual = compile_block('@<w>{F} @<w>{B} @<wb>{B} @<w>{N}')
       expected = <<-EOS
 
 foo bar"\\reviewbackslash{}\\textless{}\\textgreater{}\\textunderscore{}@\\textless{}b\\textgreater{}\\{BAZ\\} \\reviewbold{bar"\\reviewbackslash{}\\textless{}\\textgreater{}\\textunderscore{}@\\textless{}b\\textgreater{}\\{BAZ\\}} [missing word: N]
 EOS
       assert_equal expected, actual
+      assert_match(/WARN -- : :1: word not bound: N/, io.string)
     end
   end
 

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -301,8 +301,11 @@ EOB
       end
       @book.config['words_file'] = File.join(dir, 'words.csv')
 
+      io = StringIO.new
+      @builder.instance_eval{ @logger = ReVIEW::Logger.new(io) }
       actual = compile_block('@<w>{F} @<w>{B} @<wb>{B} @<w>{N}')
       assert_equal %Q(foo bar"\\<>_@<b>{BAZ} ★bar"\\<>_@<b>{BAZ}☆ [missing word: N]\n), actual
+      assert_match(/WARN -- : :1: word not bound: N/, io.string)
     end
   end
 


### PR DESCRIPTION
テストで警告が出るので、出力しない＆警告の中身をテストするように修正します