### PR TITLE
RakefileのCONFIG_FILEをrake実行時に上書きしたい

### DIFF
--- a/test/sample-book/src/Rakefile
+++ b/test/sample-book/src/Rakefile
@@ -1,11 +1,11 @@
 require 'fileutils'
 require 'rake/clean'
 
-BOOK = 'book'
+BOOK = ENV['BOOK'] || 'book'
 BOOK_PDF = BOOK + '.pdf'
 BOOK_EPUB = BOOK + '.epub'
-CONFIG_FILE = 'config.yml'
-WEBROOT = 'webroot'
+CONFIG_FILE = ENV['CONFIG_FILE'] || 'config.yml'
+WEBROOT = ENV['WEBROOT'] || 'webroot'
 TEXTROOT = BOOK + '-text'
 TOPROOT = BOOK + '-text'
 

--- a/test/sample-book/src/Rakefile
+++ b/test/sample-book/src/Rakefile
@@ -1,11 +1,11 @@
 require 'fileutils'
 require 'rake/clean'
 
-BOOK = ENV['BOOK'] || 'book'
+BOOK = ENV['REVIEW_BOOK'] || 'book'
 BOOK_PDF = BOOK + '.pdf'
 BOOK_EPUB = BOOK + '.epub'
-CONFIG_FILE = ENV['CONFIG_FILE'] || 'config.yml'
-WEBROOT = ENV['WEBROOT'] || 'webroot'
+CONFIG_FILE = ENV['REVIEW_CONFIG_FILE'] || 'config.yml'
+WEBROOT = ENV['REVIEW_WEBROOT'] || 'webroot'
 TEXTROOT = BOOK + '-text'
 TOPROOT = BOOK + '-text'
 


### PR DESCRIPTION
RakefileのCONFIG_FILEやいくつかの変数をrake実行時に上書きできるようにしました。

たとえば通常の設定はconfig.ymlに書いているものの、体験版だけ生成するファイル名や表紙を変えたい場合に、以下のようなconfig-taiken.ymlを作っています。

```
inherit: ["config.yml"]
bookname: book-taiken
booktitle: Re:VIEWサンプル書籍【体験版】
coverimage: cover-taiken.png
```

このconfig-taiken.ymlを使いたいときに、lib/task/review.rakeを書き換えることなく以下のように実行できると嬉しいというのが、本変更の趣旨です。

```
$ rake CONFIG_FILE=config-taiken.yml all
```

一応BOOKやWEBROOTも変えられるようにはしています。BOOKが変えられるようになると、config.ymlのbooknameを変更していてもrake cleanできるというメリットもあります。