### PR TITLE
抽象名\reviewincludegraphicsの導入

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -472,15 +472,15 @@ module ReVIEW
       # image is always bound here
       puts "\\begin{reviewimage}%%#{id}"
 
-      tag = 'reviewincludegraphics'
+      command = 'reviewincludegraphics'
       if @book.config.check_version('2', exception: false)
-        tag = 'includegraphics'
+        command = 'includegraphics'
       end
 
       if metrics.present?
-        puts "\\#{tag}[#{metrics}]{#{@chapter.image(id).path}}"
+        puts "\\#{command}[#{metrics}]{#{@chapter.image(id).path}}"
       else
-        puts "\\#{tag}[width=\\maxwidth]{#{@chapter.image(id).path}}"
+        puts "\\#{command}[width=\\maxwidth]{#{@chapter.image(id).path}}"
       end
       @doc_status[:caption] = true
 
@@ -558,15 +558,15 @@ module ReVIEW
       if @chapter.image(id).path
         puts "\\begin{reviewimage}%%#{id}"
 
-        tag = 'reviewincludegraphics'
+        command = 'reviewincludegraphics'
         if @book.config.check_version('2', exception: false)
-          tag = 'includegraphics'
+          command = 'includegraphics'
         end
 
         if metrics.present?
-          puts "\\#{tag}[#{metrics}]{#{@chapter.image(id).path}}"
+          puts "\\#{command}[#{metrics}]{#{@chapter.image(id).path}}"
         else
-          puts "\\#{tag}[width=\\maxwidth]{#{@chapter.image(id).path}}"
+          puts "\\#{command}[width=\\maxwidth]{#{@chapter.image(id).path}}"
         end
       else
         warn "image not bound: #{id}"
@@ -810,15 +810,15 @@ module ReVIEW
       # image is always bound here
       puts "\\begin{reviewimage}%%#{id}"
 
-      tag = 'reviewincludegraphics'
+      command = 'reviewincludegraphics'
       if @book.config.check_version('2', exception: false)
-        tag = 'includegraphics'
+        command = 'includegraphics'
       end
 
       if metrics.present?
-        puts "\\#{tag}[#{metrics}]{#{@chapter.image(id).path}}"
+        puts "\\#{command}[#{metrics}]{#{@chapter.image(id).path}}"
       else
-        puts "\\#{tag}[width=\\maxwidth]{#{@chapter.image(id).path}}"
+        puts "\\#{command}[width=\\maxwidth]{#{@chapter.image(id).path}}"
       end
       puts '\end{reviewimage}'
     end
@@ -1172,11 +1172,11 @@ module ReVIEW
 
     def inline_icon(id)
       if @chapter.image(id).path
-        tag = 'reviewincludegraphics'
+        command = 'reviewincludegraphics'
         if @book.config.check_version('2', exception: false)
-          tag = 'includegraphics'
+          command = 'includegraphics'
         end
-        macro(tag, @chapter.image(id).path)
+        macro(command, @chapter.image(id).path)
       else
         warn "image not bound: #{id}"
         "\\verb|--[[path = #{id} (#{existence(id)})]]--|"

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -471,10 +471,16 @@ module ReVIEW
       metrics = parse_metric('latex', metric)
       # image is always bound here
       puts "\\begin{reviewimage}%%#{id}"
+
+      tag = 'reviewincludegraphics'
+      if @book.config.check_version('2', exception: false)
+        tag = 'includegraphics'
+      end
+
       if metrics.present?
-        puts "\\includegraphics[#{metrics}]{#{@chapter.image(id).path}}"
+        puts "\\#{tag}[#{metrics}]{#{@chapter.image(id).path}}"
       else
-        puts "\\includegraphics[width=\\maxwidth]{#{@chapter.image(id).path}}"
+        puts "\\#{tag}[width=\\maxwidth]{#{@chapter.image(id).path}}"
       end
       @doc_status[:caption] = true
 
@@ -551,10 +557,16 @@ module ReVIEW
 
       if @chapter.image(id).path
         puts "\\begin{reviewimage}%%#{id}"
+
+        tag = 'reviewincludegraphics'
+        if @book.config.check_version('2', exception: false)
+          tag = 'includegraphics'
+        end
+
         if metrics.present?
-          puts "\\includegraphics[#{metrics}]{#{@chapter.image(id).path}}"
+          puts "\\#{tag}[#{metrics}]{#{@chapter.image(id).path}}"
         else
-          puts "\\includegraphics[width=\\maxwidth]{#{@chapter.image(id).path}}"
+          puts "\\#{tag}[width=\\maxwidth]{#{@chapter.image(id).path}}"
         end
       else
         warn "image not bound: #{id}"
@@ -797,10 +809,16 @@ module ReVIEW
       metrics = parse_metric('latex', metric)
       # image is always bound here
       puts "\\begin{reviewimage}%%#{id}"
+
+      tag = 'reviewincludegraphics'
+      if @book.config.check_version('2', exception: false)
+        tag = 'includegraphics'
+      end
+
       if metrics.present?
-        puts "\\includegraphics[#{metrics}]{#{@chapter.image(id).path}}"
+        puts "\\#{tag}[#{metrics}]{#{@chapter.image(id).path}}"
       else
