### PR TITLE
jsbook.clsでも最低限通るようにしてみる

### DIFF
--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -2,6 +2,8 @@
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}
   \RequirePackage[dvipdfmx]{pxjahyper}
+  \newif\if@reclscover \@reclscovertrue
+  \newcommand{\includefullpagegraphics}{\includegraphics}
 }{}
 \ifthenelse{\equal{\review@texcompiler}{uplatex}}{%
 \RequirePackage[deluxe,uplatex]{otf}%


### PR DESCRIPTION
意味があるかどうかはわかりませんが、review-jsbookとjsbookの違いでエラーとなる原因のreclscoverとincludefullpagegraphicsの回避を入れてみました。

texdocumentclassで review-jsbook→jsbookにしてもsyntax-bookが通るようになっています。
