### PR TITLE
[WIP] EPUB: ハイライトのエスケープ

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2018 Minero Aoki, Kenshi Muto
+# Copyright (c) 2002-2019 Minero Aoki, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -225,8 +225,8 @@ module ReVIEW
       puts ''
     end
 
-    def compile_inline(s)
-      @compiler.text(s)
+    def compile_inline(s, esc_array=nil)
+      @compiler.text(s, esc_array)
     end
 
     def inline_chapref(id)

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -225,7 +225,7 @@ module ReVIEW
       puts ''
     end
 
-    def compile_inline(s, esc_array=nil)
+    def compile_inline(s, esc_array = nil)
       @compiler.text(s, esc_array)
     end
 

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -553,7 +553,7 @@ module ReVIEW
       str.gsub("\x01", '@').gsub("\x02", '\\').gsub("\x03", '{').gsub("\x04", '}')
     end
 
-    def text(str, esc_array=nil)
+    def text(str, esc_array = nil)
       return '' if str.empty?
       words = replace_fence(str).split(/(@<\w+>\{(?:[^\}\\]|\\.)*?\})/, -1)
       words.each do |w|

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2018 Minero Aoki, Kenshi Muto, Masayoshi Takahashi,
+# Copyright (c) 2008-2019 Minero Aoki, Kenshi Muto, Masayoshi Takahashi,
 #                         KADO Masanori
 #               2002-2007 Minero Aoki
 #
@@ -463,9 +463,11 @@ module ReVIEW
       class_names.push("language-#{lang}") unless lang.blank?
       class_names.push('highlight') if highlight?
       print %Q(<pre class="#{class_names.join(' ')}">)
+      esc_array = []
+      lines.map! {|l| compile_inline(l, esc_array) }
       body = lines.inject('') { |i, j| i + detab(j) + "\n" }
       lexer = lang
-      puts highlight(body: body, lexer: lexer, format: 'html')
+      puts highlight(body: body, lexer: lexer, format: 'html', esc_array)
       puts '</pre>'
       puts '</div>'
     end

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -397,8 +397,10 @@ module ReVIEW
       class_names.push("language-#{lexer}") unless lexer.blank?
       class_names.push('highlight') if highlight?
       print %Q(<pre class="#{class_names.join(' ')}">)
+      esc_array = []
+      lines.map! {|l| compile_inline(l, esc_array) }
       body = lines.inject('') { |i, j| i + detab(j) + "\n" }
-      puts highlight(body: body, lexer: lexer, format: 'html')
+      puts revert_escape(highlight(body: body, lexer: lexer, format: 'html'), esc_array)
       puts '</pre>'
     end
 
@@ -417,9 +419,11 @@ module ReVIEW
 
     def source_body(_id, lines, lang)
       print %Q(<pre class="source">)
+      esc_array = []
+      lines.map! {|l| compile_inline(l, esc_array) }
       body = lines.inject('') { |i, j| i + detab(j) + "\n" }
       lexer = lang
-      puts highlight(body: body, lexer: lexer, format: 'html')
+      puts revert_escape(highlight(body: body, lexer: lexer, format: 'html'), esc_array)
       puts '</pre>'
     end
 
@@ -467,7 +471,7 @@ module ReVIEW
       lines.map! {|l| compile_inline(l, esc_array) }
       body = lines.inject('') { |i, j| i + detab(j) + "\n" }
       lexer = lang
-      puts highlight(body: body, lexer: lexer, format: 'html', esc_array)
+      puts revert_escape(highlight(body: body, lexer: lexer, format: 'html'), esc_array)
       puts '</pre>'
       puts '</div>'
     end
@@ -505,9 +509,11 @@ module ReVIEW
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
       print %Q(<pre class="cmd">)
+      esc_array = []
+      lines.map! {|l| compile_inline(l, esc_array) }
       body = lines.inject('') { |i, j| i + detab(j) + "\n" }
       lexer = 'shell-session'
-      puts highlight(body: body, lexer: lexer, format: 'html')
+      puts revert_escape(highlight(body: body, lexer: lexer, format: 'html'), esc_array)
       puts '</pre>'
       puts '</div>'
     end
@@ -1219,6 +1225,11 @@ module ReVIEW
 
     def olnum(num)
       @ol_num = num.to_i
+    end
+
+    def revert_escape(s, esc_array)
+      s.gsub("<span class=\"err\">\x01</span>", "\x01").
+        gsub("\x01") { esc_array.shift }
     end
 
     def defer_math_image(str, path, key)

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -398,8 +398,8 @@ module ReVIEW
       class_names.push('highlight') if highlight?
       print %Q(<pre class="#{class_names.join(' ')}">)
       esc_array = []
-      lines.map! {|l| compile_inline(l, esc_array) }
-      body = lines.inject('') { |i, j| i + detab(j) + "\n" }
+      lines.map! { |l| compile_inline(l, esc_array) }
+      body = lines.inject('') { |i, j| i + detab(j) }
       puts revert_escape(highlight(body: body, lexer: lexer, format: 'html'), esc_array)
       puts '</pre>'
     end
