### PR TITLE
TeX: Re:VIEW2向け互換性サポートの修正

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -77,7 +77,7 @@ module ReVIEW
         'footnotetext' => nil,
         'texcommand' => 'uplatex',
         'texoptions' => '-interaction=nonstopmode -file-line-error',
-        'texdocumentclass' => ['review-jsbook', ''],
+        '_texdocumentclass' => ['review-jsbook', ''],
         'dvicommand' => 'dvipdfmx',
         'dvioptions' => '-d 5 -z 9',
         # for PDFMaker

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -429,6 +429,15 @@ module ReVIEW
           'keepaspectratio'
         end
 
+      if @config.check_version('2', exception: false)
+        @coverimageoption =
+          if @documentclass == 'ubook' || @documentclass == 'utbook'
+            'width=\\textheight,height=\\textwidth,keepaspectratio,angle=90'
+          else
+            'width=\\textwidth,height=\\textheight,keepaspectratio'
+          end
+      end
+
       @locale_latex = {}
       part_tuple = I18n.get('part').split(/\%[A-Za-z]{1,3}/, 2)
       chapter_tuple = I18n.get('chapter').split(/\%[A-Za-z]{1,3}/, 2)


### PR DESCRIPTION
せっかく互換ロジック入れていたのにタイプミスしていました。
3pre3に入れたいです。
