### PR TITLE
章付きキー参照で章がないときに内部例外ではなくKeyErrorを発生させるようにする

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -478,7 +478,9 @@ module ReVIEW
     def extract_chapter_id(chap_ref)
       m = /\A([\w+-]+)\|(.+)/.match(chap_ref)
       if m
-        return [@book.contents.detect { |chap| chap.id == m[1] }, m[2]]
+        ch = @book.contents.detect { |chap| chap.id == m[1] }
+        raise KeyError unless ch
+        return [ch, m[2]]
       end
       [@chapter, chap_ref]
     end

--- a/test/test_builder.rb
+++ b/test/test_builder.rb
@@ -80,6 +80,22 @@ class BuidlerTest < Test::Unit::TestCase
     assert_equal [:text, text], @b.compile_inline(text)
   end
 
+  def test_inline_missing_ref
+    b = Builder.new
+    chapter = ReVIEW::Book::Chapter.new(ReVIEW::Book::Base.load, 1, 'chap1', nil, StringIO.new)
+    b.bind(nil, chapter, nil)
+    e = assert_raises(ReVIEW::ApplicationError) { b.inline_list('unknown|list1') }
+    assert_equal ': error: unknown list: unknown|list1', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { b.inline_table('unknown|table1') }
+    assert_equal ': error: unknown table: unknown|table1', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { b.inline_img('unknown|img1') }
+    assert_equal ': error: unknown image: unknown|img1', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { b.inline_column('unknown|column1') }
+    assert_equal ': error: unknown column: unknown|column1', e.message
+    e = assert_raises(ReVIEW::ApplicationError) { b.inline_fn('unknown|footnote1') }
+    assert_equal ': error: unknown footnote: unknown|footnote1', e.message
+  end
+
   class XBuilder < Builder
     def list_header(id, caption)
     end


### PR DESCRIPTION
#1284 の対応です。
