### PR TITLE
PDFMaker: needspaceを利用してキャプションとブロックの泣き別れを防ぐ

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -99,10 +99,10 @@
 \newcommand{\reviewemlistcaption}[1]{\review@commoncaption{}{#1}}
 \newcommand{\reviewsourcecaption}[1]{\review@commoncaption{}{#1}}
 \newcommand{\reviewcmdcaption}[1]{\review@commoncaption{}{#1}}
-\newenvironment{reviewlistblock}{\list{}{\topsep.5\baselineskip \leftmargin\z@ \itemindent\z@}\item\relax}{\endlist}% 上下アキ0.5
+\newenvironment{reviewlistblock}{\list{}{\topsep.5\baselineskip \leftmargin\z@ \itemindent\z@}\item\needspace{4\Cvs}\relax}{\endlist}% 上下アキ0.5
 
 \newcommand{\reviewequationcaption}[1]{\review@commoncaption{}{#1}}
-\newenvironment{reviewequationblock}{}{}
+\newenvironment{reviewequationblock}{\needspace{2\Cvs}}{}
 
 \newcommand{\reviewimageref}[2]{\review@intn@image #1}
 \newcommand{\reviewtableref}[2]{\review@intn@table #1}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -16,6 +16,7 @@
 \RequirePackage[deluxe]{otf}%
 }
 \RequirePackage{caption}
+\RequirePackage{needspace}
 \RequirePackage{suffix}
 \RequirePackage[T1]{fontenc}\RequirePackage{textcomp}%T1/TS1
 \RequirePackage{lmodern}
@@ -123,9 +124,9 @@
 
 \newcommand{\reviewequationcaption}[1]{%
   \medskip{\small\noindent #1}}
-\newenvironment{reviewequationblock}{}{}
+\newenvironment{reviewequationblock}{\needspace{2\Cvs}}{}
 
-\newenvironment{reviewlistblock}{}{}
+\newenvironment{reviewlistblock}{\needspace{2\Cvs}}{}
 
 \newenvironment{reviewemlist}{%
   \medskip\small\begin{shaded}\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%


### PR DESCRIPTION
munepiさんに相談したところ、needspaceを使うのがよいのではということで実装してみました。

図表以外で独自キャプションを付けているリスト系（reviewlistblock）, 式系（reviewequationblock）では現状、キャプションと内容とは結合しておらず、ページの位置によっては泣き別れが発生する。
フロートにするにもなじまないので、needspaceを使ってキャプション+αの空き領域を確保するようにする。

- 空き確保はとりあえず2行ぶんにしておく。キャプションが2行以上になるとダメだが…
- review-jlreqのreviewlistblockの値が2や3だとだめで4くらいにしないといけない理由がよくわかってない。