### PR TITLE
フェンスrevertのタイミングを変更

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -551,16 +551,16 @@ module ReVIEW
 
     def text(str)
       return '' if str.empty?
-      words = replace_fence(str).split(/(@<\w+>\{(?:[^\}\\]|\\.)*?\})/, -1).map {|s| revert_replace_fence(s) }
+      words = replace_fence(str).split(/(@<\w+>\{(?:[^\}\\]|\\.)*?\})/, -1)
       words.each do |w|
         if w.scan(/@<\w+>/).size > 1 && !/\A@<raw>/.match(w)
           error "`@<xxx>' seen but is not valid inline op: #{w}"
         end
       end
-      result = @strategy.nofunc_text(words.shift)
+      result = @strategy.nofunc_text(revert_replace_fence(words.shift))
       until words.empty?
-        result << compile_inline(words.shift.gsub(/\\\}/, '}').gsub(/\\\\/, '\\'))
-        result << @strategy.nofunc_text(words.shift)
+        result << compile_inline(revert_replace_fence(words.shift.gsub(/\\\}/, '}').gsub(/\\\\/, '\\')))
+        result << @strategy.nofunc_text(revert_replace_fence(words.shift))
       end
       result
     rescue => err

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -551,7 +551,7 @@ module ReVIEW
 
     def text(str)
       return '' if str.empty?
-      words = replace_fence(str).split(/(@<\w+>\{(?:[^\}\\]|\\.)*?\})/, -1)
+      words = replace_fence(str).split(/(@<\w+>\{(?:[^\}\\]|\\.)*?\})/, -1).map {|s| revert_replace_fence(s) }
       words.each do |w|
         if w.scan(/@<\w+>/).size > 1 && !/\A@<raw>/.match(w)
           error "`@<xxx>' seen but is not valid inline op: #{w}"
@@ -562,7 +562,7 @@ module ReVIEW
         result << compile_inline(words.shift.gsub(/\\\}/, '}').gsub(/\\\\/, '\\'))
         result << @strategy.nofunc_text(words.shift)
       end
-      revert_replace_fence(result)
+      result
     rescue => err
       error err.message
     end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -991,9 +991,9 @@ EOS
 
   def test_inline_fence
     actual = compile_inline('test @<code>|@<code>{$サンプル$}|')
-    assert_equal 'test \\reviewcode{@\\textless{}code\\textgreater{}{\\textdollar{}サンプル\\textdollar{}}}', actual
+    assert_equal 'test \\reviewcode{@\\textless{}code\\textgreater{}\\{\\textdollar{}サンプル\\textdollar{}\\}}', actual
     actual2 = compile_inline('test @<code>|@<code>{$サンプル$}|, @<m>$\begin{array}{ll}a & b\\\alpha & @\\\end{array}$')
-    assert_equal 'test \\reviewcode{@\\textless{}code\\textgreater{}{\\textdollar{}サンプル\\textdollar{}}}, $\begin{array}{ll}a & b\\\alpha & @\\\end{array}$', actual2
+    assert_equal 'test \\reviewcode{@\\textless{}code\\textgreater{}\\{\\textdollar{}サンプル\\textdollar{}\\}}, $\begin{array}{ll}a & b\\\alpha & @\\\end{array}$', actual2
   end
 
   def test_inline_w

--- a/test/test_latexbuilder_v2.rb
+++ b/test/test_latexbuilder_v2.rb
@@ -971,7 +971,7 @@ EOS
 
   def test_inline_fence
     actual = compile_inline('test @<code>|@<code>{$サンプル$}|')
-    assert_equal 'test \\texttt{@\\textless{}code\\textgreater{}{\\textdollar{}サンプル\\textdollar{}}}', actual
+    assert_equal 'test \\texttt{@\\textless{}code\\textgreater{}\\{\\textdollar{}サンプル\\textdollar{}\\}}', actual
   end
 
   def test_inline_unknown

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -137,7 +137,7 @@ class TOPBuidlerTest < Test::Unit::TestCase
 
   def test_inline_fence
     actual = compile_inline('@<m>|a|, @<m>{\\frac{1\\}{2\\}}, @<m>$\\frac{1}{2}$, @<m>{\\{ \\\\\\}}, @<m>|\\{ \\}|, test @<code>|@<code>{$サンプル$}|')
-    assert_equal '◆→TeX式ここから←◆a◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\frac{1}{2}◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\frac{1}{2}◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\\{ \\}◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\\{ \\}◆→TeX式ここまで←◆, test △@<code>{$サンプル$}☆', actual
+    assert_equal '◆→TeX式ここから←◆a◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\\frac{1}{2}◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\\frac{1}{2}◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\\{ \\}◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\\{ \\}◆→TeX式ここまで←◆, test △@<code>{$サンプル$}☆', actual
   end
 
   def test_inline_in_table

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -135,6 +135,11 @@ class TOPBuidlerTest < Test::Unit::TestCase
     assert_equal 'test ◆→コメント←◆ test2', actual
   end
 
+  def test_inline_fence
+    actual = compile_inline('@<m>|a|, @<m>{\\frac{1\\}{2\\}}, @<m>$\\frac{1}{2}$, @<m>{\\{ \\\\\\}}, @<m>|\\{ \\}|, test @<code>|@<code>{$サンプル$}|')
+    assert_equal '◆→TeX式ここから←◆a◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\frac{1}{2}◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\frac{1}{2}◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\\{ \\}◆→TeX式ここまで←◆, ◆→TeX式ここから←◆\\{ \\}◆→TeX式ここまで←◆, test △@<code>{$サンプル$}☆', actual
+  end
+
   def test_inline_in_table
     actual = compile_block("//table{\n★1☆\t▲2☆\n------------\n★3☆\t▲4☆<>&\n//}\n")
     assert_equal %Q(◆→開始:表←◆\n★★1☆☆\t★▲2☆☆\n★3☆\t▲4☆<>&\n◆→終了:表←◆\n\n), actual


### PR DESCRIPTION
#1083 の修正。

テストを変更しましたが、この結果が希望に沿った動作です。
（latex側は別のエスケープでごちゃごちゃしているので、topbuilderのテストのほうで見るのがわかりやすいです）

各処理メソッドに渡す前にrevertするようにしました。