### PR TITLE
TeX: \frontmatterをtitlepageの後ではなく前で宣言する

### DIFF
--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -18,14 +18,14 @@
 \reviewcoverpagecont
 \fi
 
-%% title page
-\ifdefined\reviewtitlepagecont
-\reviewtitlepagecont
-\fi
-
 %% frontmatter hook
 \ifdefined\reviewfrontmatterhook
 \reviewfrontmatterhook
+\fi
+
+%% title page
+\ifdefined\reviewtitlepagecont
+\reviewtitlepagecont
 \fi
 
 %% originaltitle

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -57,14 +57,14 @@
 \reviewcoverpagecont
 \fi
 
-%% title page
-\ifdefined\reviewtitlepagecont
-\reviewtitlepagecont
-\fi
-
 %% frontmatter hook
 \ifdefined\reviewfrontmatterhook
 \reviewfrontmatterhook
+\fi
+
+%% title page
+\ifdefined\reviewtitlepagecont
+\reviewtitlepagecont
 \fi
 
 %% originaltitle

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -68,14 +68,14 @@ some ad content
 \reviewcoverpagecont
 \fi
 
-%% title page
-\ifdefined\reviewtitlepagecont
-\reviewtitlepagecont
-\fi
-
 %% frontmatter hook
 \ifdefined\reviewfrontmatterhook
 \reviewfrontmatterhook
+\fi
+
+%% title page
+\ifdefined\reviewtitlepagecont
+\reviewtitlepagecont
 \fi
 
 %% originaltitle


### PR DESCRIPTION
#1128 の対応