### PR TITLE
epubmaker: fix OPF generator to cover metadata be included

### DIFF
--- a/lib/epubmaker/epubv3.rb
+++ b/lib/epubmaker/epubv3.rb
@@ -125,6 +125,14 @@ module EPUBMaker
         end
       end
 
+      if @producer.config['coverimage']
+        @producer.contents.each do |item|
+          next if !item.media.start_with?('image') || File.basename(item.file) != @producer.config['coverimage']
+          s << %Q(    <meta name="cover" content="cover-#{item.id}"/>\n)
+          break
+        end
+      end
+
       ## add custom <meta> element
       if @producer.config['opf_meta'].present?
         @producer.config['opf_meta'].each do |k, v|


### PR DESCRIPTION
review-epubmaker generates EPUB with thumbnail issue on iOS Books and macOS Finder.
This PR attempts to solve this issue by adding `cover` metadata into `.opf`.

```html
<meta name="cover" content="cover-#{item.id}"/>
```

<img width="745" alt="Screen Shot 2019-04-16 at 9 32 03" src="https://user-images.githubusercontent.com/431808/56174786-36c32980-602f-11e9-958b-721c2f89c737.png">

![IMG_0205](https://user-images.githubusercontent.com/431808/56174791-3cb90a80-602f-11e9-8ac6-33ee7af258d3.jpg)