### PR TITLE
TeX: フックreview{begin/end}documenthookの追加

### DIFF
--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -8,6 +8,11 @@
 
 \begin{document}
 
+%% begindocument hook
+\ifdefined\reviewbegindocumenthook
+\reviewbegindocumenthook
+\fi
+
 %% coverpage
 \ifdefined\reviewcoverpagecont
 \reviewcoverpagecont
@@ -96,6 +101,11 @@
 %%% backcover page
 \ifdefined\reviewbackcovercont
 \reviewbackcovercont
+\fi
+
+%% enddocument hook
+\ifdefined\reviewenddocumenthook
+\reviewenddocumenthook
 \fi
 
 \end{document}

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -51,6 +51,10 @@
   \renewcommand{\appendixname}{\reviewappendixname}
 \fi
 
+\def\reviewbegindocumenthook{}
+
+\def\reviewenddocumenthook{}
+
 \def\reviewfrontmatterhook{%
   \renewcommand{\chaptermark}[1]{{}}
   \frontmatter

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -286,6 +286,10 @@
 }
 
 % hooks
+\def\reviewbegindocumenthook{}
+
+\def\reviewenddocumenthook{}
+
 \def\reviewfrontmatterhook{%
   \renewcommand{\chaptermark}[1]{{}}
   \frontmatter

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -39,6 +39,11 @@
 
 \begin{document}
 
+%% begindocument hook
+\ifdefined\reviewbegindocumenthook
+\reviewbegindocumenthook
+\fi
+
 %% coverpage
 \ifdefined\reviewcoverpagecont
 \reviewcoverpagecont
@@ -127,6 +132,11 @@
 %%% backcover page
 \ifdefined\reviewbackcovercont
 \reviewbackcovercont
+\fi
+
+%% enddocument hook
+\ifdefined\reviewenddocumenthook
+\reviewenddocumenthook
 \fi
 
 \end{document}

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -50,6 +50,11 @@ some ad content
 
 \begin{document}
 
+%% begindocument hook
+\ifdefined\reviewbegindocumenthook
+\reviewbegindocumenthook
+\fi
+
 %% coverpage
 \ifdefined\reviewcoverpagecont
 \reviewcoverpagecont
@@ -138,6 +143,11 @@ some ad content
 %%% backcover page
 \ifdefined\reviewbackcovercont
 \reviewbackcovercont
+\fi
+
+%% enddocument hook
+\ifdefined\reviewenddocumenthook
+\reviewenddocumenthook
 \fi
 
 \end{document}


### PR DESCRIPTION
最初にコンテンツに加工を入れたいけれども、reviewcoverpagecontを変えるのはだいぶ違うし…ということがちょっとあったので、先頭・末尾用のフックを追加します。
普通は空なので、挙動としての変化はなく、未定義でも問題ありません。
