### PR TITLE
pdfmakerからの子プロセス呼び出しを、ベタ文字列ではなく、なるべく配列で渡す

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -213,20 +213,20 @@ module ReVIEW
         end
 
         2.times do
-          system_or_raise("#{texcommand} #{texoptions} #{@mastertex}.tex")
+          system_or_raise(texcommand, texoptions, "#{@mastertex}.tex")
         end
 
         call_hook('hook_beforemakeindex')
         if @config['pdfmaker']['makeindex'] && File.exist?("#{@mastertex}.idx")
-          system_or_raise("#{makeindex_command} #{makeindex_options} #{@mastertex}")
+          system_or_raise(makeindex_command, makeindex_options, @mastertex)
         end
         call_hook('hook_aftermakeindex')
 
-        system_or_raise("#{texcommand} #{texoptions} #{@mastertex}")
+        system_or_raise(texcommand, texoptions, "#{@mastertex}.tex")
         call_hook('hook_aftertexcompile')
 
         if File.exist?("#{@mastertex}.dvi")
-          system_or_raise("#{dvicommand} #{dvioptions} #{@mastertex}.dvi")
+          system_or_raise(dvicommand, dvioptions, "#{@mastertex}.dvi")
           call_hook('hook_afterdvipdf')
         end
       end
@@ -474,7 +474,7 @@ module ReVIEW
       if ENV['REVIEW_SAFE_MODE'].to_i & 1 > 0
         warn 'hook configuration is prohibited in safe mode. ignored.'
       else
-        system_or_raise("#{hook} #{Dir.pwd} #{@basedir}")
+        system_or_raise(hook, Dir.pwd, @basedir)
       end
     end
   end


### PR DESCRIPTION
顕在化するのはWindowsくらいだとは思うけど、

スペース入りのコマンドパスだったときにエラーになるのをたぶん避けられるよう、texcommandやdvicommandなどを*args型で渡すようにしてみました。

コマンドオプションまわりは複数でも文字列でそのまま渡しちゃっているのですが、Open3.capture2eのほうで良きに計らってくれてるんですね。