### PR TITLE
HTMLBuilder: hide latex log of `@<m>{...}` amd `//texequation{...//}`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -397,6 +397,8 @@ Metrics/PerceivedComplexity:
 
 Metrics/ClassLength:
   Max: 1500
+  Exclude:
+    - 'test/*.rb'
 
 Metrics/LineLength:
   Max: 256

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -14,6 +14,7 @@ require 'review/textutils'
 require 'review/webtocprinter'
 require 'digest'
 require 'tmpdir'
+require 'open3'
 
 module ReVIEW
   class HTMLBuilder < Builder
@@ -1208,7 +1209,11 @@ module ReVIEW
         tex_path = File.join(tmpdir, 'tmpmath.tex')
         dvi_path = File.join(tmpdir, 'tmpmath.dvi')
         File.write(tex_path, texsrc)
-        system("latex --interaction=nonstopmode --output-directory=#{tmpdir} #{tex_path} && dvipng -T tight -z9 -o #{path} #{dvi_path}")
+        cmd = "latex --interaction=nonstopmode --output-directory=#{tmpdir} #{tex_path} && dvipng -T tight -z9 -o #{path} #{dvi_path}"
+        out, status = Open3.capture2e(cmd)
+        unless status.success?
+          error "latex compile error\n\nError log:\n" + out
+        end
       end
     end
   end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1088,6 +1088,28 @@ EOS
     end
   end
 
+  def test_texequation_fail
+    mktmpbookdir('catalog.yml' => "CHAPS:\n - ch01.re\n",
+                 'ch01.re' => "= test\n\n//texequation{\np \\land \\bm{P}} q\n//}\n") do |dir, book, _files|
+      @book = book
+      @book.config = @config
+      @config['imgmath'] = true
+      @chapter = Book::Chapter.new(@book, 1, '-', nil, StringIO.new)
+      location = Location.new(nil, nil)
+      @builder.bind(@compiler, @chapter, location)
+      FileUtils.mkdir_p(File.join(dir, 'images'))
+      tmpio = $stderr
+      $stderr = StringIO.new
+      begin
+        assert_raise(ReVIEW::ApplicationError) do
+          _result = compile_block("//texequation{\np \\land \\bm{P}} q\n//}\n")
+        end
+      ensure
+        $stderr = tmpio
+      end
+    end
+  end
+
   def test_bib
     def @chapter.bibpaper(_id)
       Book::BibpaperIndex::Item.new('samplebib', 1, 'sample bib')

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1062,6 +1062,8 @@ EOS
   end
 
   def test_texequation
+    return true if /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
+    return true unless system('latex -version 1>/dev/null 2>/dev/null')
     mktmpbookdir('catalog.yml' => "CHAPS:\n - ch01.re\n",
                  'ch01.re' => "= test\n\n//texequation{\np \\land \\bm{P} q\n//}\n") do |dir, book, _files|
       @book = book
@@ -1089,6 +1091,8 @@ EOS
   end
 
   def test_texequation_fail
+    return true if /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
+    return true unless system('latex -version 1>/dev/null 2>/dev/null')
     mktmpbookdir('catalog.yml' => "CHAPS:\n - ch01.re\n",
                  'ch01.re' => "= test\n\n//texequation{\np \\land \\bm{P}} q\n//}\n") do |dir, book, _files|
       @book = book


### PR DESCRIPTION
`@<m>{...}`や`//texequation{...//}`で数式画像を生成する際にLaTeXのログが出力されるのを抑制します。
エラーが出た場合にはその際にログをまとめて出力します。