### PR TITLE
LATEXBuilder: support `@<bou>{...}`

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -997,7 +997,7 @@ module ReVIEW
     BOUTEN = '・'.freeze
 
     def inline_bou(str)
-      str.split(//).map { |c| macro('ruby', escape(c), macro('textgt', BOUTEN)) }.join('\allowbreak')
+      macro('reviewbou', escape(str))
     end
 
     def compile_ruby(base, ruby)

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -165,6 +165,7 @@
 \DeclareRobustCommand{\reviewtt}[1]{\texttt{#1}}
 \DeclareRobustCommand{\reviewtti}[1]{\texttt{\textit{#1}}}
 \DeclareRobustCommand{\reviewttb}[1]{\texttt{\textbf{#1}}}
+\DeclareRobustCommand{\reviewbou}[1]{\kenten{#1}}
 
 %% @<del> is ignored in LaTeX with default style
 %% \DeclareRobustCommand{\reviewstrike}[1]{#1}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -265,6 +265,7 @@
 \DeclareRobustCommand{\reviewtt}[1]{\texttt{#1}}
 \DeclareRobustCommand{\reviewtti}[1]{\texttt{\textit{#1}}}
 \DeclareRobustCommand{\reviewttb}[1]{\texttt{\textbf{#1}}}
+\DeclareRobustCommand{\reviewbou}[1]{\kenten{#1}}
 
 %% @<del> is ignored in LaTeX with default style
 \DeclareRobustCommand{\reviewstrike}[1]{#1}

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -169,6 +169,11 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     assert_equal 'abc\\reviewunderline{def}ghi', actual
   end
 
+  def test_inline_bou
+    actual = compile_inline('傍点の@<bou>{テスト}です。')
+    assert_equal '傍点の\\reviewbou{テスト}です。', actual
+  end
+
   def test_inline_m
     @config['review_version'] = '3.0'
     actual = compile_inline('abc@<m>{\\alpha^n = \\inf < 2}ghi')


### PR DESCRIPTION
fix #1220 

pxrubrica を使っているので、そのまま `\kenten` にしてみました。
生成するのは `\reviewbou{...}`にしています。