### PR TITLE
review-jsbook/review-base.sty (\footskip): dropped

### DIFF
--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -166,23 +166,6 @@ cls]
 }
 
 \newcommand*\@includefullpagegraphics[2][]{%
-  \iftdir
-    \vbox to \hanmenwidth{%
-      \ifodd\c@page
-        \vskip-\dimexpr\evensidemargin - .5\topskip + 1in\relax
-      \else
-        \vskip-\dimexpr\oddsidemargin - .5\topskip + 1in\relax
-      \fi
-      \vbox to \paperwidth{\vss
-        \hbox to \hanmenheight{%
-          \hskip-\grnchry@head\relax
-          \hbox to \paperheight{\hss
-            \rotatebox{90}{\includegraphics[#1]{#2}}%
-          \hss}%
-        \hss}%
-      \vss}%
-    \vss}%
-  \else
     \vbox to \textheight{%
       \vskip-\grnchry@head
       \vbox to \paperheight{\vss
@@ -198,7 +181,6 @@ cls]
         \hss}%
       \vss}%
     \vss}%
-  \fi
   \clearpage
 }
 

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -153,5 +153,54 @@ cls]
 ]{hyperref}
 \RequirePackage[\recls@driver]{pxjahyper}
 
+
+
+%% include fullpage graphics
+\edef\grnchry@head{\dimexpr\topmargin+1in+\headheight+\headsep}
+\edef\grnchry@gutter{\evensidemargin}
+\newcommand*\includefullpagegraphics{%
+  \clearpage
+  \@ifstar
+    {\@includefullpagegraphics}%
+    {\thispagestyle{empty}\@includefullpagegraphics}
+}
+
+\newcommand*\@includefullpagegraphics[2][]{%
+  \iftdir
+    \vbox to \hanmenwidth{%
+      \ifodd\c@page
+        \vskip-\dimexpr\evensidemargin - .5\topskip + 1in\relax
+      \else
+        \vskip-\dimexpr\oddsidemargin - .5\topskip + 1in\relax
+      \fi
+      \vbox to \paperwidth{\vss
+        \hbox to \hanmenheight{%
+          \hskip-\grnchry@head\relax
+          \hbox to \paperheight{\hss
+            \rotatebox{90}{\includegraphics[#1]{#2}}%
+          \hss}%
+        \hss}%
+      \vss}%
+    \vss}%
+  \else
+    \vbox to \textheight{%
+      \vskip-\grnchry@head
+      \vbox to \paperheight{\vss
+        \hbox to \textwidth{%
+          \ifodd\c@page
+            \hskip-\dimexpr\oddsidemargin + 1in\relax
+          \else
+            \hskip-\dimexpr\evensidemargin + 1in\relax
+          \fi
+          \hbox to \paperwidth{\hss
+            \includegraphics[#1]{#2}%
+          \hss}%
+        \hss}%
+      \vss}%
+    \vss}%
+  \fi
+  \clearpage
+}
+
 \listfiles
 \endinput

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -41,7 +41,6 @@
  {\endMakeFramed}
 
 \newcommand{\parasep}{\vspace*{3zh}}
-\setlength{\footskip}{30pt}
 
 \newcommand*\PDFDocumentInformation[1]{%
   \AtBeginShipoutFirst{\special{pdf:docinfo <<#1>>}}}

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -402,23 +402,6 @@
 }
 
 \newcommand*\@includefullpagegraphics[2][]{%
-  \iftdir
-    \vbox to \hanmenwidth{%
-      \ifodd\c@page
-        \vskip-\dimexpr\evensidemargin - .5\topskip + 1in\relax
-      \else
-        \vskip-\dimexpr\oddsidemargin - .5\topskip + 1in\relax
-      \fi
-      \vbox to \paperwidth{\vss
-        \hbox to \hanmenheight{%
-          \hskip-\grnchry@head\relax
-          \hbox to \paperheight{\hss
-            \rotatebox{90}{\includegraphics[#1]{#2}}%
-          \hss}%
-        \hss}%
-      \vss}%
-    \vss}%
-  \else
     \vbox to \textheight{%
       \vskip-\grnchry@head
       \vbox to \paperheight{\vss
@@ -434,7 +417,6 @@
         \hss}%
       \vss}%
     \vss}%
-  \fi
   \clearpage
 }
 


### PR DESCRIPTION
これは良くないので、除くべきです。

``` tex
\setlength{\footskip}{30pt}
```

なお、review-jsbook.cls では、クラスオプションとして footskip のほか、headheight, headsep も利用できるようにしています。

