### PR TITLE
TeX: 部が存在するときにはreviewusepartマクロを宣言する

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -164,6 +164,7 @@ module ReVIEW
       input_files = Hash.new { |h, key| h[key] = '' }
       book.parts.each do |part|
         if part.name.present?
+          @config['use_part'] = true
           if part.file?
             output_chaps(part.name, yamlfile)
             input_files['CHAPS'] << %Q(\\input{#{part.name}.tex}\n)

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -94,5 +94,8 @@
 \def\reviewchapterfiles{<%= @input_files['CHAPS'] %>}
 \def\reviewappendixfiles{<%= @input_files['APPENDIX'] %>}
 \def\reviewpostdeffiles{<%= @input_files['POSTDEF'] %>}
+<%- if @config['use_part'] -%>
+\def\reviewusepart{true}
+<%- end -%>
 
 \makeatother


### PR DESCRIPTION
#1197 に関連して。

「部があるかどうか」の判断をTeX側でやるのは\partの上書きなど手間なので、pdfmakerロジック内で判定して、部があれば\reviewusepartを定義（値はtrue）するようにします。

このマクロを見てRe:VIEWのクラス/スタイル側で今どうするというのはないのですが、たとえば\appendixや\backmatter内でこれを見てしおりのtoclevelをデクリメントするといったケースを想定しています。