### PR TITLE
TeX: oneblankpage, clearoddpageを追加

### DIFF
--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -503,6 +503,16 @@
   \clearpage
 }
 
+% 空ページ
+\newcommand\oneblankpage{\clearpage\thispagestyle{empty}%
+  \hbox{}\newpage\if@twocolumn\hbox{}\newpage\fi}
+
+% 横書き向けの、奇数ページまでの改丁(\cleardoublepage)・偶数ページまでの改丁(\clearoddpage)
+\let\cleardoublepage@right\cleardoublepage
+\def\cleardoublepage@left{\clearpage\if@twoside\ifodd\c@page
+  \hbox{}\thispagestyle{empty}\newpage\if@twocolumn\hbox{}\newpage\fi\fi\fi}
+\let\clearoddpage\cleardoublepage@left
+
 % coverオプションによる表紙判定の上書き
 \def\recls@tmp{true}\ifx\recls@forcecover\recls@tmp
 \@reclscovertrue


### PR DESCRIPTION
#1170 については結局本の作り方に依存してしまうので「こうである」という対処がないのですが、少なくとも「空ページを作る」のと「偶数ページまで改丁する」の命令は用意しておいたほうが、自力でreview-customでマクロ書き換えをしてもらうにしても説明が楽そうに思いました。
過去にmunepiさんが作って報告されていたものそのままですが。あと、縦書きはひとまず無視しています。

- `\oneblankpage`: 空の1ページを作成
- `\clearoddpage`: 次の偶数ページになるまで改丁（現在偶数なら何もせず、奇数なら改丁）