### PR TITLE
TeX: 奥付の左列が3文字以上の場合にあふれるのを回避

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -307,9 +307,9 @@
 \rule[8pt]{\textwidth}{1pt} \\
 {\noindent\review@pubhistories}
 
-\begin{tabular}{p{3em}p{\dimexpr\textwidth-6em}}
+\begin{tabularx}{\dimexpr\textwidth-0.5em}{lX}
 \review@colophonnames
-\end{tabular}
+\end{tabularx}
 　\\
 \rule[0pt]{\textwidth}{1pt} \\
 \ifdefined\review@rights

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -219,6 +219,7 @@ cls]
 \RequirePackage{tcolorbox}
 \tcbuselibrary{xparse,hooks,skins,breakable}
 \RequirePackage{ulem}
+\RequirePackage{tabularx}
 
 \def\recls@tmp{luatex}
 \RequirePackage[\recls@driver, \if@pdfhyperlink\else draft,\fi

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -37,6 +37,7 @@
 \RequirePackage{amssymb}
 \RequirePackage{amsthm}
 \RequirePackage{bm}
+\RequirePackage{tabularx}
 
 %% if you use @<u>{} (underline), use jumoline.sty
 \IfFileExists{jumoline.sty}{
@@ -418,9 +419,9 @@
 \rule[8pt]{\textwidth}{1pt} \\
 {\noindent\review@pubhistories}
 
-\begin{tabular}{p{3em}p{\dimexpr\textwidth-6em}}
+\begin{tabularx}{\dimexpr\textwidth-0.5em}{lX}
 \review@colophonnames
-\end{tabular}
+\end{tabularx}
 　\\
 \rule[0pt]{\textwidth}{1pt} \\
 \ifdefined\review@rights


### PR DESCRIPTION
#1252 の修正です。

折り返し対策でtabularのpを使ってみていましたがやはりどうしようもないので、tabularxを導入して、左列を「l」、右列を「X」（残りを使って折り返し）とすることにします。
-0.5emはなんとなくですが、こうしないとちょっとはみ出るっぽい。
