### PR TITLE
imgmathのfontsize/lineheightをtexequationにも適用する

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -547,7 +547,9 @@ module ReVIEW
         p = MathML::LaTeX::Parser.new(symbol: MathML::Symbol::CharacterReference)
         puts p.parse(unescape(lines.join("\n")), true)
       elsif @book.config['imgmath']
-        math_str = "\\begin{equation*}\n" + unescape(lines.join("\n")) + "\n\\end{equation*}\n"
+        math_str = "\\begin{equation*}\n" + "\\begin{block_equation}\n" +
+        unescape(lines.join("\n")) +
+        "\n\\end{block_equation}\n" + "\\end{equation*}\n"
         key = Digest::SHA256.hexdigest(math_str)
         math_dir = File.join(@book.config['imagedir'], '_review_math')
         Dir.mkdir(math_dir) unless Dir.exist?(math_dir)

--- a/lib/review/makerhelper.rb
+++ b/lib/review/makerhelper.rb
@@ -95,14 +95,37 @@ module ReVIEW
     EOB
     end
 
+    def equation_block_style(f,h)
+      <<-EOB
+\\newenvironment{block_equation}
+{
+\\fontsize{#{f}}{#{h}}\\selectfont
+}
+{
+}
+      EOB
+    end
+
     def make_math_images(math_dir)
       fontsize = @config['imgmath_options']['fontsize'].to_f
       lineheight = @config['imgmath_options']['lineheight'].to_f
 
+      block_fontsize = fontsize
+      block_lineheight = lineheight
+      if @config['imgmath_options']['block_fontsize']
+        block_fontsize = @config['imgmath_options']['block_fontsize']
+      end
+      if @config['imgmath_options']['block_lineheight']
+        block_lineheight = @config['imgmath_options']['block_lineheight']
+      end
+
       texsrc = default_imgmath_preamble
+
       if @config['imgmath_options']['preamble_file'] && File.readable?(@config['imgmath_options']['preamble_file'])
         texsrc = File.read(@config['imgmath_options']['preamble_file'])
       end
+
+      texsrc << equation_block_style(block_fontsize, block_lineheight)
 
       texsrc << <<-EOB
 \\begin{document}


### PR DESCRIPTION
現在の実装だと`imgmath`を使ったときに`texequation`内の数式にフォントサイズが適用されないので、適用するようにしました。

- `fontsize`, `lineheight`を`texequation`内の数式に適用する
- `block_fontsize`, `block_lineheight`がそれぞれ指定されている場合は`texequation`の設定を上書きする

設定イメージです：

```yml
imgmath: true
imgmath_options:
  # 基準のフォントサイズ
  fontsize: 16
  # 基準の行間
  lineheight: 24
  # texequation内の数式のフォントサイズ. 指定しない場合はfontsizeが使われる
  block_fontsize: 16
  # texequation内の数式の行間. 指定しない場合はlineheightが使われる
  block_lineheight: 24
```