-        puts "\\includegraphics[width=\\maxwidth]{#{@chapter.image(id).path}}"
+        puts "\\#{tag}[width=\\maxwidth]{#{@chapter.image(id).path}}"
       end
       puts '\end{reviewimage}'
     end
@@ -1154,7 +1172,11 @@ module ReVIEW
 
     def inline_icon(id)
       if @chapter.image(id).path
-        macro('includegraphics', @chapter.image(id).path)
+        tag = 'reviewincludegraphics'
+        if @book.config.check_version('2', exception: false)
+          tag = 'includegraphics'
+        end
+        macro(tag, @chapter.image(id).path)
       else
         warn "image not bound: #{id}"
         "\\verb|--[[path = #{id} (#{existence(id)})]]--|"

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -102,6 +102,10 @@
   \@ifundefined{reviewimagecaption}{% for 3.0.0 compatibility
     \newcommand{\reviewimagecaption}[1]{\caption{##1}}
   }
+  \@ifundefined{reviewincludegraphics}{% for 3.2.0 compatibility
+    \DeclareRobustCommand{\reviewincludegraphics}[2][]{%
+      \includegraphics[##1]{##2}}
+  }
 }
 
 \makeatother

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -47,6 +47,9 @@
 
 \newcommand{\reviewindepimagecaption[2]}{\@makecaption{}{#2}}
 
+\DeclareRobustCommand{\reviewincludegraphics}[2][]{%
+  \includegraphics[#1]{#2}}
+
 % 表
 \newenvironment{reviewtablesetup}{%
 }{}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -122,6 +122,9 @@
     \end{alltt}\end{center}
   \end{figure}}
 
+\DeclareRobustCommand{\reviewincludegraphics}[2][]{%
+  \includegraphics[#1]{#2}}
+
 \newcommand{\reviewequationcaption}[1]{%
   \medskip{\small\noindent #1}}
 \newenvironment{reviewequationblock}{\needspace{2\Cvs}}{}

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -48,6 +48,10 @@
   \@ifundefined{reviewimagecaption}{% for 3.0.0 compatibility
     \newcommand{\reviewimagecaption}[1]{\caption{##1}}
   }
+  \@ifundefined{reviewincludegraphics}{% for 3.2.0 compatibility
+    \DeclareRobustCommand{\reviewincludegraphics}[2][]{%
+      \includegraphics[##1]{##2}}
+  }
 }
 
 \makeatother

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -59,6 +59,10 @@ some ad content
   \@ifundefined{reviewimagecaption}{% for 3.0.0 compatibility
     \newcommand{\reviewimagecaption}[1]{\caption{##1}}
   }
+  \@ifundefined{reviewincludegraphics}{% for 3.2.0 compatibility
+    \DeclareRobustCommand{\reviewincludegraphics}[2][]{%
+      \includegraphics[##1]{##2}}
+  }
 }
 
 \makeatother

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -455,7 +455,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
   end
 
   def test_image_with_metric
@@ -466,7 +466,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
   end
 
   def test_image_with_metric_width
@@ -478,7 +478,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
     @config['image_scale2width'] = true
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
   end
 
   def test_image_with_metric2
@@ -489,7 +489,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
   end
 
   def test_image_with_metric2_width
@@ -501,7 +501,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
     @config['image_scale2width'] = true
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=1.2\\maxwidth,ignore=params]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=1.2\\maxwidth,ignore=params]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
   end
 
   def test_indepimage
@@ -512,7 +512,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//indepimage[sampleimg][sample photo]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
   end
 
   def test_indepimage_without_caption
@@ -524,7 +524,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
     # FIXME: indepimage's caption should not be with a counter.
     actual = compile_block("//indepimage[sampleimg]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\end{reviewimage}\n), actual
   end
 
   def test_indepimage_with_metric
@@ -535,7 +535,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
   end
 
   def test_indepimage_with_metric_width
@@ -547,7 +547,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
     @config['image_scale2width'] = true
     actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
   end
 
   def test_indepimage_with_metric2
@@ -558,7 +558,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block(%Q(//indepimage[sampleimg][sample photo][scale=1.2, html::class="sample",latex::ignore=params]\n))
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
   end
 
   def test_indepimage_without_caption_but_with_metric
@@ -570,7 +570,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
     # FIXME: indepimage's caption should not be with a counter.
     actual = compile_block("//indepimage[sampleimg][][scale=1.2]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\end{reviewimage}\n), actual
+    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\end{reviewimage}\n), actual
   end
 
   def test_table
@@ -635,7 +635,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 \\reviewimgtablecaption{test for imgtable}
 \\label{table:chap1:sampleimg}
 \\begin{reviewimage}%%sampleimg
-\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
 \\end{reviewimage}
 \\end{table}
 EOS
@@ -1138,7 +1138,7 @@ EOS
 \\reviewimageref{A.1}{image:chap1:sampleimg}
 
 \\begin{reviewimage}%%sampleimg
-\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
 \\reviewimagecaption{FOO}
 \\label{image:chap1:sampleimg}
 \\end{reviewimage}


### PR DESCRIPTION
#1318 の対応提案です。
review_versionが2のときには普通にincludegraphicsになります。3の場合はconfig.erbで後方互換性をとるようにしています。
