### PR TITLE
reviewpart環境で囲む

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -96,6 +96,13 @@ module ReVIEW
     end
     private :puts
 
+    def result
+      if @chapter.is_a?(ReVIEW::Book::Part) && !@book.config.check_version('2', exception: false)
+        puts '\end{reviewpart}'
+      end
+      @output.string
+    end
+
     HEADLINE = {
       1 => 'chapter',
       2 => 'section',
@@ -108,8 +115,13 @@ module ReVIEW
     def headline(level, label, caption)
       _, anchor = headline_prefix(level)
       headline_name = HEADLINE[level]
-      if @chapter.is_a? ReVIEW::Book::Part
-        headline_name = 'part'
+      if @chapter.is_a?(ReVIEW::Book::Part)
+        if @book.config.check_version('2', exception: false)
+          headline_name = 'part'
+        elsif level == 1
+          headline_name = 'part'
+          puts '\begin{reviewpart}'
+        end
       end
       prefix = ''
       if level > @book.config['secnolevel'] || (@chapter.number.to_s.empty? && level > 1)

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -106,6 +106,10 @@
 
 \renewcommand{\contentsname}{\review@toctitle}
 
+\newenvironment{reviewpart}{%
+\renewcommand{\thesection}{\thepart.\@arabic\c@section}%
+}{}
+
 % 囲み記事
 \newenvironment{reviewnote}[1][]{%
   \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries NOTE #1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -197,6 +197,10 @@
 \newcommand{\reviewcolumnref}[2]{\review@intn@columnname #1}
 \newcommand{\reviewsecref}[2]{#1}
 
+\newenvironment{reviewpart}{%
+\renewcommand{\thesection}{\thepart.\@arabic\c@section}%
+}{}
+
 \newcommand{\reviewminicolumntitle}[1]{%
 \review@ifempty{#1}{}{%
   {\large \review@intn@memohead{}: #1}\\}}


### PR DESCRIPTION
#1195 の対応

reviewpart環境で囲み、この中でsectionの番号をchapterではなくpartから拾うように変更します（採番したくないときには普通にnonumを使ってもらう）。
Re:VIEWバージョン2の場合はいちおう互換性のために以前どおり全部partにします。

cls側で対応することも考えましたが、reviewpart固有環境で囲むほうがクラスファイルを問わないので処理が簡易そうと判断しています。