### PR TITLE
\reviewbackcompatibilityhookの導入

### DIFF
--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -98,4 +98,10 @@
 \def\reviewusepart{true}
 <%- end -%>
 
+\def\reviewbackcompatibilityhook{
+  \@ifundefined{reviewimagecaption}{% for 3.0.0 compatibility
+    \newcommand{\reviewimagecaption}[1]{\caption{##1}}
+  }
+}
+
 \makeatother

--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -6,6 +6,9 @@
 <%-   end -%>
 <%- end -%>
 
+%% backward compatibility (defined in config.erb)
+\reviewbackcompatibilityhook
+
 \begin{document}
 
 %% begindocument hook

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -44,8 +44,17 @@
 \def\reviewappendixfiles{}
 \def\reviewpostdeffiles{}
 
+\def\reviewbackcompatibilityhook{
+  \@ifundefined{reviewimagecaption}{% for 3.0.0 compatibility
+    \newcommand{\reviewimagecaption}[1]{\caption{##1}}
+  }
+}
+
 \makeatother
 
+
+%% backward compatibility (defined in config.erb)
+\reviewbackcompatibilityhook
 
 \begin{document}
 

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -55,8 +55,17 @@ some ad content
 \def\reviewappendixfiles{}
 \def\reviewpostdeffiles{}
 
+\def\reviewbackcompatibilityhook{
+  \@ifundefined{reviewimagecaption}{% for 3.0.0 compatibility
+    \newcommand{\reviewimagecaption}[1]{\caption{##1}}
+  }
+}
+
 \makeatother
 
+
+%% backward compatibility (defined in config.erb)
+\reviewbackcompatibilityhook
 
 \begin{document}
 


### PR DESCRIPTION
#1267 の対応。
reviewimagecaptionのようにreview-updateしないと壊れるんだけど気付きにくい、というかなり限定した用途のみで後方互換性を保つロジックを記載し、\begin{document}前で呼び出します。

ユーザーが書き換えることは想定しておらず、config.erbでシステムで定義します。
現時点では以下の機能のみを中身に書いています。

- `\reviewimagecaption`が定義されていないようであれば定義する。すでに定義されているなら何もしない。

増えるたびにテストassetsも書き加えないといけないのがナンなので、今後はなるべく使わないで済むようにしたいですね…。