### PR TITLE
Add Travius and appveryor test code and Fix epubv2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: ruby
 sudo: false
 dist: trusty
 
+os:
+  - linux
+  - osx
+
 addons:
   apt:
     packages:
@@ -21,6 +25,12 @@ before_install:
       gem update --system
       gem install bundler
     fi
+    gem install epubcheck-ruby
+
+script:
+  - ruby bin/review-init hello && cd hello && ruby ../bin/review-epubmaker config.yml && epubcheck book.epub
+  - cd ..
+  - ruby bin/review-init hello2 --epub-version 2 && cd hello2 && ruby ../bin/review-epubmaker config.yml && epubcheck book.epub
 
 rvm:
   - 2.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,8 @@ addons:
 
 before_install:
   - |-
-    RUBY_VER=`ruby -e "print RUBY_VERSION"`
-    if [ "$RUBY_VER" = "2.1.10" ]; then
-      gem install bundler -v '< 2'
-    elif [ "$RUBY_VER" = "2.2.10" ]; then
-      gem install bundler -v '< 2'
-    else
-      gem update --system
-      gem install bundler
-    fi
+    gem update --system
+    gem install bundler
     gem install epubcheck-ruby
 
 script:
@@ -33,9 +26,6 @@ script:
   - ruby bin/review-init hello2 --epub-version 2 && cd hello2 && ruby ../bin/review-epubmaker config.yml && epubcheck book.epub
 
 rvm:
-  - 2.1
-  - 2.2.10
-  - 2.3.8
   - 2.4.5
   - 2.5.3
   - 2.6.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,20 @@ build_script:
   - bundle exec rake test --trace --verbose
   - bundle exec rubocop
 
+before_test:
+  - gem install -N epubcheck-ruby
+
+test_script:
+  - ruby bin/review-init hello
+  - cd hello
+  - ruby ../bin/review-epubmaker config.yml
+  - epubcheck book.epub
+  - cd ..
+  - ruby bin/review-init hello2 --epub-version 2
+  - cd hello2
+  - ruby ../bin/review-epubmaker config.yml
+  - epubcheck book.epub
+
 branches:
   only:
     - master
@@ -16,3 +30,9 @@ environment:
   matrix:
     - ruby_version: "23"
     - ruby_version: "23-x64"
+    - ruby_version: "24"
+    - ruby_version: "24-x64"
+    - ruby_version: "25"
+    - ruby_version: "25-x64"
+    - ruby_version: "26"
+    - ruby_version: "26-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,8 +28,6 @@ branches:
 
 environment:
   matrix:
-    - ruby_version: "23"
-    - ruby_version: "23-x64"
     - ruby_version: "24"
     - ruby_version: "24-x64"
     - ruby_version: "25"

--- a/lib/epubmaker/epubv2.rb
+++ b/lib/epubmaker/epubv2.rb
@@ -39,7 +39,7 @@ module EPUBMaker
         if @producer.config[item].is_a?(Array)
           s << @producer.config.names_of(item).map { |i| %Q(    <dc:#{item}>#{CGI.escapeHTML(i)}</dc:#{item}>\n) }.join
         else
-          s << %Q(    <dc:#{item}>#{CGI.escapeHTML(@producer.config.name_of(item))}</dc:#{item}>\n)
+          s << %Q(    <dc:#{item}>#{CGI.escapeHTML(@producer.config.name_of(item).to_s)}</dc:#{item}>\n)
         end
       end
 


### PR DESCRIPTION
"review-init hello2 --epub-version 2"で作成した初期ディレクトリでepubmakerを走らせると、
以下のエラーで落ちたため、テストの追加(travis / appveryorでのreview-init + epubcheckによる形式チェック)と共に修正をPRさせていただきます。

エラービルド：
https://travis-ci.org/mitsuo0114/review/builds/535126919
```
$ ruby bin/review-init hello2 --epub-version 2 && cd hello2 && ruby ../bin/review-epubmaker config.yml && epubcheck book.epub
WARN: hello2.re:1: headline is empty.
Traceback (most recent call last):
	14: from ../bin/review-epubmaker:16:in `<main>'
	13: from /Users/travis/build/mitsuo0114/review/lib/review/epubmaker.rb:70:in `execute'
	12: from /Users/travis/build/mitsuo0114/review/lib/review/epubmaker.rb:105:in `execute'
	11: from /Users/travis/build/mitsuo0114/review/lib/review/epubmaker.rb:199:in `produce'
	10: from /Users/travis/build/mitsuo0114/review/lib/epubmaker/producer.rb:204:in `produce'
	 9: from /Users/travis/build/mitsuo0114/review/lib/epubmaker/epubv2.rb:127:in `produce'
	 8: from /Users/travis/build/mitsuo0114/review/lib/epubmaker/epubcommon.rb:402:in `produce_write_common'
	 7: from /Users/travis/build/mitsuo0114/review/lib/epubmaker/epubcommon.rb:402:in `open'
	 6: from /Users/travis/build/mitsuo0114/review/lib/epubmaker/epubcommon.rb:402:in `block in produce_write_common'
	 5: from /Users/travis/build/mitsuo0114/review/lib/epubmaker/producer.rb:107:in `opf'
	 4: from /Users/travis/build/mitsuo0114/review/lib/epubmaker/epubv2.rb:25:in `opf'
	 3: from /Users/travis/build/mitsuo0114/review/lib/epubmaker/epubv2.rb:37:in `opf_metainfo'
	 2: from /Users/travis/build/mitsuo0114/review/lib/epubmaker/epubv2.rb:37:in `each'
	 1: from /Users/travis/build/mitsuo0114/review/lib/epubmaker/epubv2.rb:42:in `block in opf_metainfo'
/Users/travis/build/mitsuo0114/review/lib/epubmaker/epubv2.rb:42:in `escapeHTML': no implicit conversion of Date into String (TypeError)
```
