### PR TITLE
LATEXBuilder: allow to use Unicode character without otf package if possible

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -1001,8 +1001,13 @@ module ReVIEW
     end
 
     def inline_uchar(str)
-      # with otf package
-      macro('UTF', escape(str))
+      if @texcompiler && @texcompiler.start_with?('platex')
+        # with otf package
+        macro('UTF', escape(str))
+      else
+        # passthrough
+        [str.to_i(16)].pack('U')
+      end
     end
 
     def inline_comment(str)

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -235,7 +235,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def test_inline_uchar
     actual = compile_inline('test @<uchar>{2460} test2')
-    assert_equal 'test \\UTF{2460} test2', actual
+    assert_equal 'test ① test2', actual
   end
 
   def test_inline_idx


### PR DESCRIPTION
uplatexやlualatexの場合、`@<uchar>` で指定したUnicode文字を`\UTF`マクロなしでベタに出力するものです。