### PR TITLE
HTML/TeXにおいて、tt/tti/ttb/code内のスペースを文字どおりで残す

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -167,6 +167,9 @@ secnolevel: 2
 #   html: "rouge"
 #   latex: "listings"
 
+# @<tt>, @<code>内のスペースを入れたとおりに保持する。省略した場合はPDFMaker、EPUBMakerにおいて複数のスペースは1つに縮約される。trueにすると縮約しない
+# keepcodespace: null
+
 # カタログファイル名を指定する
 # catalogfile: catalog.yml
 

--- a/lib/review/catalog.rb
+++ b/lib/review/catalog.rb
@@ -50,7 +50,7 @@ module ReVIEW
     end
 
     def parts_with_chaps
-      return '' unless @yaml['CHAPS']
+      return [] unless @yaml['CHAPS']
       @yaml['CHAPS'].flatten.compact
     end
 

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2018 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
+# Copyright (c) 2012-2019 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -65,6 +65,7 @@ module ReVIEW
         'words_file' => nil,
         'colophon_order' => %w[aut csl trl dsr ill cov edt pbl contact prt],
         'externallink' => true,
+        'keepcodespace' => nil,
         # for IDGXML
         'tableopt' => nil,
         'listinfo' => nil,

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -910,7 +910,7 @@ module ReVIEW
 
     def inline_tti(str)
       if @book.htmlversion == 5
-        %Q(<code class="tt"><i>#{escape(str)}</i></code>)
+        %Q(<code class="tt"><i>#{keep_space(escape(str))}</i></code>)
       else
         %Q(<tt><i>#{escape(str)}</i></tt>)
       end
@@ -918,7 +918,7 @@ module ReVIEW
 
     def inline_ttb(str)
       if @book.htmlversion == 5
-        %Q(<code class="tt"><b>#{escape(str)}</b></code>)
+        %Q(<code class="tt"><b>#{keep_space(escape(str))}</b></code>)
       else
         %Q(<tt><b>#{escape(str)}</b></tt>)
       end
@@ -930,7 +930,7 @@ module ReVIEW
 
     def inline_code(str)
       if @book.htmlversion == 5
-        %Q(<code class="inline-code tt">#{escape(str)}</code>)
+        %Q(<code class="inline-code tt">#{keep_space(escape(str))}</code>)
       else
         %Q(<tt class="inline-code">#{escape(str)}</tt>)
       end
@@ -1131,7 +1131,7 @@ module ReVIEW
 
     def inline_tt(str)
       if @book.htmlversion == 5
-        %Q(<code class="tt">#{escape(str)}</code>)
+        %Q(<code class="tt">#{keep_space(escape(str))}</code>)
       else
         %Q(<tt>#{escape(str)}</tt>)
       end

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -40,6 +40,14 @@ module ReVIEW
       str.gsub('-', '&#45;')
     end
 
+    def keep_space(str)
+      if @book.config['keepcodespace']
+        str.gsub(' ', '&nbsp;')
+      else
+        str
+      end
+    end
+
     def highlight?
       @book.config['highlight'] &&
         @book.config['highlight']['html']

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -1061,7 +1061,7 @@ module ReVIEW
       if @book.config.check_version('2', exception: false)
         macro('texttt', escape(str))
       else
-        macro('reviewcode', escape(str))
+        macro('reviewcode', keep_space(escape(str)))
       end
     end
 
@@ -1073,7 +1073,7 @@ module ReVIEW
       if @book.config.check_version('2', exception: false)
         macro('texttt', escape(str))
       else
-        macro('reviewtt', escape(str))
+        macro('reviewtt', keep_space(escape(str)))
       end
     end
 
@@ -1085,7 +1085,7 @@ module ReVIEW
       if @book.config.check_version('2', exception: false)
         macro('texttt', macro('textit', escape(str)))
       else
-        macro('reviewtti', escape(str))
+        macro('reviewtti', keep_space(escape(str)))
       end
     end
 
@@ -1093,7 +1093,7 @@ module ReVIEW
       if @book.config.check_version('2', exception: false)
         macro('texttt', macro('textbf', escape(str)))
       else
-        macro('reviewttb', escape(str))
+        macro('reviewttb', keep_space(escape(str)))
       end
     end
 

--- a/lib/review/latexutils.rb
+++ b/lib/review/latexutils.rb
@@ -85,6 +85,14 @@ module ReVIEW
       str.gsub(/[\#%]/) { |s| '\\' + s }
     end
 
+    def keep_space(str)
+      if @book.config['keepcodespace']
+        str.gsub(' ', '~')
+      else
+        str
+      end
+    end
+
     def macro(name, *args)
       "\\#{name}" + args.map { |a| "{#{a}}" }.join
     end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -224,6 +224,12 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(test <code class="tt">inline test</code> test2), actual
   end
 
+  def test_inline_tt_keepspace
+    @config['keepcodespace'] = true
+    actual = compile_inline('@<tt>{a b  c   d} @<tti>{a b  c   d} @<ttb>{a b  c   d}')
+    assert_equal '<code class="tt">a&nbsp;b&nbsp;&nbsp;c&nbsp;&nbsp;&nbsp;d</code> <code class="tt"><i>a&nbsp;b&nbsp;&nbsp;c&nbsp;&nbsp;&nbsp;d</i></code> <code class="tt"><b>a&nbsp;b&nbsp;&nbsp;c&nbsp;&nbsp;&nbsp;d</b></code>', actual
+  end
+
   def test_inline_tti
     actual = compile_inline('test @<tti>{inline test} test2')
     assert_equal %Q(test <code class="tt"><i>inline test</i></code> test2), actual

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -197,6 +197,12 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     assert_equal 'test \\reviewtt{inline test} test2', actual
   end
 
+  def test_inline_tt_keepspace
+    @config['keepcodespace'] = true
+    actual = compile_inline('@<tt>{a b  c   d} @<tti>{a b  c   d} @<ttb>{a b  c   d}')
+    assert_equal '\\reviewtt{a~b~~c~~~d} \\reviewtti{a~b~~c~~~d} \\reviewttb{a~b~~c~~~d}', actual
+  end
+
   def test_inline_tt_endash
     actual = compile_inline('test @<tt>{in-line --test ---foo ----bar -----buz} --test2')
     assert_equal 'test \\reviewtt{in{-}line {-}{-}test {-}{-}{-}foo {-}{-}{-}{-}bar {-}{-}{-}{-}{-}buz} {-}{-}test2', actual


### PR DESCRIPTION
#1277 の修正です。
tt, tti, ttb, codeのインラインタグに対して加工します。

おおむね副作用はなさそうとはいえちょっと怖いので、config.ymlで`keepcodespace`が設定されている（デフォルトはnull）ときのみTeXでは`~`、HTMLでは`&nbsp;`になるように置換します。
