### PR TITLE
LATEXBuilder: fix empty caption for listings

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -362,9 +362,6 @@ module ReVIEW
     end
 
     def common_code_block_lst(_id, lines, command, title, caption, lang, first_line_num: 1)
-      if title == 'title' && caption.blank?
-        print '\vspace{-1.5em}'
-      end
       body = lines.inject('') { |i, j| i + detab(unescape(j)) + "\n" }
       args = make_code_block_args(title, caption, lang, first_line_num: first_line_num)
       puts %Q(\\begin{#{command}}[#{args}])
@@ -375,18 +372,20 @@ module ReVIEW
 
     def make_code_block_args(title, caption, lang, first_line_num: 1)
       caption_str = compile_inline((caption || ''))
-      if title == 'title' && caption_str == ''
-        caption_str = '\relax' ## dummy charactor to remove lstname
-      end
       lexer = if @book.config['highlight'] && @book.config['highlight']['lang']
                 @book.config['highlight']['lang'] # default setting
               else
                 ''
               end
       lexer = lang if lang.present?
-      args = %Q(#{title}={#{caption_str}},language={#{lexer}})
+      args = "language={#{lexer}}"
+      if title == 'title' && caption_str == ''
+        # ignore
+      else
+        args = "#{title}={#{caption_str}}," + args
+      end
       if first_line_num != 1
-        args += ",firstnumber=#{first_line_num}"
+        args << ",firstnumber=#{first_line_num}"
       end
       args
     end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -297,7 +297,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//cmd{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\vspace{-1.5em}\\begin{reviewcmdlst}[title={\\relax},language={}]\nfoo\nbar\n\nbuz\n\\end{reviewcmdlst}\n), actual
+    assert_equal %Q(\\begin{reviewcmdlst}[language={}]\nfoo\nbar\n\nbuz\n\\end{reviewcmdlst}\n), actual
   end
 
   def test_emlist
@@ -309,7 +309,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//emlist[][sql]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
-    assert_equal %Q(\n\\vspace{-1.5em}\\begin{reviewemlistlst}[title={\\relax},language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewemlistlst}\n), actual
+    assert_equal %Q(\n\\begin{reviewemlistlst}[language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewemlistlst}\n), actual
   end
 
   def test_emlist_lst_without_lang
@@ -317,7 +317,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     @book.config['highlight']['latex'] = 'listings'
     @book.config['highlight']['lang'] = 'sql'
     actual = compile_block("//emlist[]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
-    assert_equal %Q(\n\\vspace{-1.5em}\\begin{reviewemlistlst}[title={\\relax},language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewemlistlst}\n), actual
+    assert_equal %Q(\n\\begin{reviewemlistlst}[language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewemlistlst}\n), actual
   end
 
   def test_emlist_caption


### PR DESCRIPTION
* remove `\vspace{-1.5em}`
* remove caption if caption (and title) is empty