### PR TITLE
Use logger in EPUBMaker

### DIFF
--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -45,6 +45,10 @@ module EPUBMaker
       merge_config(@config.deep_merge(loader.load_file(file)))
     end
 
+    def warn(msg)
+      @logger.warn(msg)
+    end
+
     # Construct producer object.
     # +config+ takes initial parameter hash. This parameters can be overriden by EPUBMaker#load or EPUBMaker#merge_config.
     # +version+ takes EPUB version (default is 2).
@@ -54,6 +58,7 @@ module EPUBMaker
       @epub = nil
       @config['epubversion'] = version unless version.nil?
       @res = ReVIEW::I18n
+      @logger = ReVIEW.logger
 
       merge_config(config) if config
     end

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -45,10 +45,8 @@ module ReVIEW
       @logger.warn "#{File.basename($PROGRAM_NAME, '.*')}: #{msg}"
     end
 
-    def log(s)
-      if @config['debug'].present?
-        puts s
-      end
+    def log(msg)
+      @logger.debug(msg)
     end
 
     def load_yaml(yamlfile)
@@ -64,6 +62,15 @@ module ReVIEW
       @producer.load(yamlfile)
       @config = @producer.config
       @config.maker = 'epubmaker'
+      update_log_level
+    end
+
+    def update_log_level
+      if @config['debug']
+        @logger.level = Logger::DEBUG
+      else
+        @logger.level = Logger::INFO
+      end
     end
 
     def build_path


### PR DESCRIPTION
EPUBMakerで`puts`や`warn`を使っている部分が残っていたので、これをLoggerに置き換えるものです。

`EPUBMaker#log`は`debug: true`のときしか出力されないようになっていたので、log levelを設定して同様になるようにしています。