### PR TITLE
ulリストでレベルを1つより多く飛ばすのを禁止する

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -381,7 +381,7 @@ module ReVIEW
         elsif level < current_level # down
           level_diff = current_level - level
           if level_diff != 1
-            error "too many *."
+            error 'too many *.'
           end
           level = current_level
           (1..(level_diff - 1)).to_a.reverse_each do |i|

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -384,10 +384,6 @@ module ReVIEW
             error 'too many *.'
           end
           level = current_level
-          (1..(level_diff - 1)).to_a.reverse_each do |i|
-            @strategy.ul_begin { i }
-            @strategy.ul_item_begin []
-          end
           @strategy.ul_begin { level }
           @strategy.ul_item_begin buf
         elsif level > current_level # up

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -380,6 +380,9 @@ module ReVIEW
           @strategy.ul_item_begin buf
         elsif level < current_level # down
           level_diff = current_level - level
+          if level_diff != 1
+            error "too many *."
+          end
           level = current_level
           (1..(level_diff - 1)).to_a.reverse_each do |i|
             @strategy.ul_begin { i }

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1342,25 +1342,10 @@ EOS
     src = <<-EOS
   ** AAA
   * AA
-  * BBB
-  ** BB
 EOS
 
-    expected = <<-EOS
-<ul>
-<li><ul>
-<li>AAA</li>
-</ul>
-</li>
-<li>AA</li>
-<li>BBB<ul>
-<li>BB</li>
-</ul>
-</li>
-</ul>
-EOS
-    actual = compile_block(src)
-    assert_equal expected, actual
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
+    assert_equal ':1: error: too many *.', e.message
   end
 
   def test_ul_nest4
@@ -1377,37 +1362,6 @@ EOS
 <li>A<ul>
 <li>AA<ul>
 <li>AAA</li>
-</ul>
-</li>
-</ul>
-</li>
-<li>B<ul>
-<li>BB</li>
-</ul>
-</li>
-</ul>
-EOS
-    actual = compile_block(src)
-    assert_equal expected, actual
-  end
-
-  def test_ul_nest5
-    src = <<-EOS
-  * A
-  ** AA
-  **** AAAA
-  * B
-  ** BB
-EOS
-
-    expected = <<-EOS
-<ul>
-<li>A<ul>
-<li>AA<ul>
-<li><ul>
-<li>AAAA</li>
-</ul>
-</li>
 </ul>
 </li>
 </ul>

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -577,15 +577,10 @@ EOS
     src = <<-EOS
   ** AAA
   * AA
-  * BBB
-  ** BB
 EOS
 
-    expected = <<-EOS.chomp
-<ul><li aid:pstyle="ul-item"><ul2><li aid:pstyle="ul-item">AAA</li></ul2></li><li aid:pstyle="ul-item">AA</li><li aid:pstyle="ul-item">BBB<ul2><li aid:pstyle="ul-item">BB</li></ul2></li></ul>
-EOS
-    actual = compile_block(src)
-    assert_equal expected, actual
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
+    assert_equal ':1: error: too many *.', e.message
   end
 
   def test_ul_nest4


### PR DESCRIPTION
#1313 の修正

`**`から始めたり、`*`の後に`***`を始めたり といった書き方を禁止します。

現状テストはエラーになるので修正しますが、どっちにしろこういう使い方はしないはず…。
