### PR TITLE
OPFのmodifiedの時刻情報がlocaltimeで入っていたのをUTCに修正

### DIFF
--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -236,7 +236,7 @@ module EPUBMaker
       defaults = ReVIEW::Configure.new.merge(
         'language' => 'ja',
         'date' => Time.now.strftime('%Y-%m-%d'),
-        'modified' => Time.now.strftime('%Y-%02m-%02dT%02H:%02M:%02SZ'),
+        'modified' => Time.now.utc.strftime('%Y-%02m-%02dT%02H:%02M:%02SZ'),
         'isbn' => nil,
         'toclevel' => 2,
         'stylesheet' => [],


### PR DESCRIPTION
modifiedの値は、Z後置子を付けていたらUTCであるべきなのに、Time.nowでlocaltimeのまま作ってしまっていました。Zの代わりに+09:00とする方法もあるようですが、ソフトが解析するパラメータなのでUTCのほうが都合がよさそうです。

https://www.w3.org/TR/NOTE-datetime