### PR TITLE
review-jsbook.cls (tombopaper,paperwidth,paperheight): supported

### DIFF
--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -166,23 +166,6 @@ cls]
 }
 
 \newcommand*\@includefullpagegraphics[2][]{%
-  \iftdir
-    \vbox to \hanmenwidth{%
-      \ifodd\c@page
-        \vskip-\dimexpr\evensidemargin - .5\topskip + 1in\relax
-      \else
-        \vskip-\dimexpr\oddsidemargin - .5\topskip + 1in\relax
-      \fi
-      \vbox to \paperwidth{\vss
-        \hbox to \hanmenheight{%
-          \hskip-\grnchry@head\relax
-          \hbox to \paperheight{\hss
-            \rotatebox{90}{\includegraphics[#1]{#2}}%
-          \hss}%
-        \hss}%
-      \vss}%
-    \vss}%
-  \else
     \vbox to \textheight{%
       \vskip-\grnchry@head
       \vbox to \paperheight{\vss
@@ -198,7 +181,6 @@ cls]
         \hss}%
       \vss}%
     \vss}%
-  \fi
   \clearpage
 }
 

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -153,5 +153,54 @@ cls]
 ]{hyperref}
 \RequirePackage[\recls@driver]{pxjahyper}
 
+
+
+%% include fullpage graphics
+\edef\grnchry@head{\dimexpr\topmargin+1in+\headheight+\headsep}
+\edef\grnchry@gutter{\evensidemargin}
+\newcommand*\includefullpagegraphics{%
+  \clearpage
+  \@ifstar
+    {\@includefullpagegraphics}%
+    {\thispagestyle{empty}\@includefullpagegraphics}
+}
+
+\newcommand*\@includefullpagegraphics[2][]{%
+  \iftdir
+    \vbox to \hanmenwidth{%
+      \ifodd\c@page
+        \vskip-\dimexpr\evensidemargin - .5\topskip + 1in\relax
+      \else
+        \vskip-\dimexpr\oddsidemargin - .5\topskip + 1in\relax
+      \fi
+      \vbox to \paperwidth{\vss
+        \hbox to \hanmenheight{%
+          \hskip-\grnchry@head\relax
+          \hbox to \paperheight{\hss
+            \rotatebox{90}{\includegraphics[#1]{#2}}%
+          \hss}%
+        \hss}%
+      \vss}%
+    \vss}%
+  \else
+    \vbox to \textheight{%
+      \vskip-\grnchry@head
+      \vbox to \paperheight{\vss
+        \hbox to \textwidth{%
+          \ifodd\c@page
+            \hskip-\dimexpr\oddsidemargin + 1in\relax
+          \else
+            \hskip-\dimexpr\evensidemargin + 1in\relax
+          \fi
+          \hbox to \paperwidth{\hss
+            \includegraphics[#1]{#2}%
+          \hss}%
+        \hss}%
+      \vss}%
+    \vss}%
+  \fi
+  \clearpage
+}
+
 \listfiles
 \endinput

--- a/templates/latex/review-jsbook/README.md
+++ b/templates/latex/review-jsbook/README.md
@@ -95,7 +95,7 @@ jsbook.clsで利用可能な特定の用紙サイズを指定できます。
 
  * jsbook.clsのクラスオプション `nomag`：用紙サイズや版面設計は、すべてreview-jsbook側で行います。
  * hyperrefパッケージ：あらかじめhyperrefパッケージを組み込んで、`cameraready`オプションにより用途別で挙動を制御しています。
- * 各種相対フォントサイズコマンド`\small`, `\footnotesize`, `\scriptsize`, `\tiny`, `\large`, `\Large`, `\LARGE`, `\huge`, `\Huge`, `\HUGE` は、級数ベースに書き換えています。あまりちゃんと実装せずに、いい加減に変えていますが、本文級数が12Qから15Qまでぐらいであれば、それなりに大丈夫と思います。
+ * 各種相対フォントサイズコマンド`\small`, `\footnotesize`, `\scriptsize`, `\tiny`, `\large`, `\Large`, `\LARGE`, `\huge`, `\Huge`, `\HUGE` は、級数ベースに書き換えています。あまりちゃんと実装せずに、いい加減に変えていますが、それなりに大丈夫と思います。
 
 
 ## おわりに

--- a/templates/latex/review-jsbook/README.md
+++ b/templates/latex/review-jsbook/README.md
@@ -1,0 +1,107 @@
+review-jsbook.cls Users Guide
+====================
+
+現時点における最新版 `jsbook.cls  2018/06/23 jsclasses (okumura, texjporg)` をベースに、Re:VIEW向けreview-jsbook.clsを実装しました。
+
+過去のRe:VIEW 2でjsbook.clsで作っていた資産を、ほとんどそのまま Re:VIEW 3でも利用できます。
+
+## 特徴
+
+ * クラスオプション `cameraready` により、「印刷用」、「電子用」の用途を明示的な意思表示として与えてることで、用途に応じたPDFファイル生成を行えます。
+ * （基本的に）クラスオプションを `<key>=<value>` で与えられます。
+ * クラスオプション内で、用紙サイズや基本版面を自由に設計できます。
+
+ここで、クラスオプションとは、親LaTeX文章ファイルにおいて、以下のような位置にカンマ（,）区切りで記述するオプションです。
+
+```latex
+\documentclass[クラスオプションたち（省略可能）]{review-jsbook]
+```
+
+## Re:VIEWで利用する
+
+クラスオプションオプションたちは、Re:VIEW設定ファイル config.yaml 内の texdocumentclass において、以下のような位置に記述します。
+
+```yaml
+texdocumentclass: ["review-jsbook", "クラスオプションたち（省略可能）"]
+```
+
+
+## 利用可能なクラスオプションたち
+
+### 用途別PDFデータ作成 `cameraready=<用途名>`
+
+印刷用 `print`、電子用 `ebook` のいずれかの用途名を指定します。
+
+ * `print`［デフォルト］：印刷用PDFファイルを生成します。
+   * トンボあり、デジタルトンボあり（gentombowパッケージ経由）、hyperrefパッケージを`draft`モードで読み込み
+ * `ebook`：電子用PDFファイルを生成します。
+   * トンボなし、hyperrefパッケージを読み込み
+
+### 特定の用紙サイズ `paper=<用紙サイズ>`
+
+jsbook.clsで利用可能な特定の用紙サイズを指定できます。
+
+ * `a3` 
+ * `a4` 
+ * `a5`［デフォルト］
+ * `a6` 
+ * `b4`：JIS B4 
+ * `b5`：JIS B5
+ * `b6`：JIS B6 
+ * `a4var`：210mm x 283mm
+ * `b5var`：182mm x 230mm
+ * `letter`
+ * `legal`
+ * `executive`
+
+
+### トンボ用紙サイズ `tombopaper=<用紙サイズ>`
+
+トンボ用紙サイズを指定できます。
+［デフォルト］値は自動判定します。
+
+
+### カスタム用紙サイズ `paperwidth=<用紙横幅>`, `paperheight=<用紙縦幅>`
+
+カスタム用紙サイズ `paperwidth=<用紙横幅>`, `paperheight=<用紙縦幅>` （両方とも与える必要があります）を与えることで、特定の用紙サイズで設定できない用紙サイズを与えられます。
+
+例えば、とあるB5変形 `paperwidth=182mm`, `paperheight=235mm`。
+
+
+### 基本版面設計 `Q=<級数>`, `W=<字詰>`, `L=<行数>`, `H=<行送り>` , `head=<天>`, `gutter=<ノド>`
+
+基本版面 QWLH, 天、ノドを与えます。
+天、ノドをそれぞれ与えない場合、それぞれ天地、左右中央になります。
+
+ * `Q=13`［デフォルト］：文字サイズを級数（1Q = 1H = 0.25mm）で与えます。
+ * `W=35`［デフォルト］：1行字詰めを与えます。
+ * `L=32`［デフォルト］：行数を与えます。
+ * `H=22`［デフォルト］：行送り（1Q = 1H = 0.25mm）を与えます。
+ * `head=<幅>`：天を与えます。［デフォルト］は天地中央です。
+ * `gutter=<幅>`：ノドを与えます。［デフォルト］は左右中央です。
+
+例をいくつか上げます。
+
+ * paper=a5, Q=13, W=35, L=32, H=22,
+ * paper=a5, Q=14, W=38, L=34, H=20.5, head=20mm, gutter=20mm,
+ * paper=b5, Q=13, W=43, L=35, H=24, 
+ * paper=b5, Q=14, W=40, L=34, H=25.5, 
+
+
+さらに、ヘッダー、フッターに関する位置調整は、TeXのパラメータ `\headheight`, `\headsep`, `\footskip` に対応して、それぞれ `headheight`, `headsep`, `footskip` を与えられます。
+
+
+## 標準でreview-jsbook.clsを実行したときのjsbook.clsとの違い
+
+ * jsbook.clsのクラスオプション `nomag`：用紙サイズや版面設計は、すべてreview-jsbook側で行います。
+ * hyperrefパッケージ：あらかじめhyperrefパッケージを組み込んで、`cameraready`オプションにより用途別で挙動を制御しています。
+ * 各種相対フォントサイズコマンド`\small`, `\footnotesize`, `\scriptsize`, `\tiny`, `\large`, `\Large`, `\LARGE`, `\huge`, `\Huge`, `\HUGE` は、級数ベースに書き換えています。あまりちゃんと実装せずに、いい加減に変えていますが、本文級数が12Qから15Qまでぐらいであれば、それなりに大丈夫と思います。
+
+
+## おわりに
+Re:VIEW用途でなくても、review-jsbook.clsを利用できると思います。
+
+Re:VIEW 3リリースにせまられて、review-jsbook.clsを急いで実装しました。
+何かあれば、Re:VIEW upstreamであるGitHub kmuto/reviewのissueに上げていただければ、必要に応じて、review-jsbook.clsの対応も検討いたします。
+
+以上です。

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -125,6 +125,9 @@
 
 %% 用紙
 \DeclareOptionX{paper}[a5]{\gdef\recls@paper{#1}}
+\DeclareOptionX{tombopaper}{%
+  \gdef\recls@tombopaper{}%%default: auto-detect
+  \ifx#1\@empty\else\gdef\recls@tombopaper{tombo-#1}\fi}
 %% 基本版面 QWLH、天、ノド
 \DeclareOptionX{Q}[13]{\gdef\recls@Q{#1}}
 \DeclareOptionX{W}[35]{\gdef\recls@W{#1}}
@@ -139,7 +142,7 @@
 
 \PassOptionsToClass{dvipdfmx,nomag}{jsbook}
 \DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{jsbook}}%
-\ExecuteOptionsX{paper,cameraready,Q,W,L,H,head,gutter,headheight,headsep,footskip}
+\ExecuteOptionsX{paper,tombopaper,cameraready,Q,W,L,H,head,gutter,headheight,headsep,footskip}
 \ProcessOptionsX\relax
 
 \recls@set@paper{\recls@paper}
@@ -150,8 +153,12 @@
 \else\def\recls@tmp{print}\ifx\recls@cameraready\recls@tmp
   \@camerareadytrue\@pdfhyperlinkfalse
   \IfFileExists{gentombow.sty}{%
-    \AtEndOfClass{\RequirePackage[pdfbox,tombo]{gentombow}}%
+    \AtEndOfClass{\RequirePackage[pdfbox,tombo,\recls@tombopaper]{gentombow}}%
   }{%
+    \recls@warning{package gentombow: not installed}%
+    \ifx\recls@tombopaper\@empty\else
+      \recls@warning{option tombopaper: not available}%
+    \fi
     \PassOptionsToClass{tombo}{jsbook}%
   }%
 \else\def\recls@tmp{ebook}\ifx\recls@cameraready\recls@tmp

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -149,8 +149,10 @@
   Q,W,L,H,head,gutter,headheight,headsep,footskip}
 \ProcessOptionsX\relax
 
+%% set specific papersize
 \recls@set@paper{\recls@paper}
 
+%% camera-ready PDF file preparation for each print, ebook
 \def\recls@tmp{preview}\ifx\recls@cameraready\recls@tmp
 %%FIXME: cameraready=preview の挙動は保留。例：フォント関係を仕込む
   \@camerareadyfalse\@pdfhyperlinkfalse

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -402,23 +402,6 @@
 }
 
 \newcommand*\@includefullpagegraphics[2][]{%
-  \iftdir
-    \vbox to \hanmenwidth{%
-      \ifodd\c@page
-        \vskip-\dimexpr\evensidemargin - .5\topskip + 1in\relax
-      \else
-        \vskip-\dimexpr\oddsidemargin - .5\topskip + 1in\relax
-      \fi
-      \vbox to \paperwidth{\vss
-        \hbox to \hanmenheight{%
-          \hskip-\grnchry@head\relax
-          \hbox to \paperheight{\hss
-            \rotatebox{90}{\includegraphics[#1]{#2}}%
-          \hss}%
-        \hss}%
-      \vss}%
-    \vss}%
-  \else
     \vbox to \textheight{%
       \vskip-\grnchry@head
       \vbox to \paperheight{\vss
@@ -434,7 +417,6 @@
         \hss}%
       \vss}%
     \vss}%
-  \fi
   \clearpage
 }
 

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -128,6 +128,9 @@
 \DeclareOptionX{tombopaper}{%
   \gdef\recls@tombopaper{}%%default: auto-detect
   \ifx#1\@empty\else\gdef\recls@tombopaper{tombo-#1}\fi}
+%% カスタム用紙サイズ
+\DeclareOptionX{paperwidth}{\gdef\recls@paperwidth{#1}}
+\DeclareOptionX{paperheight}{\gdef\recls@paperheight{#1}}
 %% 基本版面 QWLH、天、ノド
 \DeclareOptionX{Q}[13]{\gdef\recls@Q{#1}}
 \DeclareOptionX{W}[35]{\gdef\recls@W{#1}}
@@ -142,7 +145,8 @@
 
 \PassOptionsToClass{dvipdfmx,nomag}{jsbook}
 \DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{jsbook}}%
-\ExecuteOptionsX{paper,tombopaper,cameraready,Q,W,L,H,head,gutter,headheight,headsep,footskip}
+\ExecuteOptionsX{cameraready,paper,tombopaper,paperwidth,paperheight,%
+  Q,W,L,H,head,gutter,headheight,headsep,footskip}
 \ProcessOptionsX\relax
 
 \recls@set@paper{\recls@paper}
@@ -179,6 +183,15 @@
 \PassOptionsToClass{10pt}{jsbook}%%<= forcely load 10pt
 \LoadClass{jsbook}
 %%\typeout{!!! mag: \the\mag}%%=> 1000 -> OK
+
+%% override papersize with custom papersize
+\ifx\recls@paperwidth\@empty\else\ifx\recls@paperheight\@empty\else
+  \setlength{\paperwidth}{\recls@paperwidth}
+  \setlength{\paperheight}{\recls@paperheight}
+  \def\recls@tmp{pdf}\ifx\recls@cameraready\recls@tmp
+    \AtBeginDvi{\special{papersize=\the\paperwidth,\the\paperheight}}
+  \fi
+\fi\fi
 
 \def\recls@JYn{\if@recls@uptex JY2\else JY1\fi}%
 \def\recls@JTn{\if@recls@uptex JT2\else JT1\fi}%

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -215,7 +215,7 @@
 \@tempcnta=\strip@pt\@tempdima\relax
 \@tempcntb=\strip@pt\@tempdimb\relax
 \@tempdima=\dimexpr\@tempcntb\p@/\@tempcnta\relax
-\recls@get@p@{\@tempdima}{\recls@@scale}% \typeout{!!! \recls@@scale}%
+\recls@get@p@{\@tempdima}{\recls@fnt@scale}% \typeout{!!! \recls@fnt@scale}%
 
 \RequirePackage{lmodern}
 
@@ -290,7 +290,6 @@
 \setlength\Chs{\wd0}
 \setbox0=\box\voidb@x
 
-%%FIXME: 相対フォントサイズコマンドはいい加減にしていて。12Qから15Qまでぐらいであれば、それなりに大丈夫。\recls@@scale を利用するのもよい。
 \renewcommand{\small}{%
   \ifnarrowbaselines
     \jsc@setfontsize\small
@@ -330,15 +329,22 @@
 \renewcommand{\tiny}{\jsc@setfontsize\tiny
   {.5\dimexpr\recls@Qnum\JQ}{.5\dimexpr\recls@Qnum H + 2H}}
 \if@twocolumn
-  \renewcommand{\large}{\@setfontsize\large{18\JQ}{\n@baseline}}
+  \renewcommand{\large}{\@setfontsize\large
+    {\recls@fnt@scale\dimexpr 18\JQ}{\n@baseline}}
 \else
-  \renewcommand{\large}{\@setfontsize\large{18\JQ}{27H}}
+  \renewcommand{\large}{\@setfontsize\large
+    {\recls@fnt@scale\dimexpr 18\JQ}{\recls@fnt@scale\dimexpr 27H}}
 \fi
-\renewcommand{\Large}{\@setfontsize\Large{20\JQ}{30H}}
-\renewcommand{\LARGE}{\@setfontsize\LARGE{24\JQ}{36H}}
-\renewcommand{\huge}{\@setfontsize\huge{28\JQ}{42H}}
-\renewcommand{\Huge}{\@setfontsize\Huge{32\JQ}{48H}}
-\renewcommand{\HUGE}{\jsc@setfontsize\HUGE{36\JQ}{54H}}
+\renewcommand{\Large}{\@setfontsize\Large
+  {\recls@fnt@scale\dimexpr 20\JQ}{\recls@fnt@scale\dimexpr 30H}}
+\renewcommand{\LARGE}{\@setfontsize\LARGE
+  {\recls@fnt@scale\dimexpr 24\JQ}{\recls@fnt@scale\dimexpr 36H}}
+\renewcommand{\huge}{\@setfontsize\huge
+  {\recls@fnt@scale\dimexpr 28\JQ}{\recls@fnt@scale\dimexpr 42H}}
+\renewcommand{\Huge}{\@setfontsize\Huge
+  {\recls@fnt@scale\dimexpr 32\JQ}{\recls@fnt@scale\dimexpr 48H}}
+\renewcommand{\HUGE}{\jsc@setfontsize\HUGE
+  {\recls@fnt@scale\dimexpr 36\JQ}{\recls@fnt@scale\dimexpr 54H}}
 
 %% headheight, headsep, footskip
 \setlength\topskip{\Cht}


### PR DESCRIPTION
クラスオプション `tombopaper`, `paperwidth`, `paperheight` を gentombow パッケージ前提で実装しました。