### PR TITLE
dvipdfmxオプションはdvicommandパラメータの文字列で判定するように

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -377,9 +377,13 @@ module ReVIEW
     end
 
     def erb_config
+      @texcompiler = File.basename(@config['texcommand'], '.*')
       dclass = @config['texdocumentclass'] || []
       @documentclass = dclass[0] || 'jsbook'
       @documentclassoption = dclass[1] || 'uplatex,oneside'
+      if @config['dvicommand'] =~ /dvipdfmx/ && @documentclassoption !~ /dvipdfmx/
+        @documentclassoption = "dvipdfmx,#{@documentclassoption}".sub(/,\Z/, '')
+      end
 
       @okuduke = make_colophon
       @authors = make_authors
@@ -419,7 +423,6 @@ module ReVIEW
       @locale_latex['postchaptername'] = chapter_tuple[1]
       @locale_latex['preappendixname'] = appendix_tuple[0]
       @locale_latex['postappendixname'] = appendix_tuple[1]
-      @texcompiler = File.basename(@config['texcommand'], '.*')
     end
 
     def erb_content(file)

--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -1,4 +1,4 @@
-\documentclass[dvipdfmx,<%= @documentclassoption %>]{<%= @documentclass %>}
+\documentclass[<%= @documentclassoption %>]{<%= @documentclass %>}
 <%= latex_config %>
 <%- if @config['texstyle'] -%>
 <%-   [@config['texstyle']].flatten.each do |x| -%>


### PR DESCRIPTION
#1035 のコメントをもとに。

- platex系以外のコンパイラではdvipdfmxドライバが不要なことがある。layout.tex.erbから`dvipdfmx,`を除去する。
- 既存文書の互換性維持として、dvicommandパラメータがデフォルトのままか、明示してもパラメータにdvipdfmxという文字列がある場合は`dvipdfmx,`をdocumentoptionに付与する。
- documentoptionにすでにdvipdfmxという文字列を含む場合は何もしない。
