### PR TITLE
TeX: review-jsbookでhiddenfolio+tombopaperを使ったときにfolioが無効になることの修正

### DIFF
--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -165,7 +165,7 @@
 \DeclareOptionX{paper}[a5]{\gdef\recls@paper{#1}}
 \DeclareOptionX{tombopaper}{%
   \gdef\recls@tombowopts{}%%default: auto-detect
-  \ifx#1\@empty\else\gdef\recls@tombowopts{tombo-#1}\fi}
+  \ifx#1\@empty\else\gdef\recls@tombowopts{tombow-#1}\fi}
 \DeclareOptionX{bleed_margin}[3mm]{\gdef\recls@tombobleed{#1}}
 %% 隠しノンブルプリセット
 \DeclareOptionX{hiddenfolio}{\gdef\recls@hiddenfolio{#1}}%%default: (none)


### PR DESCRIPTION
#1158 の修正

tomboだとgentombow内部でバナーなしになってしまう。tombowにする必要があった。
