### PR TITLE
imgmathのtexequation内fontsizeの設定と一時紙面サイズの拡大

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -547,7 +547,9 @@ module ReVIEW
         p = MathML::LaTeX::Parser.new(symbol: MathML::Symbol::CharacterReference)
         puts p.parse(unescape(lines.join("\n")), true)
       elsif @book.config['imgmath']
-        math_str = "\\begin{equation*}\n" + unescape(lines.join("\n")) + "\n\\end{equation*}\n"
+        fontsize = @book.config['imgmath_options']['fontsize'].to_f
+        lineheight = @book.config['imgmath_options']['lineheight'].to_f
+        math_str = "\\begin{equation*}\n\\fontsize{#{fontsize}}{#{lineheight}}\\selectfont\n#{unescape(lines.join("\n"))}\n\\end{equation*}\n"
         key = Digest::SHA256.hexdigest(math_str)
         math_dir = File.join(@book.config['imagedir'], '_review_math')
         Dir.mkdir(math_dir) unless Dir.exist?(math_dir)

--- a/lib/review/makerhelper.rb
+++ b/lib/review/makerhelper.rb
@@ -75,7 +75,7 @@ module ReVIEW
 
     def default_imgmath_preamble
       <<-EOB
-\\documentclass[uplatex]{jsarticle}
+\\documentclass[uplatex,a3paper,landscape]{jsarticle}
 \\usepackage[deluxe,uplatex]{otf}
 \\usepackage[T1]{fontenc}
 \\usepackage{textcomp}
@@ -92,6 +92,7 @@ module ReVIEW
 \\usepackage{anyfontsize}
 \\usepackage{bm}
 \\pagestyle{empty}
+% \\setpaperwidth{1000mm}
     EOB
     end
 

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1080,7 +1080,7 @@ EOS
       FileUtils.mkdir_p(File.join(dir, 'images'))
       expected = <<-EOB
 <div class=\"equation\">
-<img src=\"images/_review_math/_gen_XXX.png\" class=\"math_gen_255609d0624d30ecd7b33bfbf069fa39965e221476aeb507f48766d9f216b9eb\" alt="p \\land \\bm{P} q" />
+<img src=\"images/_review_math/_gen_XXX.png\" class=\"math_gen_84291054a12d278ea05694c20fbbc8e974ec66fc13be801c01dca764faeecccb\" alt="p \\land \\bm{P} q" />
 </div>
       EOB
       tmpio = $stderr


### PR DESCRIPTION
#1146 の対応

- fontsize設定を`\begin{equation*}`の中にも入れるようにしました。
- DPIを大きくしたときにデフォルトのA4だとすぐに描画エリアをはみ出すので、とりあえずA3横にしておきました。もっと大きくしたいときには各自で`\setlength\paperwidth{1000mm}`とかプリアンプル書いてもらう方向で。
