### PR TITLE
idgxml/text/plaintext builderでのchaprefの展開方法を独自ではなくほかのビルダに合わせる

### DIFF
--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -1067,20 +1067,30 @@ module ReVIEW
     end
 
     def inline_chapref(id)
-      chs = ['', '「', '」']
-      if @book.config['chapref']
-        chs2 = @book.config['chapref'].split(',')
-        if chs2.size != 3
-          error '--chapsplitter must have exactly 3 parameters with comma.'
-        else
-          chs = chs2
+      if @book.config.check_version('2', exception: false)
+        # backward compatibility
+        chs = ['', '「', '」']
+        if @book.config['chapref']
+          chs2 = @book.config['chapref'].split(',')
+          if chs2.size != 3
+            error '--chapsplitter must have exactly 3 parameters with comma.'
+          else
+            chs = chs2
+          end
         end
-      end
-      s = "#{chs[0]}#{@book.chapter_index.number(id)}#{chs[1]}#{@book.chapter_index.title(id)}#{chs[2]}"
-      if @book.config['chapterlink']
-        %Q(<link href="#{id}">#{s}</link>)
+        s = "#{chs[0]}#{@book.chapter_index.number(id)}#{chs[1]}#{@book.chapter_index.title(id)}#{chs[2]}"
+        if @book.config['chapterlink']
+          %Q(<link href="#{id}">#{s}</link>)
+        else
+          s
+        end
       else
-        s
+        title = super
+        if @book.config['chapterlink']
+          %Q(<link href="#{id}">#{title}</link>)
+        else
+          title
+        end
       end
     rescue KeyError
       error "unknown chapter: #{id}"

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -623,15 +623,25 @@ module ReVIEW
     end
 
     def inline_chapref(id)
-      chs = ['', '「', '」']
-      if @book.config['chapref']
-        chs2 = @book.config['chapref'].split(',')
-        if chs2.size != 3
-          error '--chapsplitter must have exactly 3 parameters with comma.'
+      if @book.config.check_version('2', exception: false)
+        # backward compatibility
+        chs = ['', '「', '」']
+        if @book.config['chapref']
+          chs2 = @book.config['chapref'].split(',')
+          if chs2.size != 3
+            error '--chapsplitter must have exactly 3 parameters with comma.'
+          end
+          chs = chs2
         end
-        chs = chs2
+        "#{chs[0]}#{@book.chapter_index.number(id)}#{chs[1]}#{@book.chapter_index.title(id)}#{chs[2]}"
+      else
+        title = super
+        if @book.config['chapterlink']
+          %Q(<link href="#{id}">#{title}</link>)
+        else
+          title
+        end
       end
-      "#{chs[0]}#{@book.chapter_index.number(id)}#{chs[1]}#{@book.chapter_index.title(id)}#{chs[2]}"
     rescue KeyError
       error "unknown chapter: #{id}"
     end


### PR DESCRIPTION
ほかのビルダ同様にbuilder.rbでやっているi18n.yml(locale.yml)のchapter_quoteを使うようにする。
ただし旧資産互換性のため、review_version: 2の場合には以前のchaprefパラメータを参照する。
