### PR TITLE
support pxrubrica by default

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -840,7 +840,7 @@ module ReVIEW
     end
 
     def compile_ruby(base, ruby)
-      macro('ruby', escape(base), escape(ruby))
+      macro('ruby', escape(base), escape(ruby).gsub('\\textbar{}', '|'))
     end
 
     # math

--- a/templates/latex/review-jsbook/review-basemacros.sty
+++ b/templates/latex/review-jsbook/review-basemacros.sty
@@ -46,6 +46,8 @@
      pdftitle={\review@booktitle_name},%
      pdfauthor={\review@aut_names}]{hyperref}
 \usepackage[dvipdfmx]{pxjahyper}
+\usepackage{pxrubrica}
+\rubysetup{g}
 
 \ifthenelse{\equal{\review@documentclass}{utbook} \OR \equal{\review@documentclass}{tbook}}{%
 \newcommand{\headfont}{\gtfamily\sffamily\bfseries}

--- a/templates/latex/review-jsbook/review-basemacros.sty
+++ b/templates/latex/review-jsbook/review-basemacros.sty
@@ -47,7 +47,7 @@
      pdfauthor={\review@aut_names}]{hyperref}
 \usepackage[dvipdfmx]{pxjahyper}
 \usepackage{pxrubrica}
-\rubysetup{g}
+\rubysetup{J}
 
 \ifthenelse{\equal{\review@documentclass}{utbook} \OR \equal{\review@documentclass}{tbook}}{%
 \newcommand{\headfont}{\gtfamily\sffamily\bfseries}


### PR DESCRIPTION
related to: #655 

標準はグループルビにしています。
※現状のRe:VIEWではルビ文字列に`|`が突っ込めない（エスケープされる）のでグループルビ以外NGです