### PR TITLE
pagerenumberingの再実装

### DIFF
--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -1,5 +1,5 @@
 %#!ptex2pdf -l -u -ot '-synctex=1' test-rejsbk
-% Copyright (c) 2018 Munehiro Yamamoto, Kenshi Muto.
+% Copyright (c) 2018-2019 Munehiro Yamamoto, Kenshi Muto.
 %
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the "Software"), to deal
@@ -458,8 +458,8 @@
 
 %% シンプルな通しノンブル
 \ifrecls@serialpage
-\renewcommand*{\pagenumbering}[1]{%
-  \gdef\thepage{\@arabic\c@page}}
+\def\pagenumbering#1{%
+  \gdef\thepage{\csname @arabic\endcsname\c@page}}
 \fi
 
 %% 開始ページを変更


### PR DESCRIPTION
#1288 の修正。
renewcommandだと展開でPDF内の情報が変なものになるようなので、もともとのlatex.ltxの内容に基づいて定義し直します。

latex.ltxのもともとの内容は
```
macro:#1->\global \c@page \@ne \gdef \thepage {\csname @#1\endcsname \c@page }
```

このうち、最初のページリセット部分を除き、#1を取って展開するところはリテラルに@arabicとすることで通しノンブル化します。