### PR TITLE
TeX: mediaオプションの追加

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -286,7 +286,7 @@ epubmaker:
 #
 # LaTeX用のdocumentclassを指定する
 # review-jsbook.clsのオプションについてはsty/README.mdを参照
-# texdocumentclass: ["review-jsbook", "cameraready=print,paper=a5"]
+# texdocumentclass: ["review-jsbook", "media=print,paper=a5"]
 #
 # LaTeX用のコマンドを指定する
 # texcommand: "uplatex"

--- a/lib/review/update.rb
+++ b/lib/review/update.rb
@@ -25,7 +25,7 @@ module ReVIEW
     HTML_VERSION = '5'
     TEX_DOCUMENTCLASS = ['review-jsbook', 'review-jlreq']
     TEX_DOCUMENTCLASS_BAD = ['jsbook', nil]
-    TEX_DOCUMENTCLASS_OPTS = 'cameraready=print,paper=a5'
+    TEX_DOCUMENTCLASS_OPTS = 'media=print,paper=a5'
     TEX_COMMAND = 'uplatex'
     TEX_OPTIONS = '-interaction=nonstopmode -file-line-error'
     DVI_COMMAND = 'dvipdfmx'
@@ -403,7 +403,7 @@ module ReVIEW
             flag = nil
           end
         end
-        opts << 'cameraready=print'
+        opts << 'media=print'
         opts << 'cover=false'
       when 'review-jlreq'
         # at this time, only think about jsbook->jlreq
@@ -428,7 +428,7 @@ module ReVIEW
             flag = nil
           end
         end
-        opts << 'cameraready=print'
+        opts << 'media=print'
         opts << 'cover=false'
       else
         flag = nil

--- a/samples/sample-book/src/config.yml
+++ b/samples/sample-book/src/config.yml
@@ -56,9 +56,9 @@ epubmaker:
 pdfmaker:
   coverimage: cover-a5.ai
   texstyle: ["reviewmacro"]
-  texdocumentclass: ["review-jsbook", "cameraready=print,paper=a5"]
-  # texdocumentclass: ["review-jsbook", "cameraready=ebook,paper=a5"]
-  # texdocumentclass: ["review-jsbook", "cameraready=print,paper=a5,tombopaper=a4,bleed_margin=3mm,cover=true,Q=14,startpage=3,serial_pagination=true,hiddenfolio=nikko-pc"]
+  texdocumentclass: ["review-jsbook", "media=print,paper=a5"]
+  # texdocumentclass: ["review-jsbook", "media=ebook,paper=a5"]
+  # texdocumentclass: ["review-jsbook", "media=print,paper=a5,tombopaper=a4,bleed_margin=3mm,cover=true,Q=14,startpage=3,serial_pagination=true,hiddenfolio=nikko-pc"]
   # texcommand: "uplatex"
   # texoptions: null
   # dvicommand: "dvipdfmx"

--- a/samples/syntax-book/config.yml
+++ b/samples/syntax-book/config.yml
@@ -22,9 +22,9 @@ epubmaker:
   htmlext: xhtml
 
 texstyle: ["reviewmacro"]
-#texdocumentclass: ["review-jsbook", "cameraready=print,paper=b5"]
-texdocumentclass: ["review-jsbook", "cameraready=ebook,paper=b5"]
-#texdocumentclass: ["review-jsbook", "cameraready=print,paper=b5,bleed_margin=3mm,cover=true,Q=14,startpage=3,serial_pagination=true,hiddenfolio=nikko-pc"]
+#texdocumentclass: ["review-jsbook", "media=print,paper=b5"]
+texdocumentclass: ["review-jsbook", "media=ebook,paper=b5"]
+#texdocumentclass: ["review-jsbook", "media=print,paper=b5,bleed_margin=3mm,cover=true,Q=14,startpage=3,serial_pagination=true,hiddenfolio=nikko-pc"]
 # texcommand: "uplatex"
 # texoptions: null
 # dvicommand: "dvipdfmx"

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -103,13 +103,14 @@ cls]
 \@namedef{@makehiddenfolio@shippo}{%
   \@nameuse{@makehiddenfolio@nikko-pc}}
 
