### PR TITLE
TravisCI: do not update rubygems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,16 +11,14 @@ addons:
       - dvipng
 
 before_install:
-  - gem update --system
   - gem update bundler
 
 rvm:
-##  - 2.0
   - 2.1
-  - 2.2.7
-  - 2.3.4
-  - 2.4.1
-  - 2.5.0
+  - 2.2.10
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
 ##  - ruby-head
 
 branches:


### PR DESCRIPTION
* fix https://travis-ci.org/kmuto/review/jobs/471337080

```
$ gem update --system
Updating rubygems-update
ERROR:  Error installing rubygems-update:
	rubygems-update requires Ruby version >= 2.3.0.
ERROR:  While executing gem ... (NoMethodError)
    undefined method `version' for nil:NilClass
The command "gem update --system" failed and exited with 1 during .
```

* update ruby (rvm) versions: use latest stable