### PR TITLE
TeX: L,C,Rのスタイルを追加

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -327,3 +327,7 @@
     \def\reviewcolophonpagecont{\review@colophonfile}
   }
 \fi
+
+\newcolumntype{L}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
+\newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
+\newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -328,6 +328,6 @@
   }
 \fi
 
-\newcolumntype{L}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
-\newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
-\newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
+\newcolumntype{L}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}p{#1}}
+\newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}p{#1}}
+\newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}p{#1}}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -427,3 +427,7 @@
     \def\reviewcolophonpagecont{\review@colophonfile}
   }
 \fi
+
+\newcolumntype{L}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
+\newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
+\newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -428,6 +428,6 @@
   }
 \fi
 
-\newcolumntype{L}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
-\newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
-\newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}m{#1}}
+\newcolumntype{L}[1]{>{\raggedright\let\newline\\\arraybackslash\hspace{0pt}}p{#1}}
+\newcolumntype{C}[1]{>{\centering\let\newline\\\arraybackslash\hspace{0pt}}p{#1}}
+\newcolumntype{R}[1]{>{\raggedleft\let\newline\\\arraybackslash\hspace{0pt}}p{#1}}


### PR DESCRIPTION
clsファイルに入れるか悩んだけど、xcolorパッケージの読み込みをしているのがbase.styなので、そちらのほうに入れることにしてみました。

通常の表のセルにおける段落モード「`p{〜}`」は左寄せ均等割り付けなのですが、これでは不便なこともあります。以下を追加します。

- `L{〜}`: 左寄せ（均等割り付けなし）で段落モード
- `C{〜}`: センターで段落モード
- `R{〜}`: 右寄せで段落モード

上下はセンターになるんですが、pみたいに上合わせにしたほうがいいのかな（strutを使う？）