### PR TITLE
remove --strip option from review-preproc

### DIFF
--- a/bin/review-preproc
+++ b/bin/review-preproc
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 #
-# Copyright (c) 2010-2014 Minero Aoki, Kenshi Muto
+# Copyright (c) 2010-2019 Minero Aoki, Kenshi Muto
 #               1999-2007 Minero Aoki
 #
 # This program is free software.
@@ -52,7 +52,6 @@ def main
   opts.on('-c', '--check', 'Check if preprocess is needed.') { mode = :check }
   opts.on('-d', '--diff', 'Show diff from current file.') { mode = :diff }
   opts.on('--replace', 'Replace file by preprocessed one.') { mode = :replace }
-  opts.on('-s', '--strip', 'Strip preprocessor tags.') { mode = :strip }
   opts.on('--tabwidth=WIDTH', "Replace tabs with space characters. (0: don't replace)") { |width| param['tabwidth'] = width.to_i }
   opts.on('--help', 'Print this message and quit.') do
     puts opts.help
@@ -87,10 +86,6 @@ def main
         end
       ensure
         FileUtils.rm_f tmp
-      end
-    when :strip
-      File.open(path) do |f|
-        ReVIEW::Preprocessor::Strip.new(f).each { |line| puts line }
       end
     else
       raise "must not happen: #{mode}"


### PR DESCRIPTION
#1257 の対応

`--strip` オプションの実用性は低く、開発陣は誰も使っていなくてバギーなので削除します。
