### PR TITLE
jlreq.cls 0401版への対処

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -69,16 +69,23 @@
 
 \newcommand{\reviewbackslash}[0]{\textbackslash{}}
 
+% 古いjlreq.clsへの互換(当面のad-hoc対応)
+\ifdefined\jlreq@@makecaption@font@setting
+\else
+\let\jlreq@@makecaption@font@setting\jlreq@@makecaption@font
+\let\jlreq@@makecaption@label@@font@setting\jlreq@@makecaption@label@font@setting
+\fi
+
 \renewcommand{\@makecaption}[2]{{% %本当はl,c,rを[]で指定したい
   \reset@font\small
   \vskip\abovecaptionskip
   \jlreq@ifempty{#1}{%
-    \sbox\@tempboxa{{\jlreq@@makecaption@font #2}}}{%
-    \sbox\@tempboxa{{\jlreq@@makecaption@label@font #1}\review@intn@captionprefix{\jlreq@@makecaption@font #2}}}
+    \sbox\@tempboxa{{\jlreq@@makecaption@font@setting #2}}}{%
+    \sbox\@tempboxa{{\jlreq@@makecaption@label@font@setting #1}\review@intn@captionprefix{\jlreq@@makecaption@font@setting #2}}}
   \ifdim \wd\@tempboxa >\hsize
   \jlreq@ifempty{#1}{%
-    {\jlreq@@makecaption@font #2}}{%
-    {\jlreq@@makecaption@label@font #1}\review@intn@captionprefix{\jlreq@@makecaption@font #2}}\relax\par
+    {\jlreq@@makecaption@font@setting #2}}{%
+    {\jlreq@@makecaption@label@font@setting #1}\review@intn@captionprefix{\jlreq@@makecaption@font@setting #2}}\relax\par
   \else
     \global\@minipagefalse
     \hbox to\hsize{\box\@tempboxa\hfil}% キャプションLeft


### PR DESCRIPTION
- フォント名マクロが変更になったので追従＆後方互換保持