-%% cameraready=print,ebook,preview
+%% media=print,ebook,preview
 \newif\if@cameraready \@camerareadyfalse
 \newif\if@pdfhyperlink \@pdfhyperlinkfalse
 \newif\if@pdftombo \@pdftombofalse
 \newif\if@reclscover \@reclscovertrue
 \newif\ifrecls@serialpage \recls@serialpagefalse
 \DeclareOptionX{cameraready}[print]{\gdef\recls@cameraready{#1}}
+\DeclareOptionX{media}[print]{\gdef\recls@cameraready{#1}}
 \DeclareOptionX{tombopaper}[a4]{\gdef\recls@tombopaper{#1}}
 \DeclareOptionX{bleed_margin}[3mm]{\gdef\recls@tombobleed{#1}}
 \DeclareOptionX{cover}[\@empty]{\gdef\recls@forcecover{#1}}
@@ -122,7 +123,7 @@ cls]
 % jlreqのオプションについては https://github.com/abenori/jlreq/blob/master/README-ja.md を参照
 \PassOptionsToClass{book,paper=a5}{jlreq}% クラスで必ず使うオプションの指定。デフォルトをA5にしておく
 \DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{jlreq}}%
-\ExecuteOptionsX{cameraready,tombopaper,bleed_margin,cover,startpage,serial_pagination,hiddenfolio}
+\ExecuteOptionsX{media,cameraready,tombopaper,bleed_margin,cover,startpage,serial_pagination,hiddenfolio}
 \ProcessOptionsX\relax
 
 \def\recls@tmp{preview}\ifx\recls@cameraready\recls@tmp
@@ -132,7 +133,7 @@ cls]
 \else\def\recls@tmp{ebook}\ifx\recls@cameraready\recls@tmp
   \@camerareadytrue\@pdfhyperlinktrue\@pdftombofalse\@reclscovertrue
 \else
-  \recls@error{No such value of cameraready: \recls@cameraready}%
+  \recls@error{No such value of media: \recls@cameraready}%
 \fi\fi\fi
 
 \LoadClass{jlreq}

--- a/templates/latex/review-jsbook/README.md
+++ b/templates/latex/review-jsbook/README.md
@@ -7,7 +7,7 @@ review-jsbook.cls Users Guide
 
 ## 特徴
 
- * クラスオプション `cameraready` により、「印刷用」「電子用」の用途を明示的な意思表示として与えることで、用途に応じた PDF ファイル生成を行えます。
+ * クラスオプション `media` により、「印刷用」「電子用」の用途を明示的な意思表示として与えることで、用途に応じた PDF ファイル生成を行えます。
  * （基本的に）クラスオプションを `<key>=<value>` で与えられます。
  * クラスオプション内で、用紙サイズや基本版面を自由に設計できます。
 
@@ -27,7 +27,7 @@ texdocumentclass: ["review-jsbook", "クラスオプションたち（省略可�
 
 ## 利用可能なクラスオプションたち
 
-### 用途別 PDF データ作成 `cameraready=<用途名>`
+### 用途別 PDF データ作成 `media=<用途名>`
 
 印刷用 `print`、電子用 `ebook` のいずれかの用途名を指定します。
 
@@ -38,7 +38,7 @@ texdocumentclass: ["review-jsbook", "クラスオプションたち（省略可�
 
 ### 表紙の挿入有無 `cover=<trueまたはfalse>`
 
-`cameraready` の値によって表紙（config.yml の coverimage に指定した画像）の配置の有無は自動で切り替わりますが、`cover=true` とすれば必ず表紙を入れるようになります。
+`media` の値によって表紙（config.yml の coverimage に指定した画像）の配置の有無は自動で切り替わりますが、`cover=true` とすれば必ず表紙を入れるようになります。
 
 なお、config.yml の coverimage で指定する画像ファイルは、原寸を想定しています。
 
@@ -125,5 +125,5 @@ texdocumentclass: ["review-jsbook", "クラスオプションたち（省略可�
 
  * jsbook.cls のクラスオプション `uplatex`：これまで texdocumentclass に指定が必要だった `uplatex` オプションは不要となっています。
  * jsbook.cls のクラスオプション `nomag`：用紙サイズや版面設計は、すべて review-jsbook.cls 側で行います。
- * hyperref パッケージ：あらかじめ hyperref パッケージを組み込んでおり、`cameraready` オプションにより用途別で挙動を制御します。
+ * hyperref パッケージ：あらかじめ hyperref パッケージを組み込んでおり、`media` オプションにより用途別で挙動を制御します。
  * 各種相対フォントサイズコマンド `\small`, `\footnotesize`, `\scriptsize`, `\tiny`, `\large`, `\Large`, `\LARGE`, `\huge`, `\Huge`, `\HUGE` は、級数ベースに書き換えています。おおむね妥当な値になっているはずです。

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -156,10 +156,11 @@
   \@nameuse{@makehiddenfolio@nikko-pc}}
 
 
-%% cameraready=print,ebook,preview
+%% media=print,ebook,preview
 \newif\if@cameraready \@camerareadyfalse
 \newif\if@pdfhyperlink \@pdfhyperlinkfalse
 \DeclareOptionX{cameraready}[print]{\gdef\recls@cameraready{#1}}
+\DeclareOptionX{media}[print]{\gdef\recls@cameraready{#1}}
 
 %% 用紙
 \DeclareOptionX{paper}[a5]{\gdef\recls@paper{#1}}
@@ -193,7 +194,7 @@
 
 \PassOptionsToClass{dvipdfmx,nomag}{jsbook}
 \DeclareOptionX*{\PassOptionsToClass{\CurrentOption}{jsbook}}%
-\ExecuteOptionsX{cameraready,hiddenfolio,%
+\ExecuteOptionsX{media,cameraready,hiddenfolio,%
   paper,tombopaper,bleed_margin,paperwidth,paperheight,%
   Q,W,L,H,head,gutter,headheight,headsep,footskip,%
   cover,startpage,serial_pagination}
@@ -205,7 +206,7 @@
 
 %% camera-ready PDF file preparation for each print, ebook
 \def\recls@tmp{preview}\ifx\recls@cameraready\recls@tmp
-%%FIXME: cameraready=preview の挙動は保留。例：フォント関係を仕込む
+%%FIXME: media=preview の挙動は保留。例：フォント関係を仕込む
   \@camerareadyfalse\@pdfhyperlinkfalse\@reclscovertrue
 \else\def\recls@tmp{print}\ifx\recls@cameraready\recls@tmp
   \@camerareadytrue\@pdfhyperlinkfalse\@reclscoverfalse
@@ -235,7 +236,7 @@
   \@camerareadytrue\@pdfhyperlinktrue\@reclscovertrue
   \PassOptionsToClass{papersize}{jsbook}%
 \else
-  \recls@error{No such value of cameraready: \recls@cameraready}%
+  \recls@error{No such value of media: \recls@cameraready}%
 \fi\fi\fi
 
 %% 内部Unicode動作の時だけupTeXとみなす

--- a/test/test_update.rb
+++ b/test/test_update.rb
@@ -234,7 +234,7 @@ EOT
     assert_match(/By default it is migrated to/, io.string)
     assert_match(/is safely replaced/, io.string)
     cont = <<EOT
-texdocumentclass: ["review-jsbook", "paper=a5,Q=15.46,landscape,oneside,twoside,vartwoside,onecolumn,twocolumn,titlepage,notitlepage,openright,openany,leqno,fleqn,disablejfam,draft,final,mingoth,winjis,jis,papersize,english,report,jslogo,nojslogo,cameraready=print,cover=false"]
+texdocumentclass: ["review-jsbook", "paper=a5,Q=15.46,landscape,oneside,twoside,vartwoside,onecolumn,twocolumn,titlepage,notitlepage,openright,openany,leqno,fleqn,disablejfam,draft,final,mingoth,winjis,jis,papersize,english,report,jslogo,nojslogo,media=print,cover=false"]
 EOT
     assert_equal cont, File.read(File.join(@tmpdir, 'config.yml'))
   end
@@ -246,7 +246,7 @@ EOT
     @u.parse_ymls(@tmpdir)
     @u.update_tex_parameters
     assert_match(/couldn't be converted fully/, io.string)
-    assert_match("'paper=a5,cameraready=print,cover=false' is suggested", io.string)
+    assert_match("'paper=a5,media=print,cover=false' is suggested", io.string)
     cont = <<EOT
 texdocumentclass: ["jsbook", "a5paper,invalid"]
 EOT
@@ -330,7 +330,7 @@ EOT
     assert_match(/By default it is migrated to/, io.string)
     assert_match(/is safely replaced/, io.string)
     cont = <<EOT
-texdocumentclass: ["review-jlreq", "paper=a5,fontsize=11pt,landscape,oneside,twoside,onecolumn,twocolumn,titlepage,notitlepage,openright,openany,leqno,fleqn,draft,final,report,cameraready=print,cover=false"]
+texdocumentclass: ["review-jlreq", "paper=a5,fontsize=11pt,landscape,oneside,twoside,onecolumn,twocolumn,titlepage,notitlepage,openright,openany,leqno,fleqn,draft,final,report,media=print,cover=false"]
 EOT
     assert_equal cont, File.read(File.join(@tmpdir, 'config.yml'))
   end


### PR DESCRIPTION
#1181 の対応。

単純にcamerareadyと同じマクロを定義します。
両方を同時に設定することは現実的にはないはずですが、その場合でも別にエラーにはならず、documentclass内で後に定義したほうが有効になる、かな。

ドキュメントなどもmediaに寄せました。
