### PR TITLE
HTMLBuilder: emlistnumとlistnumで常にhighlightメソッドを経由するように

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -435,20 +435,20 @@ module ReVIEW
     end
 
     def listnum_body(lines, lang)
+      body = lines.inject('') { |i, j| i + detab(j) + "\n" }
+      lexer = lang
+      first_line_number = line_num
+      hs = highlight(body: body, lexer: lexer, format: 'html', linenum: true,
+                     options: { linenostart: first_line_number })
+
       if highlight?
-        body = lines.inject('') { |i, j| i + detab(j) + "\n" }
-        lexer = lang
-        first_line_number = line_num
-        puts highlight(body: body, lexer: lexer, format: 'html', linenum: true,
-                       options: { linenostart: first_line_number })
+        puts hs
       else
         class_names = ['list']
         class_names.push("language-#{lang}") unless lang.blank?
-        class_names.push('highlight') if highlight?
         print %Q(<pre class="#{class_names.join(' ')}">)
-        first_line_num = line_num
-        lines.each_with_index do |line, i|
-          puts detab((i + first_line_num).to_s.rjust(2) + ': ' + line)
+        hs.split("\n").each_with_index do |line, i|
+          puts detab((i + first_line_number).to_s.rjust(2) + ': ' + line)
         end
         puts '</pre>'
       end
@@ -476,20 +476,20 @@ module ReVIEW
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
 
+      body = lines.inject('') { |i, j| i + detab(j) + "\n" }
+      lexer = lang
+      first_line_number = line_num
+      hs = highlight(body: body, lexer: lexer, format: 'html', linenum: true,
+                     options: { linenostart: first_line_number })
       if highlight?
-        body = lines.inject('') { |i, j| i + detab(j) + "\n" }
-        lexer = lang
-        first_line_number = line_num
-        puts highlight(body: body, lexer: lexer, format: 'html', linenum: true,
-                       options: { linenostart: first_line_number })
+        puts hs
       else
         class_names = ['emlist']
         class_names.push("language-#{lang}") unless lang.blank?
         class_names.push('highlight') if highlight?
         print %Q(<pre class="#{class_names.join(' ')}">)
-        first_line_num = line_num
-        lines.each_with_index do |line, i|
-          puts detab((i + first_line_num).to_s.rjust(2) + ': ' + line)
+        hs.split("\n").each_with_index do |line, i|
+          puts detab((i + first_line_number).to_s.rjust(2) + ': ' + line)
         end
         puts '</pre>'
       end


### PR DESCRIPTION
#1231 の対応

HTMLBuilderのemlistnum, listnum でハイライト有効無効にかかわらずhighlightメソッドを経由するようにしました（ほかのcmd、list等はこうなっている）。

ハイライト無効の場合は改行結合文字列をまた改行でバラすという無駄なことにはなりますが、コードリストはまずhighlightを通るという形になるので、review-ext等で扱いやすくなります。