### PR TITLE
epubmaker: include cover image into metadata for iBooks

### DIFF
--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -36,10 +36,9 @@ module EPUBMaker
       if @producer.config['coverimage']
         file = nil
         @producer.contents.each do |item|
-          if !item.media.start_with?('image') || item.file !~ /#{@producer.config["coverimage"]}\Z/
+          if !item.media.start_with?('image') || item.file !~ /#{@producer.config['coverimage']}\Z/
             next
           end
-
           s << %Q(    <meta name="cover" content="#{item.id}"/>\n)
           file = item.file
           break

--- a/lib/epubmaker/epubv3.rb
+++ b/lib/epubmaker/epubv3.rb
@@ -26,6 +26,7 @@ module EPUBMaker
     # Return opf file content.
     def opf
       @opf_metainfo = opf_metainfo
+      @opf_coverimage = opf_coverimage
       @opf_manifest = opf_manifest
       @opf_toc = opf_tocx
       @package_attrs = ''

--- a/templates/opf/epubv3.opf.erb
+++ b/templates/opf/epubv3.opf.erb
@@ -2,6 +2,7 @@
 <package version="3.0" xmlns="http://www.idpf.org/2007/opf" unique-identifier="BookId" xml:lang="<%= @producer.config['language'] %>"<%= @package_attrs %>>
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:opf="http://www.idpf.org/2007/opf">
 <%= @opf_metainfo %>
+<%= @opf_coverimage %>
   </metadata>
 <%= @opf_manifest %>
 <%= @opf_toc %>


### PR DESCRIPTION
#1292 の代替

- もともと epubv2 向けにcommonでopf_coverimageというのを用意していた
- EPUBv3では表紙のmetaは不要になったはずでopfからは除去していたが、AppleのiBooksではまだこれを参照してしまう模様
- metaがあること自体でvalidatorがエラーになることはないようなので、EPUBv3でも復活させる
