### PR TITLE
supported \AtEndOfReVIEWMacro 

### DIFF
--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -166,23 +166,6 @@ cls]
 }
 
 \newcommand*\@includefullpagegraphics[2][]{%
-  \iftdir
-    \vbox to \hanmenwidth{%
-      \ifodd\c@page
-        \vskip-\dimexpr\evensidemargin - .5\topskip + 1in\relax
-      \else
-        \vskip-\dimexpr\oddsidemargin - .5\topskip + 1in\relax
-      \fi
-      \vbox to \paperwidth{\vss
-        \hbox to \hanmenheight{%
-          \hskip-\grnchry@head\relax
-          \hbox to \paperheight{\hss
-            \rotatebox{90}{\includegraphics[#1]{#2}}%
-          \hss}%
-        \hss}%
-      \vss}%
-    \vss}%
-  \else
     \vbox to \textheight{%
       \vskip-\grnchry@head
       \vbox to \paperheight{\vss
@@ -198,7 +181,6 @@ cls]
         \hss}%
       \vss}%
     \vss}%
-  \fi
   \clearpage
 }
 

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -23,6 +23,12 @@
 \ProvidesClass{review-jlreq}[2018/10/05 Re:VIEW pLaTeX class modified for jlreq.
 cls]
 
+%% hook at end of reviewmacro
+\let\@endofreviewmacrohook\@empty
+\def\AtEndOfReVIEWMacro{%
+  \g@addto@macro\@endofreviewmacrohook}
+\@onlypreamble\AtEndOfReVIEWMacro
+
 \RequirePackage{fix-cm}%%\RequirePackage{fix-cm,exscale}
 \IfFileExists{latexrelease.sty}{}{\RequirePackage{fixltx2e}}
 

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -153,5 +153,54 @@ cls]
 ]{hyperref}
 \RequirePackage[\recls@driver]{pxjahyper}
 
