### PR TITLE
review-jsbook.cls: 行数が与えられているときの版面縦幅の計算を jsbook.cls の仕様に合わせて修正 #1235

### DIFF
--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -331,7 +331,7 @@
 \ifx\recls@number@of@lines\@empty\else
   \setlength\textheight{\recls@number@of@lines\Cvs}
   \addtolength\textheight{-\Cvs}\addtolength\textheight{\Cwd}
-  \addtolength\textheight{1H}
+  \addtolength\textheight{\dimexpr\topskip-\Cht}%%adjustment for jsbook.cls's \topskip
 \fi
 
 %% ノド、小口


### PR DESCRIPTION
#1235 を修正しました。
