### PR TITLE
//commentのエスケープの修正

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2018 Minero Aoki, Kenshi Muto, Masayoshi Takahashi,
+# Copyright (c) 2008-2019 Minero Aoki, Kenshi Muto, Masayoshi Takahashi,
 #                         KADO Masanori
 #               2002-2007 Minero Aoki
 #
@@ -748,11 +748,11 @@ module ReVIEW
     end
 
     def comment(lines, comment = nil)
-      lines ||= []
-      lines.unshift comment unless comment.blank?
       return unless @book.config['draft']
+      lines ||= []
+      lines.unshift escape(comment) unless comment.blank?
       str = lines.join('<br />')
-      puts %Q(<div class="draft-comment">#{escape(str)}</div>)
+      puts %Q(<div class="draft-comment">#{str}</div>)
     end
 
     def footnote(id, str)

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -581,11 +581,11 @@ module ReVIEW
     end
 
     def comment(lines, comment = nil)
-      return true unless @book.config['draft']
+      return unless @book.config['draft']
       lines ||= []
-      lines.unshift comment unless comment.blank?
+      lines.unshift escape(comment) unless comment.blank?
       str = lines.join("\n")
-      print "<msg>#{escape(str)}</msg>"
+      print "<msg>#{str}</msg>"
     end
 
     def inline_comment(str)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -853,13 +853,13 @@ module ReVIEW
     end
 
     def comment(lines, comment = nil)
+      return true unless @book.config['draft']
       lines ||= []
       unless comment.blank?
-        lines.unshift comment
+        lines.unshift escape(comment)
       end
-      return true unless @book.config['draft']
       str = lines.join('\par ')
-      puts macro('pdfcomment', escape(str))
+      puts macro('pdfcomment', str)
     end
 
     def hr

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -240,7 +240,7 @@ module ReVIEW
       unless comment.blank?
         lines.unshift comment
       end
-      str = lines.join
+      str = lines.join("\n")
       puts "◆→#{str}←◆"
     end
 

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1758,8 +1758,10 @@ EOS
 
   def test_comment_for_draft
     @config['draft'] = true
-    actual = compile_block('//comment[コメント]')
-    assert_equal %Q(<div class="draft-comment">コメント</div>\n), actual
+    actual = compile_block('//comment[コメント<]')
+    assert_equal %Q(<div class="draft-comment">コメント&lt;</div>\n), actual
+    actual = compile_block("//comment{\nA<>\nB&\n//}")
+    assert_equal %Q(<div class="draft-comment">A&lt;&gt;<br />B&amp;</div>\n), actual
   end
 
   def test_inline_comment

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -721,8 +721,10 @@ EOS
 
   def test_comment_for_draft
     @config['draft'] = true
-    actual = compile_block('//comment[コメント]')
-    assert_equal '<msg>コメント</msg>', actual
+    actual = compile_block('//comment[コメント<]')
+    assert_equal '<msg>コメント&lt;</msg>', actual
+    actual = compile_block("//comment{\nA<>\nB&\n//}")
+    assert_equal %Q(<msg>A&lt;&gt;\nB&amp;</msg>), actual
   end
 
   def test_inline_comment

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -993,8 +993,10 @@ EOS
 
   def test_comment_for_draft
     @config['draft'] = true
-    actual = compile_block('//comment[コメント]')
-    assert_equal %Q(\\pdfcomment{コメント}\n), actual
+    actual = compile_block('//comment[コメント<]')
+    assert_equal %Q(\\pdfcomment{コメント\\textless{}}\n), actual
+    actual = compile_block("//comment{\nA<>\nB&\n//}")
+    assert_equal %Q(\\pdfcomment{A\\textless{}\\textgreater{}\\par B\\&}\n), actual
   end
 
   def test_inline_comment

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -182,8 +182,10 @@ class TOPBuidlerTest < Test::Unit::TestCase
 
   def test_comment_for_draft
     @config['draft'] = true
-    actual = compile_block('//comment[コメント]')
-    assert_equal %Q(◆→コメント←◆\n), actual
+    actual = compile_block('//comment[コメント<]')
+    assert_equal %Q(◆→コメント<←◆\n), actual
+    actual = compile_block("//comment{\nA<>\nB&\n//}")
+    assert_equal %Q(◆→A<>\nB&←◆\n), actual
   end
 
   def test_list


### PR DESCRIPTION
#1264 の修正。

`//comment[]`と`//comment{`の両方で正しくエスケープされるように修正しました。
