### PR TITLE
remove duplicated tcy

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -228,7 +228,6 @@ module ReVIEW
     definline :hidx
     definline :comment
     definline :include
-    definline :tcy
     definline :embed
     definline :pageref
     definline :w


### PR DESCRIPTION
`definline :tcy` is duplicated in compile.rb