### PR TITLE
headline解析でnotoc, nodispを飛ばす

### DIFF
--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -345,7 +345,7 @@ module ReVIEW
             end
           end
 
-          if %w[notoc nodisp].include?(m[2])
+          if %w[nonum notoc nodisp].include?(m[2])
             headlines[index] = m[3].present? ? m[3].strip : m[4].strip
             items.push Item.new(headlines.join('|'), nil, m[4].strip)
           else

--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2018 Minero Aoki, Kenshi Muto
+# Copyright (c) 2008-2019 Minero Aoki, Kenshi Muto
 #               2002-2007 Minero Aoki
 #
 # This program is free software.
@@ -316,6 +316,7 @@ module ReVIEW
           if m.nil? || m[1].size > 10 # Ignore too deep index
             next
           end
+
           index = m[1].size - 2
 
           # column
@@ -343,9 +344,15 @@ module ReVIEW
               indexs[i] ||= 0
             end
           end
-          indexs[index] += 1
-          headlines[index] = m[3].present? ? m[3].strip : m[4].strip
-          items.push Item.new(headlines.join('|'), indexs.dup, m[4].strip)
+
+          if %w(notoc nodisp).include?(m[2])
+            headlines[index] = m[3].present? ? m[3].strip : m[4].strip
+            items.push Item.new(headlines.join('|'), nil, m[4].strip)
+          else
+            indexs[index] += 1
+            headlines[index] = m[3].present? ? m[3].strip : m[4].strip
+            items.push Item.new(headlines.join('|'), indexs.dup, m[4].strip)
+          end
         end
         new(items, chap)
       end
@@ -364,6 +371,10 @@ module ReVIEW
       end
 
       def number(id)
+        unless self[id].number
+          # when notoc
+          return ''
+        end
         n = @chap.number
         # XXX: remove magic number (move to lib/review/book/chapter.rb)
         if @chap.on_appendix? && @chap.number > 0 && @chap.number < 28

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -1002,7 +1002,7 @@ module ReVIEW
 
     def inline_hd_chap(chap, id)
       n = chap.headline_index.number(id)
-      if chap.number and @book.config['secnolevel'] >= n.split('.').size
+      if chap.number && @book.config['secnolevel'] >= n.split('.').size && n.present?
         str = I18n.t('hd_quote', [n, compile_inline(chap.headline(id).caption)])
       else
         str = I18n.t('hd_quote_without_number', compile_inline(chap.headline(id).caption))

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -1148,7 +1148,7 @@ module ReVIEW
     def inline_hd_chap(chap, id)
       if chap.number
         n = chap.headline_index.number(id)
-        if @book.config['secnolevel'] >= n.split('.').size
+        if @book.config['secnolevel'] >= n.split('.').size && n.present?
           return I18n.t('hd_quote', [n, compile_inline(chap.headline(id).caption)])
         end
       end

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -1103,7 +1103,7 @@ module ReVIEW
 
     def inline_hd_chap(chap, id)
       n = chap.headline_index.number(id)
-      if chap.number and @book.config['secnolevel'] >= n.split('.').size
+      if chap.number and @book.config['secnolevel'] >= n.split('.').size && n.present?
         str = I18n.t('hd_quote', [chap.headline_index.number(id), compile_inline(chap.headline(id).caption)])
       else
         str = I18n.t('hd_quote_without_number', compile_inline(chap.headline(id).caption))

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Kenshi Muto
+# Copyright (c) 2018-2019 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -366,7 +366,7 @@ module ReVIEW
     def inline_hd_chap(chap, id)
       if chap.number
         n = chap.headline_index.number(id)
-        if @book.config['secnolevel'] >= n.split('.').size
+        if @book.config['secnolevel'] >= n.split('.').size && n.present?
           return I18n.t('hd_quote', [n, compile_inline(chap.headline(id).caption)])
         end
       end

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -217,6 +217,8 @@ class IndexTest < Test::Unit::TestCase
 == sec1
 ===[nodisp] sec1-0
 === sec1-1
+==[nonum] sec03
+== sec04
     EOB
     book = Book::Base.load
     chap = Book::Chapter.new(book, 1, '-', nil)
@@ -226,5 +228,7 @@ class IndexTest < Test::Unit::TestCase
     assert_equal [1], index['sec1'].number
     assert_equal nil, index['sec1-0'].number
     assert_equal [1, 1], index['sec1-1'].number
+    assert_equal nil, index['sec03'].number
+    assert_equal [2], index['sec04'].number
   end
 end

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -208,4 +208,23 @@ class IndexTest < Test::Unit::TestCase
     index = Book::HeadlineIndex.parse(src, chap)
     assert_equal [1, 1, 1], index['sec1-1-1'].number
   end
+
+  def test_headeline_index11
+    src = <<-EOB
+= chap1
+==[nodisp] sec01
+==[notoc] sec02
+== sec1
+===[nodisp] sec1-0
+=== sec1-1
+    EOB
+    book = Book::Base.load
+    chap = Book::Chapter.new(book, 1, '-', nil)
+    index = Book::HeadlineIndex.parse(src, chap)
+    assert_equal nil, index['sec01'].number
+    assert_equal nil, index['sec02'].number
+    assert_equal [1], index['sec1'].number
+    assert_equal nil, index['sec1-0'].number
+    assert_equal [1, 1], index['sec1-1'].number
+  end
 end


### PR DESCRIPTION
#1294 の対応

- notoc, nodispがあったときには採番カウンタを増やさない。numberで呼び出されるときには空文字列とする（nilでもよかったかもしれないけど、ちょっと互換性など怖いので）
- 各ビルダのほうはnumberが空だったらwithout_numberのほうのフォーマット文字列を利用する
- テストどう書くといいんでしょう…

notocの下位にnotocではない見出しを付けたときには、notoc前の採番ルールに従うことになる。これに対処するのはきついので仕様としたい。

```
ch01.re
== A
==[notoc] B
=== C
== D
```
とあるとき、Aは「1.1 A」、Bは「B」、Cは「1.1.1 C」、Dは「1.2 D」に展開される。このCのこと。



