### PR TITLE
Rakefileの依存関係にcatalog.ymlなどを追加したい

### DIFF
--- a/test/sample-book/src/Rakefile
+++ b/test/sample-book/src/Rakefile
@@ -5,6 +5,7 @@ BOOK = ENV['REVIEW_BOOK'] || 'book'
 BOOK_PDF = BOOK + '.pdf'
 BOOK_EPUB = BOOK + '.epub'
 CONFIG_FILE = ENV['REVIEW_CONFIG_FILE'] || 'config.yml'
+CATALOG_FILE = ENV['REVIEW_CATALOG_FILE'] || 'catalog.yml'
 WEBROOT = ENV['REVIEW_WEBROOT'] || 'webroot'
 TEXTROOT = BOOK + '-text'
 TOPROOT = BOOK + '-text'
@@ -64,14 +65,19 @@ end
 desc 'generate EPUB file'
 task epub: BOOK_EPUB
 
-SRC = FileList['*.re'] + [CONFIG_FILE]
+IMAGES = FileList['images/**/*']
+OTHERS = ENV['REVIEW_DEPS'] ? ENV['REVIEW_DEPS'].split(',') : []
+SRC = FileList['./**/*.re', '*.rb'] + [CONFIG_FILE, CATALOG_FILE] \
+        + IMAGES + OTHERS
+SRC_EPUB = FileList['*.css']
+SRC_PDF = FileList['layouts/*.erb', 'sty/**/*.sty']
 
-file BOOK_PDF => SRC do
+file BOOK_PDF => SRC + SRC_PDF do
   FileUtils.rm_rf [BOOK_PDF, BOOK, BOOK + '-pdf']
   sh "review-pdfmaker #{CONFIG_FILE}"
 end
 
-file BOOK_EPUB => SRC do
+file BOOK_EPUB => SRC + SRC_EPUB do
   FileUtils.rm_rf [BOOK_EPUB, BOOK, BOOK + '-epub']
   sh "review-epubmaker #{CONFIG_FILE}"
 end


### PR DESCRIPTION
catalog.ymlやimages/以下のファイルが更新されたときにも、
rake allでepubやpdfが再ビルドされると嬉しいです。

本修正では以下のファイルがビルド時の依存ファイルとなります。

* カレントディレクトリ以下のすべての.reファイル
  * 注：これまではカレントディレクトリ直下のみ対象だった
* カレントディレクトリ直下の.rbファイル（``review-ext.rb``用）
* カレントディレクトリ直下の.cssファイル（epub taskのみ）
* sty/以下の.styファイルとlayouts/直下の.erbファイル（pdf taskのみ）
* images/以下のすべてのファイル
* 環境変数``REVIEW_DEPS``でカンマ区切りで指定したファイル
  * ``credit.xhtml``のようなconfig.ymlの設定次第で必要になるファイルを想定しています

また、一応catalog.ymlも変数化して環境変数で上書きできるようにはしてあります。

実際にtouchとrakeを繰り返した例は以下のとおりです。

```
$ rake all
$ touch catalog.yml
$ rake all
review-pdfmaker config.yml
(snip)
review-epubmaker config.yml
(snip)

epub taskのみ影響するファイル
$ touch style.css
$ rake all
review-epubmaker config.yml
(snip)

pdftask のみ影響するファイル
$ touch sty/review-base.sty
$ rake all
review-pdfmaker config.yml
(snip)

REVIEW_DEPSを指定しなかったときと指定したとき
$ touch Gemfile
$ rake all
$ rake REVIEW_DEPS=Gemfile all
review-pdfmaker config.yml
(snip)
review-epubmaker config.yml
(snip)
$ touch Rakefile
$ rake REVIEW_DEPS=Gemfile,Rakefile all
review-pdfmaker config.yml
(snip)
review-epubmaker config.yml
(snip)
```

以上、よろしくお願いいたします。