@@ -420,8 +420,8 @@ module ReVIEW
     def source_body(_id, lines, lang)
       print %Q(<pre class="source">)
       esc_array = []
-      lines.map! {|l| compile_inline(l, esc_array) }
-      body = lines.inject('') { |i, j| i + detab(j) + "\n" }
+      lines.map! { |l| compile_inline(l, esc_array) }
+      body = lines.inject('') { |i, j| i + detab(j) }
       lexer = lang
       puts revert_escape(highlight(body: body, lexer: lexer, format: 'html'), esc_array)
       puts '</pre>'
@@ -468,8 +468,8 @@ module ReVIEW
       class_names.push('highlight') if highlight?
       print %Q(<pre class="#{class_names.join(' ')}">)
       esc_array = []
-      lines.map! {|l| compile_inline(l, esc_array) }
-      body = lines.inject('') { |i, j| i + detab(j) + "\n" }
+      lines.map! { |l| compile_inline(l, esc_array) }
+      body = lines.inject('') { |i, j| i + detab(j) }
       lexer = lang
       puts revert_escape(highlight(body: body, lexer: lexer, format: 'html'), esc_array)
       puts '</pre>'
@@ -510,8 +510,8 @@ module ReVIEW
       end
       print %Q(<pre class="cmd">)
       esc_array = []
-      lines.map! {|l| compile_inline(l, esc_array) }
-      body = lines.inject('') { |i, j| i + detab(j) + "\n" }
+      lines.map! { |l| compile_inline(l, esc_array) }
+      body = lines.inject('') { |i, j| i + detab(j) }
       lexer = 'shell-session'
       puts revert_escape(highlight(body: body, lexer: lexer, format: 'html'), esc_array)
       puts '</pre>'
@@ -1229,6 +1229,7 @@ module ReVIEW
 
     def revert_escape(s, esc_array)
       s.gsub("<span class=\"err\">\x01</span>", "\x01").
+        gsub("<span style=\"border: 1px solid #FF0000\">\x01</span>", "\x01").
         gsub("\x01") { esc_array.shift }
     end
 

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2018 Minero Aoki, Kenshi Muto
+# Copyright (c) 2008-2019 Minero Aoki, Kenshi Muto
 #               2002-2007 Minero Aoki
 #
 # This program is free software.
@@ -340,6 +340,8 @@ module ReVIEW
       puts "<caption aid:pstyle='#{css_class}-title'>#{compile_inline(caption)}</caption>" if caption.present?
       print '<pre>'
       no = 1
+      esc_array = []
+      lines.map! { |l| compile_inline(l, esc_array) }
       lines.each do |line|
         if @book.config['listinfo']
           print %Q(<listinfo line="#{no}")
@@ -347,7 +349,7 @@ module ReVIEW
           print %Q( end="#{no}") if no == lines.size
           print '>'
         end
-        print detab(line)
+        print revert_escape(detab(line), esc_array)
         print "\n"
         print '</listinfo>' if @book.config['listinfo']
         no += 1
@@ -1168,6 +1170,10 @@ module ReVIEW
 
     def image_ext
       'eps'
+    end
+
+    def revert_escape(s, esc_array)
+      s.gsub("\x01") { esc_array.shift }
     end
   end
 end # module ReVIEW

--- a/test/test_builder.rb
+++ b/test/test_builder.rb
@@ -4,7 +4,7 @@ require 'review/builder'
 require 'review/book'
 
 class MockCompiler
-  def text(s)
+  def text(s, _array = nil)
     [:text, s]
   end
 end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -630,7 +630,7 @@ EOS
 <pre class="list highlight">test1
 test1.5
 
-test&lt;i&gt;2&lt;/i&gt;
+test<i>2</i>
 </pre>
 </div>
     EOS
@@ -706,7 +706,7 @@ end
     @book.config['highlight']['html'] = 'rouge'
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
 
-    assert_equal %Q(<div id="samplelist" class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list highlight">test1\ntest1.5\n\ntest&lt;i&gt;2&lt;/i&gt;\n</pre>\n</div>\n), actual
+    assert_equal %Q(<div id="samplelist" class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list highlight">test1\ntest1.5\n\ntest<i>2</i>\n</pre>\n</div>\n), actual
   end
 
   def test_list_rouge_lang


### PR DESCRIPTION
#1251 の対応

compiler, builder双方にだいぶ気持ちが悪いことをしないといけない。

- リスト類をembedと同じ扱いにして、inline_compileは各リストメソッド側で実行するという回避方法。泥縄っぽくて後々痛い目にあうか？
- x01文字は当然ハイライタではエラーになるので、後の戻し処理でエラー表記spanごと削る方法で対処している
- LaTeX側はlistingsがコンパイル時にスタイルマクロ内での解析実行となっており、ここにエスケープを割り込んで戻す、というロジックを入れるのは無理そう。EPUBだけの固有機能ということになり、気持ち悪い。
- inline_compileを実行したときになんか改行が増える？？
- idgxmlでテストエラー。改行まわりなのでHTML以外のほかのビルダも同じのはず
- emlistnum, listnumはハイライト処理の一本化のマージが先に必要
