### PR TITLE
pdfmaker: tableとfigureでのフロート設定をマクロで定義できるようにする

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -601,7 +601,11 @@ module ReVIEW
         if caption.present?
           @table_caption = true
           @doc_status[:caption] = true
-          puts "\\begin{table}[h]%%#{id}"
+          if @book.config.check_version('2', exception: false)
+            puts "\\begin{table}[h]%%#{id}"
+          else
+            puts "\\begin{table}%%#{id}"
+          end
           puts macro('reviewtablecaption*', compile_inline(caption))
           @doc_status[:caption] = nil
         end
@@ -609,7 +613,11 @@ module ReVIEW
         if caption.present?
           @table_caption = true
           @doc_status[:caption] = true
-          puts "\\begin{table}[h]%%#{id}"
+          if @book.config.check_version('2', exception: false)
+            puts "\\begin{table}[h]%%#{id}"
+          else
+            puts "\\begin{table}%%#{id}"
+          end
           puts macro('reviewtablecaption', compile_inline(caption))
           @doc_status[:caption] = nil
         end

--- a/templates/latex/review-jlreq/review-style.sty
+++ b/templates/latex/review-jlreq/review-style.sty
@@ -81,10 +81,10 @@
 \newcommand{\reviewcmdcaption}[1]{\review@commoncaption{}{#1}}
 \newenvironment{reviewlistblock}{\list{}{\topsep.5\baselineskip \leftmargin\z@ \itemindent\z@}\item\relax}{\endlist}% 上下アキ0.5
 
-\newenvironment{reviewimage}[1][H]{%
+\newenvironment{reviewimage}[1]{%
   \begin{figure}[#1]\begin{center}}{\end{center}\end{figure}}
 
-\newenvironment{reviewdummyimage}[1][ht]{%
+\newenvironment{reviewdummyimage}[1]{%
   \begin{reviewimage}[#1]}{\end{reviewimage}}
 
 \newcommand{\reviewindepimagecaption[2]}{\@makecaption{}{#2}}
@@ -147,3 +147,7 @@
 % ヘッダスタイル
 \ModifyPageStyle{headings}{nombre_position={top-fore_edge},running_head_position={top-fore_edge}}
 \pagestyle{headings}
+
+% 図表フロートの配置
+\floatplacement{figure}{H}
+\floatplacement{table}{htp}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -88,13 +88,13 @@
 \fi
 
 \newenvironment{reviewimage}{%
-  \begin{figure}[H]
+  \begin{figure}
     \begin{center}}{%
     \end{center}
   \end{figure}}
 
 \newenvironment{reviewdummyimage}{%
-  \begin{figure}[H]
+  \begin{figure}
     \begin{center}\begin{alltt}}{%
     \end{alltt}\end{center}
   \end{figure}}

--- a/templates/latex/review-jsbook/review-style.sty
+++ b/templates/latex/review-jsbook/review-style.sty
@@ -41,3 +41,6 @@
 
 %% disable hyperlink color and border
 \hypersetup{hidelinks}
+
+\floatplacement{figure}{H}
+\floatplacement{table}{htp}

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -593,7 +593,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def test_emtable
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal "\\begin{table}[h]%%\n\\reviewtablecaption*{foo}\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n\\end{table}\n\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
+    assert_equal "\\begin{table}%%\n\\reviewtablecaption*{foo}\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n\\end{table}\n\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
                  actual
   end
 
@@ -1076,7 +1076,7 @@ EOS
 
 \\reviewtableref{A.1}{table:chap1:foo}
 
-\\begin{table}[h]%%foo
+\\begin{table}%%foo
 \\reviewtablecaption{FOO}
 \\label{table:chap1:foo}
 \\begin{reviewtable}{|l|l|}


### PR DESCRIPTION
latexbuilderおよびスタイルファイルで、tableはh（=htp）、imageはHというフロート配置になっていますが、そもそもfloat.styを組み込んでいるので決めうちよりも`\floatplacement`マクロで制御するほうが妥当そうです。

いちおうRe:VIEW 2系には後方互換でtableにhを残しています。
