### PR TITLE
review-initへのアーカイブロード展開の機能の追加

### DIFF
--- a/lib/review/init.rb
+++ b/lib/review/init.rb
@@ -8,6 +8,8 @@
 
 require 'fileutils'
 require 'optparse'
+require 'net/http'
+require 'tempfile'
 require 'review'
 
 module ReVIEW
@@ -38,6 +40,7 @@ module ReVIEW
         generate_rakefile(dir)
         generate_gemfile(dir)
         generate_doc(dir) unless @without_doc
+        download_and_extract_archive(dir, @archive) if @archive
       end
     end
 
@@ -58,11 +61,14 @@ module ReVIEW
       opts.on('--latex-template name', 'specify LaTeX template name. (default: review-jsbook)') do |tname|
         @template = tname
       end
-      opts.on('', '--epub-version VERSION', 'define EPUB version') do |version|
+      opts.on('', '--epub-version VERSION', 'define EPUB version.') do |version|
         @epub_version = version
       end
-      opts.on('', '--without-doc', "don't generate doc files") do
+      opts.on('', '--without-doc', "don't generate doc files.") do
         @without_doc = true
+      end
+      opts.on('-p', '--package archivefile', 'extract from local or network archive.') do |archive|
+        @archive = archive
       end
 
       begin
@@ -189,6 +195,68 @@ EOS
       FileUtils.mkdir_p docdir
       md_files = Dir.glob(@review_dir + '/doc/*.md').map.to_a
       FileUtils.cp md_files, docdir
+    end
+
+    def download_and_extract_archive(dir, filename)
+      begin
+        require 'zip'
+      rescue LoadError
+        @logger.error 'extracting needs rubyzip.'
+        exit 1
+      end
+
+      if filename =~ %r{\Ahttps?://}
+        begin
+          @logger.info "Downloading from #{filename}"
+          zipdata = Net::HTTP.get(URI.parse(filename))
+        rescue StandardError => err
+          @logger.error "Failed to download #{filename}: #{err.message}"
+          exit 1
+        end
+
+        begin
+          f = Tempfile.new('reviewinit')
+          zipfilename = f.path
+          f.write zipdata
+          f.close
+
+          extract_archive(dir, zipfilename, filename)
+        ensure
+          f.unlink
+        end
+      else
+        unless File.readable?(filename)
+          @logger.error "Failed to open #{filename}"
+          exit 1
+        end
+        extract_archive(dir, filename, filename)
+      end
+    end
+
+    def extract_archive(dir, filename, originalfilename)
+      made = nil
+      begin
+        Zip::File.open(filename) do |zip|
+          zip.each do |entry|
+            fname = entry.name.gsub('\\', '/')
+            if fname =~ /__MACOSX/ || fname =~ /\.DS_Store/
+              next
+            end
+
+            if fname =~ %r{\A/} || fname =~ %r{/\.\./} # simple fool proof
+              made = nil
+              break
+            end
+
+            # `true' means override
+            entry.extract(File.join(dir, fname)) { true }
+          end
+          made = true
+        end
+        raise Zip::Error unless made
+      rescue Zip::Error => err
+        @logger.error "#{originalfilename} seems invalid or broken zip file: #{err.message}"
+      end
     end
   end
 end

--- a/lib/review/init.rb
+++ b/lib/review/init.rb
@@ -243,7 +243,7 @@ EOS
               next
             end
 
-            if fname =~ %r{\A/} || fname =~ %r{/\.\./} # simple fool proof
+            if fname =~ %r{\A/} || fname =~ /\.\./ # simple fool proof
               made = nil
               break
             end


### PR DESCRIPTION
#1102 の対応。
プロジェクトフォルダの作成後にzipアーカイブを単純に上書き展開するという仕掛けです。

- `-p ローカルファイルパス` または `-p https://〜`・`-p http://〜`  でzipファイルを指定します。
- ネットワークダウンロードは `Net::HTTP` なので301などには対応していません。パスワード制限のところにも対応していません。まぁこのあたりはダウンロードしてから指定してもらうのがよさそう。open-uriは今は使うべきではない、になっているんですね…
- 一応「`/`」から始まるパス、および「`/../`」が含まれるパスは発見次第展開を中止するという安全策は入れています。
- パスの日本語まわりなどはOSのロケール状態まで見るのもきついので対処していません。