### PR TITLE
add --debug flag to review-epubmaker

### DIFF
--- a/bin/review-epubmaker
+++ b/bin/review-epubmaker
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-# Copyright (c) 2010-2017 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2019 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -10,39 +10,7 @@ require 'pathname'
 require 'optparse'
 bindir = Pathname.new(__FILE__).realpath.dirname
 $LOAD_PATH.unshift((bindir + '../lib').realpath)
+
 require 'review/epubmaker'
-require 'review/version'
 
-@logger = ReVIEW.logger
-
-rv = ReVIEW::EPUBMaker.new
-
-opts = OptionParser.new
-opts.version = ReVIEW::VERSION
-opts.banner = "Usage: #{File.basename($PROGRAM_NAME)} [options] YAML_filename [export_filename]"
-opts.on('--help', 'Prints this message and quit.') do
-  puts opts.help
-  exit 0
-end
-
-begin
-  opts.parse!
-rescue OptionParser::ParseError => err
-  @logger.error err.message
-  $stderr.puts opts.help
-  exit 1
-end
-
-if ARGV.size < 1
-  puts opts.help
-  exit 1
-end
-
-unless File.exist?(ARGV[0])
-  @logger.error "#{File.basename($PROGRAM_NAME, '.*')}: #{ARGV[0]} not found."
-  exit 1
-end
-
-yaml_file = ARGV[0]
-bookname = ARGV[1]
-rv.produce(yaml_file, bookname)
+ReVIEW::EPUBMaker.execute(*ARGV)


### PR DESCRIPTION
#1281 の対応

`review-epubmaker --debug  (--no-debug)`オプションを追加します。

pdfmaker.rbで実装を示していただいていたおかげで、思ったよりも大変でなくできました。
性質上、特に後方互換性が失われるものはないはずです。
