### PR TITLE
remove ReVIEW::Preprocessor::Strip; not used now

### DIFF
--- a/lib/review/preprocessor.rb
+++ b/lib/review/preprocessor.rb
@@ -43,28 +43,6 @@ module ReVIEW
   class Preprocessor
     include ErrorUtils
 
-    class Strip
-      def initialize(f)
-        @f = f
-      end
-
-      def path
-        @f.path
-      end
-
-      def lineno
-        @f.lineno
-      end
-
-      def gets
-        @f.each_line do |line|
-          return "\#@\#\n" if /\A\#@/ =~ line
-          return line
-        end
-        nil
-      end
-    end
-
     def initialize(repo, param)
       @repository = repo
       @config = param

--- a/test/test_preprocessor.rb
+++ b/test/test_preprocessor.rb
@@ -2,22 +2,8 @@ require 'test_helper'
 require 'review/preprocessor'
 require 'stringio'
 
-class PreprocessorStripTest < Test::Unit::TestCase
+class PreprocessorTest < Test::Unit::TestCase
   include ReVIEW
 
-  def test_gets
-    f = StringIO.new '= Header'
-    s = Preprocessor::Strip.new(f)
-    expect = '= Header'
-    actual = s.gets
-    assert_equal expect, actual
-  end
-
-  def test_gets_with_comment
-    f = StringIO.new '#@warn(write it later)'
-    s = Preprocessor::Strip.new(f)
-    expect = '#@#' + "\n"
-    actual = s.gets
-    assert_equal expect, actual
-  end
+  ## TODO: add tests
 end


### PR DESCRIPTION
related: #1257, #1261

上記のissue/PRの対応によりStripクラスの出番はなくなったようなので、クラスごと削除します。