### PR TITLE
「部」の中の見出しの通し番号が前章の番号の続きになってしまうのを修正

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -122,6 +122,7 @@ module ReVIEW
         elsif level == 1
           headline_name = 'part'
           puts '\begin{reviewpart}'
+          puts '\setcounter{section}{0}'
         end
       end
       prefix = ''


### PR DESCRIPTION
早速Re:VIEW 3.0を使い始めています。色々改善されていて楽しみです。ありがとうございます！

さて、 #1195 で部の中で見出しを使いたいとリクエストして、 #1196 で早速それを実現していただいて、Re:VIEW 3.0にも含まれたわけですが、このIssueのタイトルの通り部内の見出しの通し番号の振り方がおかしいようです。

以下のcatalog.ymlで、

```
CHAPS:
  - ch01.re
  - pt01.re:
    - ch02.re
```

ch01.re内で2段階目の見出しをつけると、その数に続く数字がpt01.re内での見出しの通し番号として使われてしまいます(I.2、I.3の部分は本来I.1、I.2が正しいと思われる)。

<img width="265" alt="screen shot 2018-12-01 at 16 57 40" src="https://user-images.githubusercontent.com/501949/49325760-fdf84b80-f58a-11e8-8b00-d3bf38a15dba.png">

このPRでは、部が始まるたびに見出し番号をリセットすることで、見出し番号が続きになってしまうのを回避します。