### PR TITLE
TeX: cover,bleed_margin,serial_pagination,startpageのjsbookへの追加

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -131,6 +131,7 @@ secnolevel: 2
 # cover: null
 #
 # 表紙に配置し、書籍の影絵にも利用する画像ファイル。省略した場合はnull (画像を使わない)。画像ディレクトリ内に置いてもディレクトリ名は不要(例: cover.jpg)
+# PDFMaker 固有の表紙設定は pdfmaker セクション内で上書き可能
 # coverimage: null
 #
 # 表紙の後に大扉ページを作成するか。省略した場合はtrue (作成する)

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -62,12 +62,13 @@ cls]
 \newif\if@pdfhyperlink \@pdfhyperlinkfalse
 \newif\if@pdftombo \@pdftombofalse
 \newif\if@reclscover \@reclscovertrue
+\newif\ifrecls@serialpage \recls@serialpagefalse
 \DeclareOptionX{cameraready}[print]{\gdef\recls@cameraready{#1}}
 \DeclareOptionX{tombopaper}[a4]{\gdef\recls@tombopaper{#1}}
 \DeclareOptionX{bleed_margin}[3mm]{\gdef\recls@tombobleed{#1}}
 \DeclareOptionX{cover}[\@empty]{\gdef\recls@forcecover{#1}}
 \DeclareOptionX{startpage}[1]{\gdef\recls@startpage{\numexpr #1-1\relax}}
-\DeclareOptionX{serial_pagination}[false]{\gdef\recls@serialpage{#1}}
+\DeclareOptionX{serial_pagination}[false]{\csname recls@serialpage#1\endcsname}
 
 % jlreqのオプションについては https://github.com/abenori/jlreq/blob/master/README-ja.md を参照
 \PassOptionsToClass{book,paper=a5}{jlreq}% クラスで必ず使うオプションの指定。デフォルトをA5にしておく
@@ -194,8 +195,8 @@ cls]
 }
 
 % シンプルな通しノンブル
-\def\recls@tmp{true}\ifx\recls@serialpage\recls@tmp
-  \def\pagenumbering#1{%
+\ifrecls@serialpage
+\renewcommand*{\pagenumbering}[1]{%
   \gdef\thepage{\@arabic\c@page}}
 \fi
 

--- a/templates/latex/review-jsbook/README.md
+++ b/templates/latex/review-jsbook/README.md
@@ -32,9 +32,15 @@ texdocumentclass: ["review-jsbook", "クラスオプションたち（省略可�
 印刷用 `print`、電子用 `ebook` のいずれかの用途名を指定します。
 
  * `print`［デフォルト］：印刷用 PDF ファイルを生成します。
-   * トンボあり、デジタルトンボあり（gentombow パッケージが利用可能な場合）、hyperref パッケージを `draft` モードで読み込み
+   * トンボあり、デジタルトンボあり（gentombow パッケージが利用可能な場合）、hyperref パッケージを `draft` モードで読み込み、表紙は入れない
  * `ebook`：電子用PDFファイルを生成します。
-   * トンボなし、hyperref パッケージを読み込み
+   * トンボなし、hyperref パッケージを読み込み、表紙を入れる
+
+### 表紙の挿入有無 `cover=<trueまたはfalse>`
+
+`cameraready` の値によって表紙（config.yml の coverimage に指定した画像）の配置の有無は自動で切り替わりますが、`cover=true` とすれば必ず表紙を入れるようになります。
+
+なお、config.yml の coverimage で指定する画像ファイルは、原寸を想定しています。
 
 ### 特定の用紙サイズ `paper=<用紙サイズ>`
 
@@ -53,10 +59,13 @@ texdocumentclass: ["review-jsbook", "クラスオプションたち（省略可�
  * `legal`
  * `executive`
 
-### トンボ用紙サイズ `tombopaper=<用紙サイズ>`
+### トンボ用紙サイズ `tombopaper=<用紙サイズ>` および塗り足し幅 `bleed_margin=<幅>`
 
-トンボ用紙サイズを指定できます。
+`tombopaper` ではトンボ用紙サイズを指定できます。
 ［デフォルト］値は自動判定します。
+
+`bleed_margin` では塗り足し領域の幅を指定できます。
+［デフォルト］3mm になります。
 
 デジタルトンボを含め、gentombow パッケージが利用可能なときのみ有効です。
 
@@ -86,6 +95,19 @@ texdocumentclass: ["review-jsbook", "クラスオプションたち（省略可�
  * paper=b5, Q=14, W=40, L=34, H=25.5, 
 
 さらに、ヘッダー、フッターに関する位置調整は、TeX のパラメータ `\headheight`, `\headsep`, `\footskip` に対応しており、それぞれ `headheight`, `headsep`, `footskip` を与えられます。
+
+## 開始ページ番号 `startpage=<ページ番号>`
+
+大扉からのページ開始番号を指定します。
+
+［デフォルト］は1です。表紙・表紙裏（表1・表2）のぶんを飛ばしたければ、`startpage=3` とします。
+
+## 通しページ番号（通しノンブル） `serial_pagination=<trueまたはfalse>`
+
+大扉からアラビア数字でページ番号を通すかどうかを指定します。
+
+ * `true`：大扉を開始ページとして、前付（catalog.yml で PREDEF に指定したもの）、さらに本文（catalog.yml で CHAPS に指定したもの）に連続したページ番号をアラビア数字で振ります（通しノンブルと言います）。
+ * `false`［デフォルト］：大扉を開始ページとして前付の終わり（通常は目次）までのページ番号をローマ数字で振ります。本文は 1 を開始ページとしてアラビア数字で振り直します（別ノンブルと言います）。
 
 ## 標準で review-jsbook.cls を実行したときの jsbook.cls との違い
 

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -321,14 +321,16 @@
 }
 
 % cover
-\ifdefined\review@coverimage
-  \def\reviewcoverpagecont{%
-    \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
-    \cleardoublepage
-  }
-\fi
-\ifdefined\review@coverfile
-  \def\reviewcoverpagecont{\review@coverfile}
+\if@reclscover
+  \ifdefined\review@coverimage
+    \def\reviewcoverpagecont{%
+      \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
+      \cleardoublepage
+    }
+  \fi
+  \ifdefined\review@coverfile
+    \def\reviewcoverpagecont{\review@coverfile}
+  \fi
 \fi
 
 % titlepage

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -1,5 +1,5 @@
 %#!ptex2pdf -l -u -ot '-synctex=1' test-rejsbk
-% Copyright (c) 2018 Munehiro Yamamoto.
+% Copyright (c) 2018 Munehiro Yamamoto, Kenshi Muto.
 %
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the "Software"), to deal
@@ -134,6 +134,7 @@
 \DeclareOptionX{tombopaper}{%
   \gdef\recls@tombopaper{}%%default: auto-detect
   \ifx#1\@empty\else\gdef\recls@tombopaper{tombo-#1}\fi}
+\DeclareOptionX{bleed_margin}[3mm]{\gdef\recls@tombobleed{#1}}
 %% カスタム用紙サイズ
 \DeclareOptionX{paperwidth}{\gdef\recls@paperwidth{#1}}
 \DeclareOptionX{paperheight}{\gdef\recls@paperheight{#1}}
@@ -149,10 +150,19 @@
 \DeclareOptionX{headsep}[\z@]{\gdef\recls@headsep{#1}}
 \DeclareOptionX{footskip}[\z@]{\gdef\recls@footskip{#1}}
 
+%% 表紙・開始番号・通しノンブル
+\newif\if@reclscover \@reclscovertrue
+\newif\ifrecls@serialpage \recls@serialpagefalse
+\DeclareOptionX{cover}[\@empty]{\gdef\recls@forcecover{#1}}
+\DeclareOptionX{startpage}[1]{\gdef\recls@startpage{\numexpr#1}}
+\DeclareOptionX{serial_pagination}[false]{\csname recls@serialpage#1\endcsname}
+
 \PassOptionsToClass{dvipdfmx,nomag}{jsbook}
 \DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{jsbook}}%
-\ExecuteOptionsX{cameraready,paper,tombopaper,paperwidth,paperheight,%
-  Q,W,L,H,head,gutter,headheight,headsep,footskip}
+\ExecuteOptionsX{cameraready,paper,tombopaper,bleed_margin,%
+  paperwidth,paperheight,%
+  Q,W,L,H,head,gutter,headheight,headsep,footskip,%
+  cover,startpage,serial_pagination}
 \ProcessOptionsX\relax
 
 %% set specific papersize
@@ -161,11 +171,12 @@
 %% camera-ready PDF file preparation for each print, ebook
 \def\recls@tmp{preview}\ifx\recls@cameraready\recls@tmp
 %%FIXME: cameraready=preview の挙動は保留。例：フォント関係を仕込む
-  \@camerareadyfalse\@pdfhyperlinkfalse
+  \@camerareadyfalse\@pdfhyperlinkfalse\@reclscovertrue
 \else\def\recls@tmp{print}\ifx\recls@cameraready\recls@tmp
-  \@camerareadytrue\@pdfhyperlinkfalse
+  \@camerareadytrue\@pdfhyperlinkfalse\@reclscoverfalse
   \IfFileExists{gentombow.sty}{%
-    \AtEndOfClass{\RequirePackage[pdfbox,tombo,\recls@tombopaper]{gentombow}}%
+    \AtEndOfClass{\RequirePackage[pdfbox,tombo,\recls@tombopaper]{gentombow}%
+      \settombowbleed{\recls@tombobleed}}%
   }{%
     \recls@warning{package gentombow: not installed}%
     \ifx\recls@tombopaper\@empty\else
@@ -174,7 +185,7 @@
     \PassOptionsToClass{tombo}{jsbook}%
   }%
 \else\def\recls@tmp{ebook}\ifx\recls@cameraready\recls@tmp
-  \@camerareadytrue\@pdfhyperlinktrue
+  \@camerareadytrue\@pdfhyperlinktrue\@reclscovertrue
   \PassOptionsToClass{papersize}{jsbook}%
 \else
   \recls@error{No such value of cameraready: \recls@cameraready}%
@@ -451,6 +462,43 @@
     \vss}%
   \clearpage
 }
+
+% coverオプションによる表紙判定の上書き
+\def\recls@tmp{true}\ifx\recls@forcecover\recls@tmp
+\@reclscovertrue
+\else\def\recls@tmp{false}\ifx\recls@forcecover\recls@tmp
+\@reclscoverfalse
+\else% それ以外の値は単に無視
+\fi\fi
+
+% シンプルな通しノンブル
+\ifrecls@serialpage
+\renewcommand*{\pagenumbering}[1]{%
+  \gdef\thepage{\@arabic\c@page}}
+\fi
+
+% 開始ページを変更
+\let\recls@frontmatterorg\frontmatter
+\renewcommand*{\frontmatter}{
+  \recls@frontmatterorg
+  \setcounter{page}{\the\recls@startpage}
+}
+
+% titlepageのsetcounterを使わない
+\renewenvironment{titlepage}{%
+    \cleardoublepage
+    \if@twocolumn
+      \@restonecoltrue\onecolumn
+    \else
+      \@restonecolfalse\newpage
+    \fi
+    \thispagestyle{empty}%
+%    \setcounter{page}\@ne
+  }%
+  {\if@restonecol\twocolumn \else \newpage \fi
+    \if@twoside\else
+%      \setcounter{page}\@ne
+    \fi}
 
 \listfiles
 \endinput


### PR DESCRIPTION
jlreqでひとまずそれっぽく動くようになったので、jsbookのほうにも入れます。

titlepageの挙動が違うのでcls側で書き換えているのと、startpageの持ち方が違います（jlreqでは-1する必要があったけどjsbookではそのままを使う）。
