### PR TITLE
ul/ol/dl/bibpaperで改行を保持する

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -257,7 +257,7 @@ module ReVIEW
     end
 
     def ul_item(lines)
-      str = lines.join
+      str = lines.join("\n")
       str.sub!(/\A(\[)/) { '\lbrack{}' }
       puts '\item ' + str
     end
@@ -276,7 +276,7 @@ module ReVIEW
     end
 
     def ol_item(lines, _num)
-      str = lines.join
+      str = lines.join("\n")
       str.sub!(/\A(\[)/) { '\lbrack{}' }
       puts '\item ' + str
     end
@@ -298,7 +298,7 @@ module ReVIEW
     end
 
     def dd(lines)
-      puts lines.join
+      puts lines.join("\n")
     end
 
     def dl_end
@@ -1193,7 +1193,7 @@ module ReVIEW
     end
 
     def bibpaper_bibpaper(_id, _caption, lines)
-      print split_paragraph(lines).join
+      print split_paragraph(lines).join("\n")
       puts ''
     end
 

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -280,12 +280,12 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def test_dlist
     actual = compile_block(": foo\n  foo.\n  bar.\n")
-    assert_equal %Q(\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.bar.\n\\end{description}\n), actual
+    assert_equal %Q(\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\nbar.\n\\end{description}\n), actual
   end
 
   def test_dlist_with_bracket
     actual = compile_block(": foo[bar]\n    foo.\n    bar.\n")
-    assert_equal %Q(\n\\begin{description}\n\\item[foo\\lbrack{}bar\\rbrack{}] \\mbox{} \\\\\nfoo.bar.\n\\end{description}\n), actual
+    assert_equal %Q(\n\\begin{description}\n\\item[foo\\lbrack{}bar\\rbrack{}] \\mbox{} \\\\\nfoo.\nbar.\n\\end{description}\n), actual
   end
 
   def test_dlist_beforeulol
@@ -783,8 +783,10 @@ EOS
     expected = <<-EOS
 
 \\begin{itemize}
-\\item AAA{-}AA
-\\item BBB{-}BB
+\\item AAA
+{-}AA
+\\item BBB
+{-}BB
 \\end{itemize}
 EOS
     actual = compile_block(src)

--- a/test/test_latexbuilder_v2.rb
+++ b/test/test_latexbuilder_v2.rb
@@ -249,12 +249,12 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
 
   def test_dlist
     actual = compile_block(": foo\n  foo.\n  bar.\n")
-    assert_equal %Q(\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.bar.\n\\end{description}\n), actual
+    assert_equal %Q(\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\nbar.\n\\end{description}\n), actual
   end
 
   def test_dlist_with_bracket
     actual = compile_block(": foo[bar]\n    foo.\n    bar.\n")
-    assert_equal %Q(\n\\begin{description}\n\\item[foo\\lbrack{}bar\\rbrack{}] \\mbox{} \\\\\nfoo.bar.\n\\end{description}\n), actual
+    assert_equal %Q(\n\\begin{description}\n\\item[foo\\lbrack{}bar\\rbrack{}] \\mbox{} \\\\\nfoo.\nbar.\n\\end{description}\n), actual
   end
 
   def test_dlist_beforeulol
@@ -739,8 +739,10 @@ EOS
     expected = <<-EOS
 
 \\begin{itemize}
-\\item AAA{-}AA
-\\item BBB{-}BB
+\\item AAA
+{-}AA
+\\item BBB
+{-}BB
 \\end{itemize}
 EOS
     actual = compile_block(src)


### PR DESCRIPTION
#1312 の場当たり対処。
LaTeXのみとりあえず英単語・和文間の処理を（本文同様に）LaTeX側に任せるものです。
2行目以降の行頭行末の空文字はlinesに渡る段階で除去されているようなので、文字間でアキができることはなさそうです。

（本質的には行からの段落合成のロジックをちゃんと作りたいですが、実際実装を作ってみるとlinesに届くときにはすでに加工済みになっているため、末尾・行頭でエスケープ文字やインラインタグが入ったときに詰む感じです。）