### PR TITLE
remove default style

### DIFF
--- a/templates/latex/review-jsbook/review-style.sty
+++ b/templates/latex/review-jsbook/review-style.sty
@@ -1,27 +1,5 @@
-% Page dimensions (without geometry pageckage)
-%
-\setlength{\paperheight}    {257 truemm}
-\setlength{\paperwidth}     {182 truemm}
-\setlength{\textheight}     {190 truemm}
-\setlength{\textwidth}      {130 truemm}
-\setlength{\marginparwidth} {15  truemm}
-\setlength{\marginparsep}   {2   truemm}
-\setlength{\oddsidemargin}  {1   truemm}
-\setlength{\evensidemargin} {1   truemm}
-\setlength{\topmargin}      {-15 truemm}
-\setlength{\headsep}        {15  truemm}
-\setlength{\headheight}     {5   truemm}
-\setlength{\hoffset}{0in}
-\setlength{\voffset}{0in}
-
-%%\setlength{\marginparsep}   {2   truemm}
-%%\setlength{\oddsidemargin}  {26  truemm}
-%%\setlength{\evensidemargin} {26  truemm}
-%%\setlength{\topmargin}      {10  truemm}
-%%\setlength{\headsep}        {15  truemm}
-%%\setlength{\headheight}     {5   truemm}
-%%\setlength{\hoffset}{-1in}
-%%\setlength{\voffset}{-1in}
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{review-style}[2018/07/01]
 
 \RequirePackage{fancyhdr}
 \pagestyle{fancy}


### PR DESCRIPTION
いったんレイアウト周りの設定を消します。とはいえこれだと壊れた感じなので、あとで対応策を考えておきます…。

あと、特にメリットはなさそうですが、`\ProvidesPackage`とかを追加しておきます。