### PR TITLE
use \zw insead of zw for LuaLaTeX. add 1 indent space for column.

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -63,7 +63,7 @@
 
 % コラム
 \newenvironment{reviewcolumn}[1][COLUMN]{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,boxrule=0.2mm,arc=2mm,colback=white,colframe=black!100!white,title={\sffamily\bfseries #1}]\par}
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,boxrule=0.2mm,arc=2mm,colback=white,colframe=black!100!white,before upper={\parindent1\zw},title={\sffamily\bfseries #1}]\par}
  {\end{tcolorbox}}
 
 \newcommand{\reviewbackslash}[0]{\textbackslash{}}
@@ -247,11 +247,7 @@
        \thispagestyle{empty}
        \begin{center}%
        \mbox{}%
-       \ifx\review@jlreq@driver\review@jlreq@driver@luatex
-         \vskip5\zw
-       \else
-         \vskip5zw
-       \fi
+       \vskip5\zw
        \reviewtitlefont%
        {\Huge\review@booktitlename\par}%
        \ifdefined\review@subtitlename
@@ -266,11 +262,7 @@
        \end{tabular}\par}%
        \vfill
        {\large\review@date \review@intn@edition%
-         \ifx\review@jlreq@driver\review@jlreq@driver@luatex
-           \hspace{2\zw}%
-         \else
-           \hspace{2zw}%
-         \fi
+         \hspace{2\zw}%
          \review@intn@publishedby\par}%
        \vskip4\zw\mbox{}
        \end{center}%

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -92,7 +92,7 @@ cls]
     \edef\recls@tmp{\thepage}%
     \lower\dimexpr4pt+\recls@tombobleed+.5\paperheight+5\p@\hbox{%
       \vbox{\expandafter\@tfor\expandafter\recls@x\expandafter:\expandafter=\recls@tmp\do{%
-        \hbox to 1zw{\hss\recls@x\hss}}}}}%
+        \hbox to 1\zw{\hss\recls@x\hss}}}}}%
   \ifodd\c@page
     \rlap{\recls@hiddfolio}%
   \else


### PR DESCRIPTION
- `zw`はLuaLaTeXでは実装されていない単位のため、`\zw` を使うようにしました。upLaTeX用にはjlreq.clsが`\zw`→`zw`の面倒を見てくれるので問題ありません。
- コラムの場合に字下げがないのはたしかに気になるので、インデントを付けるようにしました。noteやmemoには入れていませんが、同じようにして付けることは簡単に可能ではあります。