### PR TITLE
TeX: coverパラメータでカスタムした効果の適用

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -230,9 +230,6 @@
 }
 
 % cover
-\ifdefined\review@cover
-  \def\reviewcoverpagecont{\review@coverfile}
-\fi
 \ifdefined\review@coverimage
   \def\reviewcoverpagecont{%
     \thispagestyle{empty}
@@ -243,6 +240,9 @@
     \vfill\null
     \clearpage
   }
+\fi
+\ifdefined\review@coverfile
+  \def\reviewcoverpagecont{\review@coverfile}
 \fi
 
 % titlepage

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -306,9 +306,6 @@
 }
 
 % cover
-\ifdefined\review@cover
-  \def\reviewcoverpagecont{\review@coverfile}
-\fi
 \ifdefined\review@coverimage
   \def\reviewcoverpagecont{%
 \thispagestyle{empty}
@@ -317,6 +314,9 @@
 \end{center}
 \clearpage
   }
+\fi
+\ifdefined\review@coverfile
+  \def\reviewcoverpagecont{\review@coverfile}
 \fi
 
 % titlepage


### PR DESCRIPTION
Re:VIEW 3から入れたstyのロジックで、

coverパラメータ(カスタムなtex断片ファイル指定)を入れる→\review@coverfileにその内容が読み込まれて入るの後、

\review@coverfileがあればそれを使い、coverimageに優先する が正しい挙動のはずが、

間違って何も定義のない \review@cover で判定していた、coverimageがあると上書きしてしまっていた

のを修正します。