### PR TITLE
RuboCop 0.59.2に対する更新

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -304,6 +304,9 @@ Layout/DotPosition:
 Layout/EmptyLines:
   Enabled: true
 
+Layout/EmptyLineAfterGuardClause:
+  Enabled: false
+
 Layout/EmptyLinesAroundAccessModifier:
   Enabled: true
 
@@ -441,6 +444,9 @@ Naming/AccessorMethodName:
 # When defining the == operator, name its argument other.
 #Style/BinaryOperatorParameterName:
 #  Enabled: true
+
+Naming/FileName:
+  Enabled: false
 
 Naming/HeredocDelimiterNaming:
   Enabled: false

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -481,7 +481,7 @@ module ReVIEW
       while word = scanner.scan(/(\[\]|\[.*?[^\\]\])/)
         w2 = word[1..-2].gsub(/\\(.)/) do
           ch = $1
-          (ch == ']' or ch == '\\') ? ch : '\\' + ch
+          [']', '\\'].include?(ch) ? ch : '\\' + ch
         end
         words << w2
       end


### PR DESCRIPTION
compiler.rbを直した以外は「警告無視」の方向で。