+
+
+%% include fullpage graphics
+\edef\grnchry@head{\dimexpr\topmargin+1in+\headheight+\headsep}
+\edef\grnchry@gutter{\evensidemargin}
+\newcommand*\includefullpagegraphics{%
+  \clearpage
+  \@ifstar
+    {\@includefullpagegraphics}%
+    {\thispagestyle{empty}\@includefullpagegraphics}
+}
+
+\newcommand*\@includefullpagegraphics[2][]{%
+  \iftdir
+    \vbox to \hanmenwidth{%
+      \ifodd\c@page
+        \vskip-\dimexpr\evensidemargin - .5\topskip + 1in\relax
+      \else
+        \vskip-\dimexpr\oddsidemargin - .5\topskip + 1in\relax
+      \fi
+      \vbox to \paperwidth{\vss
+        \hbox to \hanmenheight{%
+          \hskip-\grnchry@head\relax
+          \hbox to \paperheight{\hss
+            \rotatebox{90}{\includegraphics[#1]{#2}}%
+          \hss}%
+        \hss}%
+      \vss}%
+    \vss}%
+  \else
+    \vbox to \textheight{%
+      \vskip-\grnchry@head
+      \vbox to \paperheight{\vss
+        \hbox to \textwidth{%
+          \ifodd\c@page
+            \hskip-\dimexpr\oddsidemargin + 1in\relax
+          \else
+            \hskip-\dimexpr\evensidemargin + 1in\relax
+          \fi
+          \hbox to \paperwidth{\hss
+            \includegraphics[#1]{#2}%
+          \hss}%
+        \hss}%
+      \vss}%
+    \vss}%
+  \fi
+  \clearpage
+}
+
 \listfiles
 \endinput

--- a/templates/latex/review-jlreq/reviewmacro.sty
+++ b/templates/latex/review-jlreq/reviewmacro.sty
@@ -6,3 +6,10 @@
 
 % ユーザー固有の定義
 \usepackage{review-custom}
+
+%% run \@endofreviewmacrohook at the end of reviewmacro style
+\@ifundefined{@endofreviewmacrohook}{}{%
+\let\AtEndOfReVIEWMacro\@firstofone
+\@endofreviewmacrohook}
+
+\endinput

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -402,23 +402,6 @@
 }
 
 \newcommand*\@includefullpagegraphics[2][]{%
-  \iftdir
-    \vbox to \hanmenwidth{%
-      \ifodd\c@page
-        \vskip-\dimexpr\evensidemargin - .5\topskip + 1in\relax
-      \else
-        \vskip-\dimexpr\oddsidemargin - .5\topskip + 1in\relax
-      \fi
-      \vbox to \paperwidth{\vss
-        \hbox to \hanmenheight{%
-          \hskip-\grnchry@head\relax
-          \hbox to \paperheight{\hss
-            \rotatebox{90}{\includegraphics[#1]{#2}}%
-          \hss}%
-        \hss}%
-      \vss}%
-    \vss}%
-  \else
     \vbox to \textheight{%
       \vskip-\grnchry@head
       \vbox to \paperheight{\vss
@@ -434,7 +417,6 @@
         \hss}%
       \vss}%
     \vss}%
-  \fi
   \clearpage
 }
 

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -31,6 +31,12 @@
 \def\recls@warningnoline{\ClassWarningNoLine{review-jsbook}}
 \def\recls@info{\ClassInfo{review-jsbook}}
 
+%% hook at end of reviewmacro
+\let\@endofreviewmacrohook\@empty
+\def\AtEndOfReVIEWMacro{%
+  \g@addto@macro\@endofreviewmacrohook}
+\@onlypreamble\AtEndOfReVIEWMacro
+
 %% fixes to LaTeX2e
 \RequirePackage{fix-cm}%%\RequirePackage{fix-cm,exscale}
 \IfFileExists{latexrelease.sty}{}{\RequirePackage{fixltx2e}}

--- a/templates/latex/review-jsbook/reviewmacro.sty
+++ b/templates/latex/review-jsbook/reviewmacro.sty
@@ -6,3 +6,10 @@
 
 % ユーザー固有の定義
 \RequirePackage{review-custom}
+
+%% run \@endofreviewmacrohook at the end of reviewmacro style
+\@ifundefined{@endofreviewmacrohook}{}{%
+\let\AtEndOfReVIEWMacro\@firstofone
+\@endofreviewmacrohook}
+
+\endinput


### PR DESCRIPTION
`review-{jlreq,jsbook}.cls` + `reviewmacro.sty (review-{base,style,custom}.sty)` 中だけで利用可能な（通常のLaTeXの \AtBeginDocument と同等な挙動を持つ）フック `\AtEndOfReVIEWMacro` を実装しました。

このフックが嬉しいのは、例えば、cls ファイル内で tcolorbox が提供する \newtcbbox を cls で定義する節見出し \section で利用したいとします（展開するマクロ内ではなくて、スコープが浅いところで）。
すると、順番に cls -> sty を読んでいきますから、\newtcbbox をTeX側が知るためには、 早いところで \usepackage{tcolorbox}をしている必要があります。
しかしながら、各種パッケージの読み込み順の制御や読み込みパッケージをまとめておきたい場合に、これでは、cls 内の \section の場所で \newtcbbox が利用できないことになります（もちろん、マクロの定義を点在させれば、可能ですが分かりにくいですよね。もちろん、tcolorbox パッケージよりも後に 節見出し \section を再定義すればよいですが、 cls ファイルとしてデザインを提供している場合は、面倒ですよね。）。

そこで、必要な場所で \AtEndReVIEWMacro{  ... } を順に入れておくだけで、 reviewmacro.sty 読み込みの一番最後で、 \AtEndReVIEWMacro で入れたものを一気に実行します。（\AtBeginDocument などと同じ使い勝手！）

実際のところ、これを利用するユーザーは、かなり限られるとは思いますが、あっても悪くないと思います。