### PR TITLE
samples内のgentombowスタイルファイルの名前を修正

### DIFF
--- a/samples/sample-book/src/lib/tasks/z01_copy_sty.rake
+++ b/samples/sample-book/src/lib/tasks/z01_copy_sty.rake
@@ -9,9 +9,9 @@ task :copy_sty do
   Dir.glob(File.join(jsbook_dir, 'review-*.sty')) do |file|
     FileUtils.cp file, 'sty'
   end
-  FileUtils.cp File.join(gentombow_dir, 'gentombow.sty'), 'sty/gentombow09j.sty'
+  FileUtils.cp File.join(gentombow_dir, 'gentombow.sty'), 'sty/gentombow.sty'
 end
 
-CLEAN.include([Dir.glob('sty/review-*.sty'), 'sty/review-jsbook.cls', 'sty/gentombow09j.sty'])
+CLEAN.include([Dir.glob('sty/review-*.sty'), 'sty/review-jsbook.cls', 'sty/gentombow.sty'])
 
 Rake::Task[BOOK_PDF].enhance([:copy_sty])

--- a/samples/syntax-book/lib/tasks/z01_copy_sty.rake
+++ b/samples/syntax-book/lib/tasks/z01_copy_sty.rake
@@ -9,9 +9,9 @@ task :copy_sty do
   Dir.glob(File.join(jsbook_dir, 'review-*.sty')) do |file|
     FileUtils.cp file, 'sty'
   end
-  FileUtils.cp File.join(gentombow_dir, 'gentombow.sty'), 'sty/gentombow09j.sty'
+  FileUtils.cp File.join(gentombow_dir, 'gentombow.sty'), 'sty/gentombow.sty'
 end
 
-CLEAN.include([Dir.glob('sty/review-*.sty'), 'sty/review-jsbook.cls', 'sty/gentombow09j.sty'])
+CLEAN.include([Dir.glob('sty/review-*.sty'), 'sty/review-jsbook.cls', 'sty/gentombow.sty'])
 
 Rake::Task[BOOK_PDF].enhance([:copy_sty])


### PR DESCRIPTION
previewでstyにコピーするものをgentombow09j.styとしていたのを3.0release版でgentombow.styとしたが、samplesのほうがそれに追従していなかったのを修正。
（普通のユーザには無関係）
