### PR TITLE
caption_positionのサポート

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -384,6 +384,10 @@ Layout/SpaceInsideStringInterpolation:
 Layout/TrailingBlankLines:
   Enabled: true
 
+Layout/TrailingWhitespace:
+  Enabled: true
+  AllowInHeredoc: true
+
 #### Metrics
 
 Metrics/BlockNesting:

--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -176,6 +176,9 @@ secnolevel: 2
 # @<w>命令で使用する単語ファイルのパス
 # words_file: words.csv
 
+# 内容に対してキャプションを置く位置 (top=内容の上、bottom=内容の下)。TeXなどのスタイルはデフォルトの設定を前提にしており、変更した場合はスタイルを調整する必要があるかもしれないことに注意
+# caption_position: {image: bottom, table: top, list: top, equation: top}
+
 # review-vol向けのヒント情報
 # 1ページの行数文字数と1kbごとのページ数を用紙サイズで指定する(A5 or B5)
 # page_metric: A5

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -99,6 +99,10 @@ module ReVIEW
       end
     end
 
+    def cap_top?(type)
+      @book.config['caption_position'][type] != 'bottom'
+    end
+
     def headline_prefix(level)
       @sec_counter.inc(level)
       anchor = @sec_counter.anchor(level)
@@ -122,11 +126,11 @@ module ReVIEW
 
     def list(lines, id, caption, lang = nil)
       begin
-        if @book.config['caption_position']['list'] != 'bottom'
+        if cap_top?('list')
           list_header id, caption, lang
         end
         list_body id, lines, lang
-        if @book.config['caption_position']['list'] == 'bottom'
+        unless cap_top?('list')
           list_header id, caption, lang
         end
       rescue KeyError
@@ -136,11 +140,11 @@ module ReVIEW
 
     def listnum(lines, id, caption, lang = nil)
       begin
-        if @book.config['caption_position']['list'] != 'bottom'
+        if cap_top?('list')
           list_header id, caption, lang
         end
         listnum_body lines, lang
-        if @book.config['caption_position']['list'] == 'bottom'
+        unless cap_top?('list')
           list_header id, caption, lang
         end
       rescue KeyError
@@ -149,11 +153,11 @@ module ReVIEW
     end
 
     def source(lines, caption, lang = nil)
-      if @book.config['caption_position']['list'] != 'bottom'
+      if cap_top?('list')
         source_header caption
       end
       source_body lines, lang
-      if @book.config['caption_position']['list'] == 'bottom'
+      unless cap_top?('list')
         source_header caption
       end
     end
@@ -182,7 +186,7 @@ module ReVIEW
       rows = adjust_n_cols(rows)
 
       begin
-        if @book.config['caption_position']['table'] != 'bottom' && caption.present?
+        if cap_top?('table') && caption.present?
           table_header id, caption
         end
 
@@ -202,7 +206,7 @@ module ReVIEW
           end
         end
 
-        if @book.config['caption_position']['table'] == 'bottom' && caption.present?
+        if !cap_top?('table') && caption.present?
           table_header id, caption
         end
 

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2018 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
+# Copyright (c) 2012-2019 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -101,6 +101,12 @@ module ReVIEW
           'lineheight' => 10 * 1.2,
           'pdfcrop_pixelize_cmd' => 'pdftocairo -png -r 90 -f %p -l %p -singlefile %i %O',
           'dvipng_cmd' => 'dvipng -T tight -z 9 -p %p -l %p -o %o %i'
+        },
+        'caption_position' => {
+          'list' => 'top',
+          'image' => 'bottom',
+          'table' => 'top',
+          'equation' => 'top'
         }
       ]
       conf.maker = nil

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -424,7 +424,7 @@ module ReVIEW
       end
     end
 
-    def source_body(_id, lines, lang)
+    def source_body(lines, lang)
       print %Q(<pre class="source">)
       body = lines.inject('') { |i, j| i + detab(j) + "\n" }
       lexer = lang
@@ -435,11 +435,16 @@ module ReVIEW
     def listnum(lines, id, caption, lang = nil)
       puts %Q(<div id="#{normalize_id(id)}" class="code">)
       begin
-        list_header id, caption, lang
+        if cap_top?('list')
+          list_header id, caption, lang
+        end
+        listnum_body lines, lang
+        unless cap_top?('list')
+          list_header id, caption, lang
+        end
       rescue KeyError
         error "no such list: #{id}"
       end
-      listnum_body lines, lang
       puts '</div>'
     end
 

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -704,6 +704,7 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
+      return if rows.empty?
 
       if id
         puts %Q(<div id="#{normalize_id(id)}" class="table">)

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -288,7 +288,7 @@ module ReVIEW
 
     def box(lines, caption = nil)
       puts %Q(<div class="syntax">)
-      if @book.config['caption_position']['list'] != 'bottom' && caption.present?
+      if cap_top?('list') && caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
 
@@ -298,7 +298,7 @@ module ReVIEW
       end
       puts '</pre>'
 
-      if @book.config['caption_position']['list'] == 'bottom' && caption.present?
+      if !cap_top?('list') && caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
       puts '</div>'
@@ -380,11 +380,11 @@ module ReVIEW
     def list(lines, id, caption, lang = nil)
       puts %Q(<div id="#{normalize_id(id)}" class="caption-code">)
       begin
-        if @book.config['caption_position']['list'] != 'bottom'
+        if cap_top?('list')
           list_header id, caption, lang
         end
         list_body id, lines, lang
-        if @book.config['caption_position']['list'] == 'bottom'
+        unless cap_top?('list')
           list_header id, caption, lang
         end
       rescue KeyError
@@ -465,7 +465,7 @@ module ReVIEW
 
     def emlist(lines, caption = nil, lang = nil)
       puts %Q(<div class="emlist-code">)
-      if @book.config['caption_position']['list'] != 'bottom' && caption.present?
+      if cap_top?('list') && caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
 
@@ -478,7 +478,7 @@ module ReVIEW
       puts highlight(body: body, lexer: lexer, format: 'html')
       puts '</pre>'
 
-      if @book.config['caption_position']['list'] == 'bottom' && caption.present?
+      if !cap_top?('list') && caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
       puts '</div>'
@@ -486,7 +486,7 @@ module ReVIEW
 
     def emlistnum(lines, caption = nil, lang = nil)
       puts %Q(<div class="emlistnum-code">)
-      if @book.config['caption_position']['list'] != 'bottom' && caption.present?
+      if cap_top?('list') && caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
 
@@ -508,7 +508,7 @@ module ReVIEW
         puts '</pre>'
       end
 
-      if @book.config['caption_position']['list'] == 'bottom' && caption.present?
+      if !cap_top?('list') && caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
       puts '</div>'
@@ -516,7 +516,7 @@ module ReVIEW
 
     def cmd(lines, caption = nil)
       puts %Q(<div class="cmd-code">)
-      if @book.config['caption_position']['list'] != 'bottom' && caption.present?
+      if cap_top?('list') && caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
 
@@ -526,7 +526,7 @@ module ReVIEW
       puts highlight(body: body, lexer: lexer, format: 'html')
       puts '</pre>'
 
-      if @book.config['caption_position']['list'] == 'bottom' && caption.present?
+      if !cap_top?('list') && caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
       end
       puts '</div>'
@@ -571,7 +571,7 @@ module ReVIEW
         end
 
         texequation_header id, caption
-        if @book.config['caption_position']['equation'] != 'bottom'
+        if cap_top?('equation')
           puts caption_str
         end
       end
@@ -579,7 +579,7 @@ module ReVIEW
       texequation_body(lines)
 
       if id
-        if @book.config['caption_position']['equation'] == 'bottom'
+        unless cap_top?('equation')
           puts caption_str
         end
         puts '</div>'
@@ -645,13 +645,13 @@ module ReVIEW
     def image_image(id, caption, metric)
       metrics = parse_metric('html', metric)
       puts %Q(<div id="#{normalize_id(id)}" class="image">)
-      if @book.config['caption_position']['image'] != 'bottom'
+      if cap_top?('image')
         image_header id, caption
       end
 
       puts %Q(<img src="#{@chapter.image(id).path.sub(%r{\A\./}, '')}" alt="#{escape(compile_inline(caption))}"#{metrics} />)
 
-      if @book.config['caption_position']['image'] == 'bottom'
+      unless cap_top?('image')
         image_header id, caption
       end
       puts '</div>'
@@ -660,7 +660,7 @@ module ReVIEW
     def image_dummy(id, caption, lines)
       warn "image not bound: #{id}"
       puts %Q(<div id="#{normalize_id(id)}" class="image">)
-      if @book.config['caption_position']['image'] != 'bottom'
+      if cap_top?('image')
         image_header id, caption
       end
 
@@ -670,7 +670,7 @@ module ReVIEW
       end
       puts '</pre>'
 
-      if @book.config['caption_position']['image'] == 'bottom'
+      unless cap_top?('image')
         image_header id, caption
       end
       puts '</div>'
@@ -706,7 +706,7 @@ module ReVIEW
         puts %Q(<div class="table">)
       end
       begin
-        if @book.config['caption_position']['table'] != 'bottom' && caption.present?
+        if cap_top?('table') && caption.present?
           table_header id, caption
         end
         table_begin rows.first.size
@@ -725,7 +725,7 @@ module ReVIEW
         end
         table_end
 
-        if @book.config['caption_position']['table'] == 'bottom' && caption.present?
+        if !cap_top?('table') && caption.present?
           table_header id, caption
         end
       rescue KeyError
@@ -773,13 +773,13 @@ module ReVIEW
 
       puts %Q(<div id="#{normalize_id(id)}" class="imgtable image">)
       begin
-        if @book.config['caption_position']['table'] != 'bottom' && caption.present?
+        if cap_top?('table') && caption.present?
           table_header id, caption
         end
 
         imgtable_image(id, caption, metric)
 
-        if @book.config['caption_position']['table'] == 'bottom' && caption.present?
+        if !cap_top?('table') && caption.present?
           table_header id, caption
         end
       rescue KeyError
@@ -822,7 +822,7 @@ module ReVIEW
       metrics = parse_metric('html', metric)
       caption = '' unless caption.present?
       puts %Q(<div id="#{normalize_id(id)}" class="image">)
-      if @book.config['caption_position']['image'] != 'bottom' && caption.present?
+      if cap_top?('image') && caption.present?
         puts %Q(<p class="caption">)
         puts %Q(#{I18n.t('numberless_image')}#{I18n.t('caption_prefix')}#{compile_inline(caption)})
         puts '</p>'
@@ -841,7 +841,7 @@ module ReVIEW
         end
       end
 
-      if @book.config['caption_position']['image'] == 'bottom' && caption.present?
+      if !cap_top?('image') && caption.present?
         puts %Q(<p class="caption">)
         puts %Q(#{I18n.t('numberless_image')}#{I18n.t('caption_prefix')}#{compile_inline(caption)})
         puts '</p>'

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -338,7 +338,7 @@ module ReVIEW
 
     def quotedlist(lines, css_class, caption)
       print %Q(<list type='#{css_class}'>)
-      if @book.config['caption_position']['list'] != 'bottom' && caption.present?
+      if cap_top?('list') && caption.present?
         puts "<caption aid:pstyle='#{css_class}-title'>#{compile_inline(caption)}</caption>"
       end
       print '<pre>'
@@ -356,7 +356,7 @@ module ReVIEW
         no += 1
       end
       print '</pre>'
-      if @book.config['caption_position']['list'] == 'bottom' && caption.present?
+      if !cap_top?('list') && caption.present?
         puts "<caption aid:pstyle='#{css_class}-title'>#{compile_inline(caption)}</caption>"
       end
       puts '</list>'
@@ -403,11 +403,11 @@ module ReVIEW
     def image_image(id, caption, metric = nil)
       metrics = parse_metric('idgxml', metric)
       puts '<img>'
-      if @book.config['caption_position']['image'] != 'bottom'
+      if cap_top?('image')
         image_header id, caption
       end
       puts %Q(<Image href="file://#{@chapter.image(id).path.sub(%r{\A./}, '')}"#{metrics} />)
-      if @book.config['caption_position']['image'] == 'bottom'
+      unless cap_top?('image')
         image_header id, caption
       end
       puts '</img>'
@@ -415,7 +415,7 @@ module ReVIEW
 
     def image_dummy(id, caption, lines)
       puts '<img>'
-      if @book.config['caption_position']['image'] != 'bottom'
+      if cap_top?('image')
         image_header id, caption
       end
       print %Q(<pre aid:pstyle="dummyimage">)
@@ -424,7 +424,7 @@ module ReVIEW
         print "\n"
       end
       print '</pre>'
-      if @book.config['caption_position']['image'] == 'bottom'
+      unless cap_top?('image')
         image_header id, caption
       end
       puts '</img>'
@@ -451,7 +451,7 @@ module ReVIEW
           caption_str = %Q(<caption>#{I18n.t('equation')}#{I18n.t('format_number', [get_chap, @chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}</caption>)
         end
 
-        if @book.config['caption_position']['equation'] != 'bottom'
+        if cap_top?('equation')
           puts caption_str
         end
       end
@@ -463,7 +463,7 @@ module ReVIEW
       puts '</replace>'
 
       if id
-        if @book.config['caption_position']['equation'] == 'bottom'
+        unless cap_top?('equation')
           puts caption_str
         end
         puts '</equationblock>'
@@ -512,7 +512,7 @@ module ReVIEW
       end
 
       begin
-        if @book.config['caption_position']['table'] != 'bottom' && caption.present?
+        if cap_top?('table') && caption.present?
           table_header id, caption
         end
         return if rows.empty?
@@ -538,7 +538,7 @@ module ReVIEW
         end
         trputs(tablewidth, rows, cellwidth, sepidx)
         print '</tbody>'
-        if @book.config['caption_position']['table'] == 'bottom' && caption.present?
+        if !cap_top?('table') && caption.present?
           table_header id, caption
         end
         puts '</table>'
@@ -603,11 +603,11 @@ module ReVIEW
       if @chapter.image(id).bound?
         metrics = parse_metric('idgxml', metric)
         puts '<table>'
-        if @book.config['caption_position']['table'] != 'bottom' && caption.present?
+        if cap_top?('table') && caption.present?
           table_header id, caption
         end
         puts %Q(<imgtable><Image href="file://#{@chapter.image(id).path.sub(%r{\A./}, '')}"#{metrics} /></imgtable>)
-        if @book.config['caption_position']['table'] == 'bottom' && caption.present?
+        if !cap_top?('table') && caption.present?
           table_header id, caption
         end
         puts '</table>'
@@ -1018,7 +1018,7 @@ module ReVIEW
         end
       end
 
-      if @book.config['caption_position']['list'] != 'bottom' && caption.present?
+      if cap_top?('list') && caption.present?
         puts %Q(<#{type}><#{titleopentag}>#{compile_inline(caption)}</#{titleclosetag}>)
       else
         puts "<#{type}>"
@@ -1038,7 +1038,7 @@ module ReVIEW
         no += 1
       end
 
-      if @book.config['caption_position']['list'] == 'bottom' && caption.present?
+      if !cap_top?('list') && caption.present?
         puts %Q(<#{type}><#{titleopentag}>#{compile_inline(caption)}</#{titleclosetag}>)
       end
       puts "</#{type}>"
@@ -1055,7 +1055,7 @@ module ReVIEW
     def indepimage(_lines, id, caption = nil, metric = nil)
       metrics = parse_metric('idgxml', metric)
       puts '<img>'
-      if @book.config['caption_position']['image'] != 'bottom' && caption.present?
+      if cap_top?('image') && caption.present?
         puts %Q(<caption>#{compile_inline(caption)}</caption>)
       end
 
@@ -1065,7 +1065,7 @@ module ReVIEW
         warn %Q(image not bound: #{id})
       end
 
-      if @book.config['caption_position']['image'] == 'bottom' && caption.present?
+      if !cap_top?('image') && caption.present?
         puts %Q(<caption>#{compile_inline(caption)}</caption>)
       end
       puts '</img>'

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -268,9 +268,13 @@ module ReVIEW
       "<span type='list'>#{super(id)}</span>"
     end
 
-    def list_header(id, caption, _lang)
+    def list(lines, id, caption, lang = nil)
       puts '<codelist>'
-      return true unless caption.present?
+      super(lines, id, caption, lang)
+      puts '</codelist>'
+    end
+
+    def list_header(id, caption, _lang)
       if get_chap.nil?
         puts %Q(<caption>#{I18n.t('list')}#{I18n.t('format_number_without_chapter', [@chapter.list(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}</caption>)
       else
@@ -297,7 +301,13 @@ module ReVIEW
     def list_body(_id, lines, _lang)
       print '<pre>'
       codelines_body(lines)
-      puts '</pre></codelist>'
+      puts '</pre>'
+    end
+
+    def listnum(lines, id, caption, lang = nil)
+      puts '<codelist>'
+      super(lines, id, caption, lang)
+      puts '</codelist>'
     end
 
     def emlist(lines, caption = nil, _lang = nil)
@@ -329,7 +339,7 @@ module ReVIEW
         print '</listinfo>' if @book.config['listinfo']
         no += 1
       end
-      puts '</pre></codelist>'
+      puts '</pre>'
     end
 
     def cmd(lines, caption = nil)
@@ -1039,7 +1049,7 @@ module ReVIEW
       end
 
       if !cap_top?('list') && caption.present?
-        puts %Q(<#{type}><#{titleopentag}>#{compile_inline(caption)}</#{titleclosetag}>)
+        puts %Q(<#{titleopentag}>#{compile_inline(caption)}</#{titleclosetag}>)
       end
       puts "</#{type}>"
     end
@@ -1166,15 +1176,26 @@ module ReVIEW
       error "unknown chapter: #{id}"
     end
 
-    def source_header(caption)
+    def source(lines, caption, lang = nil)
       puts '<source>'
+      if cap_top?('list')
+        source_header caption
+      end
+      source_body lines, lang
+      unless cap_top?('list')
+        source_header caption
+      end
+      puts '</source>'
+    end
+
+    def source_header(caption)
       puts %Q(<caption>#{compile_inline(caption)}</caption>) if caption.present?
     end
 
     def source_body(lines, _lang)
       puts '<pre>'
       codelines_body(lines)
-      puts '</pre></source>'
+      puts '</pre>'
     end
 
     def bibpaper(lines, id, caption)

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -484,7 +484,6 @@ module ReVIEW
       tablewidth = @book.config['tableopt'] ? @book.config['tableopt'].split(',')[0].to_f / @book.config['pt_to_mm_unit'].to_f : nil
       col = 0
 
-      puts '<table>'
       rows = []
       sepidx = nil
       lines.each_with_index do |line, idx|
@@ -500,6 +499,9 @@ module ReVIEW
         col2 = rows[rows.length - 1].split(/\t/).length
         col = col2 if col2 > col
       end
+      return if rows.empty?
+
+      puts '<table>'
 
       cellwidth = []
       if tablewidth
@@ -525,7 +527,6 @@ module ReVIEW
         if cap_top?('table') && caption.present?
           table_header id, caption
         end
-        return if rows.empty?
 
         if tablewidth.nil?
           print '<tbody>'

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -400,7 +400,7 @@ module ReVIEW
         @doc_status[:caption] = nil
       end
 
-      if @book.config['caption_position']['list'] != 'bottom' && caption_str
+      if cap_top?('list') && caption_str
         puts caption_str
       end
 
@@ -412,7 +412,7 @@ module ReVIEW
       print body
       puts macro('end', command)
 
-      if @book.config['caption_position']['list'] == 'bottom' && caption_str
+      if !cap_top?('list') && caption_str
         puts caption_str
       end
 
@@ -494,7 +494,7 @@ module ReVIEW
     end
 
     def image_image(id, caption, metric)
-      if @book.config['caption_position']['image'] != 'bottom'
+      if cap_top?('image')
         output_caption(caption, 'reviewimagecaption')
         puts macro('label', image_label(id))
       end
@@ -508,7 +508,7 @@ module ReVIEW
         puts "\\includegraphics[width=\\maxwidth]{#{@chapter.image(id).path}}"
       end
 
-      if @book.config['caption_position']['image'] == 'bottom'
+      unless cap_top?('image')
         output_caption(caption, 'reviewimagecaption')
         puts macro('label', image_label(id))
       end
@@ -517,7 +517,7 @@ module ReVIEW
 
     def image_dummy(id, caption, lines)
       warn "image not bound: #{id}"
-      if @book.config['caption_position']['image'] != 'bottom'
+      if cap_top?('image')
         output_caption(caption, 'reviewimagecaption')
         puts macro('label', image_label(id))
       end
@@ -529,7 +529,7 @@ module ReVIEW
         puts detab(line.rstrip)
       end
 
-      if @book.config['caption_position']['image'] == 'bottom'
+      unless cap_top?('image')
         output_caption(caption, 'reviewimagecaption')
         puts macro('label', image_label(id))
       end
@@ -589,7 +589,7 @@ module ReVIEW
       if @chapter.image(id).path
         puts "\\begin{reviewimage}%%#{id}"
 
-        if @book.config['caption_position']['image'] != 'bottom' && caption_str
+        if cap_top?('image') && caption_str
           puts caption_str
         end
 
@@ -602,7 +602,7 @@ module ReVIEW
         warn "image not bound: #{id}"
         puts '\begin{reviewdummyimage}'
 
-        if @book.config['caption_position']['image'] != 'bottom' && caption_str
+        if cap_top?('image') && caption_str
           puts caption_str
         end
 
@@ -612,7 +612,7 @@ module ReVIEW
         end
       end
 
-      if @book.config['caption_position']['image'] == 'bottom' && caption_str
+      if !cap_top?('image') && caption_str
         puts caption_str
       end
 
@@ -685,7 +685,7 @@ module ReVIEW
         else
           puts "\\begin{table}%%#{id}"
         end
-        if @book.config['caption_position']['table'] != 'bottom'
+        if cap_top?('table')
           output_caption(caption, 'reviewtablecaption')
         end
       end
@@ -791,7 +791,7 @@ module ReVIEW
       puts macro('end', 'reviewtable')
 
       if @table_caption
-        if @book.config['caption_position']['table'] == 'bottom'
+        unless cap_top?('table')
           output_caption(@table_caption, 'reviewtablecaption')
         end
 
@@ -821,7 +821,7 @@ module ReVIEW
           @table_caption = caption
           puts "\\begin{table}[h]%%#{id}"
 
-          if @book.config['caption_position']['table'] != 'bottom'
+          if cap_top?('table')
             output_caption(caption, 'reviewimgtablecaption')
           end
         end
@@ -832,7 +832,7 @@ module ReVIEW
       imgtable_image(id, caption, metric)
 
       if @table_caption
-        if @book.config['caption_position']['table'] == 'bottom'
+        unless cap_top?('table')
           output_caption(caption, 'reviewimgtablecaption')
         end
 
@@ -881,7 +881,7 @@ module ReVIEW
         end
       end
 
-      if @book.config['caption_position']['equation'] != 'bottom' && caption_str
+      if cap_top?('equation') && caption_str
         puts caption_str
       end
 
@@ -892,7 +892,7 @@ module ReVIEW
       puts macro('end', 'equation*')
 
       if id
-        if @book.config['caption_position']['equation'] == 'bottom' && caption_str
+        if !cap_top?('equation') && caption_str
           puts caption_str
         end
         puts macro('end', 'reviewequationblock')

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -494,14 +494,14 @@ module ReVIEW
     end
 
     def image_image(id, caption, metric)
+      metrics = parse_metric('latex', metric)
+      # image is always bound here
+      puts "\\begin{reviewimage}%%#{id}"
       if cap_top?('image')
         output_caption(caption, 'reviewimagecaption')
         puts macro('label', image_label(id))
       end
 
-      metrics = parse_metric('latex', metric)
-      # image is always bound here
-      puts "\\begin{reviewimage}%%#{id}"
       if metrics.present?
         puts "\\includegraphics[#{metrics}]{#{@chapter.image(id).path}}"
       else
@@ -671,7 +671,7 @@ module ReVIEW
           end
         end
 
-        table_end
+        table_end(id)
       rescue KeyError
         error "no such table: #{id}"
       end
@@ -687,10 +687,10 @@ module ReVIEW
         end
         if cap_top?('table')
           output_caption(caption, 'reviewtablecaption')
+          if id
+            puts macro('label', table_label(id))
+          end
         end
-      end
-      if id
-        puts macro('label', table_label(id))
       end
     end
 
@@ -787,12 +787,15 @@ module ReVIEW
       puts ' \\\\  \hline'
     end
 
-    def table_end
+    def table_end(id = nil)
       puts macro('end', 'reviewtable')
 
       if @table_caption
         unless cap_top?('table')
           output_caption(@table_caption, 'reviewtablecaption')
+          if id
+            puts macro('label', table_label(id))
+          end
         end
 
         puts '\end{table}'
@@ -823,9 +826,9 @@ module ReVIEW
 
           if cap_top?('table')
             output_caption(caption, 'reviewimgtablecaption')
+            puts macro('label', table_label(id))
           end
         end
-        puts macro('label', table_label(id))
       rescue ReVIEW::KeyError
         error "no such table: #{id}"
       end
@@ -834,6 +837,7 @@ module ReVIEW
       if @table_caption
         unless cap_top?('table')
           output_caption(caption, 'reviewimgtablecaption')
+          puts macro('label', table_label(id))
         end
 
         puts '\end{table}'

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -246,7 +246,6 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      blank
       rows = []
       sepidx = nil
       lines.each_with_index do |line, idx|
@@ -259,13 +258,15 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
+      return if rows.empty?
+
+      blank
 
       begin
         if cap_top?('table') && caption.present?
           table_header(id, caption)
           blank
         end
-        return if rows.empty?
         table_begin rows.first.size
         if sepidx
           sepidx.times do

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -160,13 +160,13 @@ module ReVIEW
 
     def base_block(_type, lines, caption = nil)
       blank
-      if @book.config['caption_position']['list'] != 'bottom' && caption.present?
+      if cap_top?('list') && caption.present?
         puts compile_inline(caption)
       end
 
       puts lines.join("\n")
 
-      if @book.config['caption_position']['list'] == 'bottom' && caption.present?
+      if !cap_top?('list') && caption.present?
         puts compile_inline(caption)
       end
       blank
@@ -185,13 +185,13 @@ module ReVIEW
 
     def emlistnum(lines, caption = nil, _lang = nil)
       blank
-      if @book.config['caption_position']['list'] != 'bottom' && caption.present?
+      if cap_top?('list') && caption.present?
         puts compile_inline(caption)
       end
       lines.each_with_index do |line, i|
         puts((i + 1).to_s.rjust(2) + ": #{line}")
       end
-      if @book.config['caption_position']['list'] == 'bottom' && caption.present?
+      if !cap_top?('list') && caption.present?
         puts compile_inline(caption)
       end
       blank
@@ -231,13 +231,13 @@ module ReVIEW
         else
           caption_str = "#{I18n.t('equation')}#{I18n.t('format_number_without_chapter', [@chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
         end
-        if @book.config['caption_position']['equation'] != 'bottom'
+        if cap_top?('equation')
           puts caption_str
         end
       end
 
       puts lines.join("\n")
-      if @book.config['caption_position']['equation'] == 'bottom' && id
+      if !cap_top?('equation') && caption_str
         puts caption_str
       end
       blank
@@ -259,7 +259,7 @@ module ReVIEW
       rows = adjust_n_cols(rows)
 
       begin
-        if @book.config['caption_position']['table'] != 'bottom' && caption.present?
+        if cap_top?('table') && caption.present?
           table_header(id, caption)
           blank
         end
@@ -279,7 +279,7 @@ module ReVIEW
           end
         end
 
-        if @book.config['caption_position']['table'] == 'bottom' && caption.present?
+        if !cap_top?('table') && caption.present?
           blank
           table_header(id, caption)
         end

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -167,6 +167,7 @@ module ReVIEW
       puts lines.join("\n")
 
       if !cap_top?('list') && caption.present?
+        blank
         puts compile_inline(caption)
       end
       blank
@@ -192,6 +193,7 @@ module ReVIEW
         puts((i + 1).to_s.rjust(2) + ": #{line}")
       end
       if !cap_top?('list') && caption.present?
+        blank
         puts compile_inline(caption)
       end
       blank

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -152,8 +152,8 @@ module ReVIEW
     end
 
     def listnum(lines, id, caption, lang = nil)
+      blank
       puts "◆→開始:#{@titles['list']}←◆"
-
       begin
         if cap_top?('list')
           list_header id, caption, lang
@@ -167,6 +167,8 @@ module ReVIEW
       rescue KeyError
         error "no such list: #{id}"
       end
+      puts "◆→終了:#{@titles['list']}←◆"
+      blank
     end
 
     def emlistnum(lines, caption = nil, _lang = nil)
@@ -179,6 +181,7 @@ module ReVIEW
         puts((i + 1).to_s.rjust(2) + ": #{line}")
       end
       if !cap_top?('list') && caption.present?
+        blank
         puts "■#{compile_inline(caption)}"
       end
       puts "◆→終了:#{@titles['emlist']}←◆"
@@ -189,8 +192,6 @@ module ReVIEW
       lines.each_with_index do |line, i|
         puts((i + 1).to_s.rjust(2) + ": #{line}")
       end
-      puts "◆→終了:#{@titles['list']}←◆"
-      blank
     end
 
     def image(lines, id, caption, metric = nil)
@@ -241,10 +242,10 @@ module ReVIEW
       end
       puts lines.join("\n")
 
+      puts "◆→終了:#{@titles['texequation']}←◆"
       if !cap_top?('equation') && caption_str
         puts caption_str
       end
-      puts "◆→終了:#{@titles['texequation']}←◆"
       blank
     end
 

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -95,12 +95,12 @@ module ReVIEW
       blank
       puts "◆→開始:#{@titles['list']}←◆"
       begin
-        if @book.config['caption_position']['list'] != 'bottom'
+        if cap_top?('list')
           list_header id, caption, lang
           blank
         end
         list_body id, lines, lang
-        if @book.config['caption_position']['list'] == 'bottom'
+        unless cap_top?('list')
           blank
           list_header id, caption, lang
         end
@@ -129,13 +129,13 @@ module ReVIEW
       blank
       puts "◆→開始:#{@titles[type]}←◆"
       blank
-      if @book.config['caption_position']['list'] != 'bottom' && caption.present?
+      if cap_top?('list') && caption.present?
         puts "■#{compile_inline(caption)}"
       end
 
       puts lines.join("\n")
 
-      if @book.config['caption_position']['list'] == 'bottom' && caption.present?
+      if !cap_top?('list') && caption.present?
         puts "■#{compile_inline(caption)}"
       end
       puts "◆→終了:#{@titles[type]}←◆"
@@ -155,12 +155,12 @@ module ReVIEW
       puts "◆→開始:#{@titles['list']}←◆"
 
       begin
-        if @book.config['caption_position']['list'] != 'bottom'
+        if cap_top?('list')
           list_header id, caption, lang
           blank
         end
         listnum_body lines, lang
-        if @book.config['caption_position']['list'] == 'bottom'
+        unless cap_top?('list')
           blank
           list_header id, caption, lang
         end
@@ -172,13 +172,13 @@ module ReVIEW
     def emlistnum(lines, caption = nil, _lang = nil)
       blank
       puts "◆→開始:#{@titles['emlist']}←◆"
-      if @book.config['caption_position']['list'] != 'bottom' && caption.present?
+      if cap_top?('list') && caption.present?
         puts "■#{compile_inline(caption)}"
       end
       lines.each_with_index do |line, i|
         puts((i + 1).to_s.rjust(2) + ": #{line}")
       end
-      if @book.config['caption_position']['list'] == 'bottom' && caption.present?
+      if !cap_top?('list') && caption.present?
         puts "■#{compile_inline(caption)}"
       end
       puts "◆→終了:#{@titles['emlist']}←◆"
@@ -205,7 +205,7 @@ module ReVIEW
         caption_str = "#{I18n.t('image')}#{I18n.t('format_number_without_chapter', [@chapter.image(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
       end
 
-      if @book.config['caption_position']['image'] != 'bottom'
+      if cap_top?('image')
         puts caption_str
         blank
       end
@@ -217,7 +217,7 @@ module ReVIEW
           puts line
         end
       end
-      if @book.config['caption_position']['image'] == 'bottom'
+      unless cap_top?('image')
         blank
         puts caption_str
       end
@@ -235,13 +235,13 @@ module ReVIEW
         else
           caption_str = "#{I18n.t('equation')}#{I18n.t('format_number_without_chapter', [@chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
         end
-        if @book.config['caption_position']['equation'] != 'bottom'
+        if cap_top?('equation')
           puts caption_str
         end
       end
       puts lines.join("\n")
 
-      if @book.config['caption_position']['equation'] == 'bottom' && caption_str
+      if !cap_top?('equation') && caption_str
         puts caption_str
       end
       puts "◆→終了:#{@titles['texequation']}←◆"
@@ -266,7 +266,7 @@ module ReVIEW
       rows = adjust_n_cols(rows)
 
       begin
-        if @book.config['caption_position']['table'] != 'bottom' && caption.present?
+        if cap_top?('table') && caption.present?
           table_header id, caption
           blank
         end
@@ -285,7 +285,7 @@ module ReVIEW
             tr([th(h)] + cs.map { |s| td(s) })
           end
         end
-        if @book.config['caption_position']['table'] == 'bottom' && caption.present?
+        if !cap_top?('table') && caption.present?
           blank
           table_header id, caption
         end

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -128,7 +128,6 @@ module ReVIEW
     def base_block(type, lines, caption = nil)
       blank
       puts "◆→開始:#{@titles[type]}←◆"
-      blank
       if cap_top?('list') && caption.present?
         puts "■#{compile_inline(caption)}"
       end
@@ -136,6 +135,7 @@ module ReVIEW
       puts lines.join("\n")
 
       if !cap_top?('list') && caption.present?
+        blank
         puts "■#{compile_inline(caption)}"
       end
       puts "◆→終了:#{@titles[type]}←◆"

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -250,9 +250,6 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      blank
-      puts "◆→開始:#{@titles['table']}←◆"
-
       rows = []
       sepidx = nil
       lines.each_with_index do |line, idx|
@@ -265,13 +262,16 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
+      return if rows.empty?
+
+      blank
+      puts "◆→開始:#{@titles['table']}←◆"
 
       begin
         if cap_top?('table') && caption.present?
           table_header id, caption
           blank
         end
-        return if rows.empty?
         table_begin rows.first.size
         if sepidx
           sepidx.times do

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -467,6 +467,10 @@ EOS
 
     actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
     assert_equal %Q(<div id="sampleimg" class="image">\n<img src="images/chap1-sampleimg.png" alt="sample photo" />\n<p class="caption">\n図1.1: sample photo\n</p>\n</div>\n), actual
+
+    @config['caption_position']['image'] = 'top'
+    actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
+    assert_equal %Q(<div id="sampleimg" class="image">\n<p class="caption">\n図1.1: sample photo\n</p>\n<img src="images/chap1-sampleimg.png" alt="sample photo" />\n</div>\n), actual
   end
 
   def test_image_with_metric
@@ -511,6 +515,10 @@ EOS
 
     actual = compile_block("//indepimage[sampleimg][sample photo]\n")
     assert_equal %Q(<div id="sampleimg" class="image">\n<img src="images/chap1-sampleimg.png" alt="sample photo" />\n<p class="caption">\n図: sample photo\n</p>\n</div>\n), actual
+
+    @config['caption_position']['image'] = 'top'
+    actual = compile_block("//indepimage[sampleimg][sample photo]\n")
+    assert_equal %Q(<div id="sampleimg" class="image">\n<p class="caption">\n図: sample photo\n</p>\n<img src="images/chap1-sampleimg.png" alt="sample photo" />\n</div>\n), actual
   end
 
   def test_indepimage_without_caption
@@ -584,6 +592,10 @@ EOS
     end
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
     assert_equal %Q(<div id="samplelist" class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list">test1\ntest1.5\n\ntest<i>2</i>\n</pre>\n</div>\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
+    assert_equal %Q(<div id="samplelist" class="caption-code">\n<pre class="list">test1\ntest1.5\n\ntest<i>2</i>\n</pre>\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n</div>\n), actual
   end
 
   def test_inline_list
@@ -707,6 +719,11 @@ end
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
 
     assert_equal %Q(<div id="samplelist" class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list highlight">test1\ntest1.5\n\ntest&lt;i&gt;2&lt;/i&gt;\n</pre>\n</div>\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
+
+    assert_equal %Q(<div id="samplelist" class="caption-code">\n<pre class="list highlight">test1\ntest1.5\n\ntest&lt;i&gt;2&lt;/i&gt;\n</pre>\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n</div>\n), actual
   end
 
   def test_list_rouge_lang
@@ -807,6 +824,30 @@ EOS
 102:   return true
 103: end
 </pre>
+</div>
+EOS
+
+    assert_equal expected, actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block(<<-EOS)
+//firstlinenum[100]
+//listnum[samplelist][this is @<b>{test}<&>_][ruby]{
+def foo(a1, a2=:test)
+  (1..3).times{|i| a.include?(:foo)}
+  return true
+end
+//}
+EOS
+
+    expected = <<-EOS
+<div id="samplelist" class="code">
+<pre class="list language-ruby">100: def foo(a1, a2=:test)
+101:   (1..3).times{|i| a.include?(:foo)}
+102:   return true
+103: end
+</pre>
+<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>
 </div>
 EOS
 
@@ -991,6 +1032,10 @@ EOB
   def test_emlist_caption
     actual = compile_block("//emlist[cap1]{\nlineA\nlineB\n//}\n")
     assert_equal %Q(<div class="emlist-code">\n<p class="caption">cap1</p>\n<pre class="emlist">lineA\nlineB\n</pre>\n</div>\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//emlist[cap1]{\nlineA\nlineB\n//}\n")
+    assert_equal %Q(<div class="emlist-code">\n<pre class="emlist">lineA\nlineB\n</pre>\n<p class="caption">cap1</p>\n</div>\n), actual
   end
 
   def test_emlist_with_tab
@@ -1037,6 +1082,18 @@ EOS
 </div>
 EOS
     assert_equal expected, actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//firstlinenum[1000]\n//emlistnum[cap][text]{\nlineA\nlineB\n//}\n")
+    expected = <<-EOS
+<div class="emlistnum-code">
+<pre class="emlist language-text">1000: lineA
+1001: lineB
+</pre>
+<p class="caption">cap</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_with_4tab
@@ -1065,6 +1122,52 @@ EOS
   def test_cmd_caption
     actual = compile_block("//cmd[cap1]{\nlineA\nlineB\n//}\n")
     assert_equal %Q(<div class="cmd-code">\n<p class="caption">cap1</p>\n<pre class="cmd">lineA\nlineB\n</pre>\n</div>\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//cmd[cap1]{\nlineA\nlineB\n//}\n")
+    assert_equal %Q(<div class="cmd-code">\n<pre class="cmd">lineA\nlineB\n</pre>\n<p class="caption">cap1</p>\n</div>\n), actual
+  end
+
+  def test_other_lists
+    src = <<-EOS
+//box[BOX]{
+foo
+//}
+
+//source[SOURCE]{
+foo
+//}
+EOS
+    actual = compile_block(src)
+    expected = <<-EOS
+<div class="syntax">
+<p class="caption">BOX</p>
+<pre class="syntax">foo
+</pre>
+</div>
+<div class="source-code">
+<p class="caption">SOURCE</p>
+<pre class="source">foo
+</pre>
+</div>
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block(src)
+    expected = <<-EOS
+<div class="syntax">
+<pre class="syntax">foo
+</pre>
+<p class="caption">BOX</p>
+</div>
+<div class="source-code">
+<pre class="source">foo
+</pre>
+<p class="caption">SOURCE</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_texequation
@@ -1643,6 +1746,31 @@ EOS
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     assert_equal %Q(<div class="table">\n<table>\n<tr><th>aaa</th><th>bbb</th></tr>\n<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>\n</table>\n</div>\n),
                  actual
+
+    actual = compile_block("//table[foo][FOO]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+<div id="foo" class="table">
+<p class="caption">表1.1: FOO</p>
+<table>
+<tr><th>aaa</th><th>bbb</th></tr>
+<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>
+</table>
+</div>
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//table[foo][FOO]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+<div id="foo" class="table">
+<table>
+<tr><th>aaa</th><th>bbb</th></tr>
+<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>
+</table>
+<p class="caption">表1.1: FOO</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_table
@@ -1657,6 +1785,19 @@ EOS
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     assert_equal %Q(<div class="table">\n<p class="caption">foo</p>\n<table>\n<tr><th>aaa</th><th>bbb</th></tr>\n<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>\n</table>\n</div>\n<div class="table">\n<table>\n<tr><th>aaa</th><th>bbb</th></tr>\n<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>\n</table>\n</div>\n),
                  actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+<div class="table">
+<table>
+<tr><th>aaa</th><th>bbb</th></tr>
+<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>
+</table>
+<p class="caption">foo</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_imgtable
@@ -1668,6 +1809,11 @@ EOS
 
     actual = compile_block("//imgtable[sampleimg][test for imgtable]{\n//}\n")
     expected = %Q(<div id="sampleimg" class="imgtable image">\n<p class="caption">表1.1: test for imgtable</p>\n<img src="images/chap1-sampleimg.png" alt="test for imgtable" />\n</div>\n)
+    assert_equal expected, actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//imgtable[sampleimg][test for imgtable]{\n//}\n")
+    expected = %Q(<div id="sampleimg" class="imgtable image">\n<img src="images/chap1-sampleimg.png" alt="test for imgtable" />\n<p class="caption">表1.1: test for imgtable</p>\n</div>\n)
     assert_equal expected, actual
   end
 
@@ -1800,6 +1946,20 @@ EOS
 <pre>e=mc^2
 </pre>
 </div>
+</div>
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+
+    @config['caption_position']['equation'] = 'bottom'
+    expected = <<-EOS
+<p><span class="eqref">式1.1</span></p>
+<div id="emc2" class="caption-equation">
+<div class="equation">
+<pre>e=mc^2
+</pre>
+</div>
+<p class="caption">式1.1: The Equivalence of Mass <i>and</i> Energy</p>
 </div>
 EOS
     actual = compile_block(src)

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -136,6 +136,10 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
   def test_emtable
     actual = compile_block("//emtable[foo]{\nA\n//}\n//emtable{\nA\n//}")
     assert_equal %Q(<table><caption>foo</caption><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table><table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table>), actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//emtable[foo]{\nA\n//}\n//emtable{\nA\n//}")
+    assert_equal %Q(<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody><caption>foo</caption></table><table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table>), actual
   end
 
   def test_inline_br
@@ -256,11 +260,18 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
   def test_emlist
     actual = compile_block("//emlist[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
     assert_equal %Q(<list type='emlist'><caption aid:pstyle='emlist-title'>this is <b>test</b>&lt;&amp;&gt;_</caption><pre>test1\ntest1.5\n\ntest<i>2</i>\n</pre></list>), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//emlist[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
+    assert_equal %Q(<list type='emlist'><pre>test1\ntest1.5\n\ntest<i>2</i>\n</pre><caption aid:pstyle='emlist-title'>this is <b>test</b>&lt;&amp;&gt;_</caption></list>), actual
   end
 
   def test_emlistnum
     actual = compile_block("//emlistnum[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
     assert_equal %Q(<list type='emlistnum'><caption aid:pstyle='emlistnum-title'>this is <b>test</b>&lt;&amp;&gt;_</caption><pre><span type='lineno'> 1: </span>test1\n<span type='lineno'> 2: </span>test1.5\n<span type='lineno'> 3: </span>\n<span type='lineno'> 4: </span>test<i>2</i>\n</pre></list>), actual
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//emlistnum[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
+    assert_equal %Q(<list type='emlistnum'><pre><span type='lineno'> 1: </span>test1\n<span type='lineno'> 2: </span>test1.5\n<span type='lineno'> 3: </span>\n<span type='lineno'> 4: </span>test<i>2</i>\n</pre><caption aid:pstyle='emlistnum-title'>this is <b>test</b>&lt;&amp;&gt;_</caption></list>), actual
   end
 
   def test_emlist_listinfo
@@ -286,6 +297,10 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     end
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
     assert_equal %Q(<codelist><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption><pre>test1\ntest1.5\n\ntest<i>2</i>\n</pre></codelist>), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
+    assert_equal %Q(<codelist><pre>test1\ntest1.5\n\ntest<i>2</i>\n</pre><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption></codelist>), actual
   end
 
   def test_listnum
@@ -294,6 +309,10 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     end
     actual = compile_block("//listnum[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
     assert_equal %Q(<codelist><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption><pre><span type='lineno'> 1: </span>test1\n<span type='lineno'> 2: </span>test1.5\n<span type='lineno'> 3: </span>\n<span type='lineno'> 4: </span>test<i>2</i>\n</pre></codelist>), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//listnum[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
+    assert_equal %Q(<codelist><pre><span type='lineno'> 1: </span>test1\n<span type='lineno'> 2: </span>test1.5\n<span type='lineno'> 3: </span>\n<span type='lineno'> 4: </span>test<i>2</i>\n</pre><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption></codelist>), actual
   end
 
   def test_listnum_linenum
@@ -317,18 +336,54 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     @config['listinfo'] = true
     actual = compile_block("//insn[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
     assert_equal %Q(<insn><floattitle type="insn">this is <b>test</b>&lt;&amp;&gt;_</floattitle><listinfo line="1" begin="1">test1\n</listinfo><listinfo line="2">test1.5\n</listinfo><listinfo line="3">\n</listinfo><listinfo line="4" end="4">test<i>2</i>\n</listinfo></insn>), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//insn[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
+    assert_equal %Q(<insn><listinfo line="1" begin="1">test1\n</listinfo><listinfo line="2">test1.5\n</listinfo><listinfo line="3">\n</listinfo><listinfo line="4" end="4">test<i>2</i>\n</listinfo><floattitle type="insn">this is <b>test</b>&lt;&amp;&gt;_</floattitle></insn>), actual
   end
 
   def test_box
     @config['listinfo'] = true
     actual = compile_block("//box[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
     assert_equal %Q(<box><caption aid:pstyle="box-title">this is <b>test</b>&lt;&amp;&gt;_</caption><listinfo line="1" begin="1">test1\n</listinfo><listinfo line="2">test1.5\n</listinfo><listinfo line="3">\n</listinfo><listinfo line="4" end="4">test<i>2</i>\n</listinfo></box>), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//box[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
+    assert_equal %Q(<box><listinfo line="1" begin="1">test1\n</listinfo><listinfo line="2">test1.5\n</listinfo><listinfo line="3">\n</listinfo><listinfo line="4" end="4">test<i>2</i>\n</listinfo><caption aid:pstyle="box-title">this is <b>test</b>&lt;&amp;&gt;_</caption></box>), actual
   end
 
   def test_box_non_listinfo
     @config['listinfo'] = nil
     actual = compile_block("//box[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
     assert_equal %Q(<box><caption aid:pstyle="box-title">this is <b>test</b>&lt;&amp;&gt;_</caption>test1\ntest1.5\n\ntest<i>2</i>\n</box>), actual
+  end
+
+  def test_other_lists
+    src = <<-EOS
+//cmd[CMD]{
+foo
+//}
+
+//source[SOURCE]{
+foo
+//}
+EOS
+    actual = compile_block(src)
+    expected = <<-EOS.chomp
+<list type='cmd'><caption aid:pstyle='cmd-title'>CMD</caption><pre>foo
+</pre></list><source><caption>SOURCE</caption><pre>foo
+</pre></source>
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block(src)
+    expected = <<-EOS.chomp
+<list type='cmd'><pre>foo
+</pre><caption aid:pstyle='cmd-title'>CMD</caption></list><source><pre>foo
+</pre><caption>SOURCE</caption></source>
+EOS
+    assert_equal expected, actual
   end
 
   def test_flushright
@@ -360,6 +415,10 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
 
     actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
     assert_equal %Q(<img><Image href="file://images/chap1-sampleimg.png" /><caption>図1.1　sample photo</caption></img>), actual
+
+    @config['caption_position']['image'] = 'top'
+    actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
+    assert_equal %Q(<img><caption>図1.1　sample photo</caption><Image href="file://images/chap1-sampleimg.png" /></img>), actual
   end
 
   def test_image_with_metric
@@ -393,6 +452,10 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
 
     actual = compile_block("//indepimage[sampleimg][sample photo]\n")
     assert_equal %Q(<img><Image href="file://images/chap1-sampleimg.png" /><caption>sample photo</caption></img>), actual
+
+    @config['caption_position']['image'] = 'top'
+    actual = compile_block("//indepimage[sampleimg][sample photo]\n")
+    assert_equal %Q(<img><caption>sample photo</caption><Image href="file://images/chap1-sampleimg.png" /></img>), actual
   end
 
   def test_indepimage_without_caption
@@ -753,6 +816,11 @@ e=mc^2
 //}
 EOS
     expected = %Q(<p><span type='eq'>式1.1</span></p><equationblock><caption>式1.1　The Equivalence of Mass <i>and</i> Energy</caption><replace idref="texblock-1"><pre>e=mc^2</pre></replace></equationblock>)
+    actual = compile_block(src)
+    assert_equal expected, actual
+
+    @config['caption_position']['equation'] = 'bottom'
+    expected = %Q(<p><span type='eq'>式1.1</span></p><equationblock><replace idref="texblock-1"><pre>e=mc^2</pre></replace><caption>式1.1　The Equivalence of Mass <i>and</i> Energy</caption></equationblock>)
     actual = compile_block(src)
     assert_equal expected, actual
   end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -305,6 +305,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     @config['caption_position']['list'] = 'bottom'
     actual = compile_block("//cmd[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
     expected = <<-EOS
+
 \\begin{reviewlistblock}
 \\begin{reviewcmd}
 foo
@@ -348,6 +349,22 @@ EOS
   def test_emlist_caption
     actual = compile_block("//emlist[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
     assert_equal %Q(\n\\begin{reviewlistblock}\n\\reviewemlistcaption{cap1}\n\\begin{reviewemlist}\nfoo\nbar\n\nbuz\n\\end{reviewemlist}\n\\end{reviewlistblock}\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//emlist[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
+    expected = <<-EOS
+
+\\begin{reviewlistblock}
+\\begin{reviewemlist}
+foo
+bar
+
+buz
+\\end{reviewemlist}
+\\reviewemlistcaption{cap1}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_empty_caption
@@ -369,11 +386,42 @@ EOS
   def test_emlistnum_caption
     actual = compile_block("//emlistnum[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
     assert_equal %Q(\n\\begin{reviewlistblock}\n\\reviewemlistcaption{cap1}\n\\begin{reviewemlist}\n 1: foo\n 2: bar\n 3: \n 4: buz\n\\end{reviewemlist}\n\\end{reviewlistblock}\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//emlistnum[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
+    expected = <<-EOS
+
+\\begin{reviewlistblock}
+\\begin{reviewemlist}
+ 1: foo
+ 2: bar
+ 3: 
+ 4: buz
+\\end{reviewemlist}
+\\reviewemlistcaption{cap1}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_list
     actual = compile_block("//list[id1][cap1]{\nfoo\nbar\n\nbuz\n//}\n")
     assert_equal %Q(\\begin{reviewlistblock}\n\\reviewlistcaption{リスト1.1: cap1}\n\\begin{reviewlist}\nfoo\nbar\n\nbuz\n\\end{reviewlist}\n\\end{reviewlistblock}\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//list[id1][cap1]{\nfoo\nbar\n\nbuz\n//}\n")
+    expected = <<-EOS
+\\begin{reviewlistblock}
+\\begin{reviewlist}
+foo
+bar
+
+buz
+\\end{reviewlist}
+\\reviewlistcaption{リスト1.1: cap1}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_list_lst
@@ -394,6 +442,24 @@ EOS
   def test_listnum
     actual = compile_block("//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
     assert_equal %Q(\\begin{reviewlistblock}\n\\reviewlistcaption{リスト1.1: ruby}\n\\begin{reviewlist}\n 1: class Foo\n 2:   def foo\n 3:     bar\n 4: \n 5:     buz\n 6:   end\n 7: end\n\\end{reviewlist}\n\\end{reviewlistblock}\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
+    expected = <<-EOS
+\\begin{reviewlistblock}
+\\begin{reviewlist}
+ 1: class Foo
+ 2:   def foo
+ 3:     bar
+ 4: 
+ 5:     buz
+ 6:   end
+ 7: end
+\\end{reviewlist}
+\\reviewlistcaption{リスト1.1: ruby}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum_linenum
@@ -418,6 +484,21 @@ EOS
   def test_source
     actual = compile_block("//source[foo/bar/test.rb]{\nfoo\nbar\n\nbuz\n//}\n")
     assert_equal %Q(\\begin{reviewlistblock}\n\\reviewsourcecaption{foo/bar/test.rb}\n\\begin{reviewsource}\nfoo\nbar\n\nbuz\n\\end{reviewsource}\n\\end{reviewlistblock}\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//source[foo/bar/test.rb]{\nfoo\nbar\n\nbuz\n//}\n")
+    expected = <<-EOS
+\\begin{reviewlistblock}
+\\begin{reviewsource}
+foo
+bar
+
+buz
+\\end{reviewsource}
+\\reviewsourcecaption{foo/bar/test.rb}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_source_empty_caption
@@ -471,6 +552,17 @@ EOS
 
     actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
     assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+
+    @config['caption_position']['image'] = 'top'
+    actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewimagecaption{sample photo}
+\\label{image:chap1:sampleimg}
+\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric
@@ -528,6 +620,16 @@ EOS
 
     actual = compile_block("//indepimage[sampleimg][sample photo]\n")
     assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+
+    @config['caption_position']['image'] = 'top'
+    actual = compile_block("//indepimage[sampleimg][sample photo]\n")
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewindepimagecaption{図: sample photo}
+\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_without_caption
@@ -592,6 +694,35 @@ EOS
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     assert_equal "\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
                  actual
+
+    actual = compile_block("//table[foo][FOO]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+\\begin{table}%%foo
+\\reviewtablecaption{FOO}
+\\label{table:chap1:foo}
+\\begin{reviewtable}{|l|l|}
+\\hline
+\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline
+ccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline
+\\end{reviewtable}
+\\end{table}
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//table[foo][FOO]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+\\begin{table}%%foo
+\\begin{reviewtable}{|l|l|}
+\\hline
+\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline
+ccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline
+\\end{reviewtable}
+\\reviewtablecaption{FOO}
+\\label{table:chap1:foo}
+\\end{table}
+EOS
+    assert_equal expected, actual
   end
 
   def test_customize_cellwidth
@@ -652,6 +783,20 @@ EOS
 \\begin{reviewimage}%%sampleimg
 \\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
 \\end{reviewimage}
+\\end{table}
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//imgtable[sampleimg][test for imgtable]{\n//}\n")
+
+    expected = <<-EOS
+\\begin{table}[h]%%sampleimg
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+\\reviewimgtablecaption{test for imgtable}
+\\label{table:chap1:sampleimg}
 \\end{table}
 EOS
     assert_equal expected, actual
@@ -1195,6 +1340,21 @@ EOS
 \\begin{equation*}
 e=mc^2
 \\end{equation*}
+\\end{reviewequationblock}
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+
+    @config['caption_position']['equation'] = 'bottom'
+    expected = <<-EOS
+
+\\reviewequationref{1.1}
+
+\\begin{reviewequationblock}
+\\begin{equation*}
+e=mc^2
+\\end{equation*}
+\\reviewequationcaption{式1.1: The Equivalence of Mass \\reviewit{and} Energy}
 \\end{reviewequationblock}
 EOS
     actual = compile_block(src)

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -301,6 +301,21 @@ class LATEXBuidlerTest < Test::Unit::TestCase
   def test_cmd_caption
     actual = compile_block("//cmd[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
     assert_equal %Q(\n\\begin{reviewlistblock}\n\\reviewcmdcaption{cap1}\n\\begin{reviewcmd}\nfoo\nbar\n\nbuz\n\\end{reviewcmd}\n\\end{reviewlistblock}\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//cmd[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
+    expected = <<-EOS
+\\begin{reviewlistblock}
+\\begin{reviewcmd}
+foo
+bar
+
+buz
+\\end{reviewcmd}
+\\reviewcmdcaption{cap1}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd_lst

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -617,7 +617,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def test_emtable
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal "\\begin{table}%%\n\\reviewtablecaption*{foo}\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n\\end{table}\n\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
+    assert_equal "\\begin{table}%%\n\\reviewtablecaption{foo}\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n\\end{table}\n\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
                  actual
   end
 

--- a/test/test_latexbuilder_v2.rb
+++ b/test/test_latexbuilder_v2.rb
@@ -567,7 +567,7 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
 
   def test_emtable
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal "\\begin{table}[h]%%\n\\reviewtablecaption*{foo}\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n\\end{table}\n\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
+    assert_equal "\\begin{table}[h]%%\n\\reviewtablecaption{foo}\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n\\end{table}\n\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
                  actual
   end
 

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -9,10 +9,7 @@ class MARKDOWNBuilderTest < Test::Unit::TestCase
 
   def setup
     @builder = MARKDOWNBuilder.new
-    @config = {
-      'secnolevel' => 2,
-      'stylesheet' => nil
-    }
+    @config = ReVIEW::Configure.values
     @book = Book::Base.new('.')
     @book.config = @config
     @compiler = ReVIEW::Compiler.new(@builder)
@@ -171,6 +168,6 @@ BBB
 
   def test_ruby
     actual = compile_block('@<ruby>{謳,うた}い文句')
-    assert_equal "<ruby><rb>謳</rb><rp>（</rp><rt>うた</rt><rp>）</rp></ruby>い文句\n\n", actual
+    assert_equal "<ruby>謳<rp>（</rp><rt>うた</rt><rp>）</rp></ruby>い文句\n\n", actual
   end
 end

--- a/test/test_md2inaobuilder.rb
+++ b/test/test_md2inaobuilder.rb
@@ -9,10 +9,7 @@ class MD2INAOBuilderTest < Test::Unit::TestCase
 
   def setup
     @builder = MD2INAOBuilder.new
-    @config = {
-      'secnolevel' => 2,
-      'stylesheet' => nil
-    }
+    @config = ReVIEW::Configure.values
     @book = Book::Base.new('.')
     @book.config = @config
     @compiler = ReVIEW::Compiler.new(@builder)

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -188,6 +188,17 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
     end
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
     assert_equal %Q(リスト1.1　this is test<&>_\n\nfoo\nbar\n\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
+    expected = <<-EOS
+foo
+bar
+
+リスト1.1　this is test<&>_
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum
@@ -196,11 +207,91 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
     end
     actual = compile_block("//listnum[test][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
     assert_equal %Q(リスト1.1　this is test<&>_\n\n 1: foo\n 2: bar\n\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//listnum[test][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
+    expected = <<-EOS
+ 1: foo
+ 2: bar
+
+リスト1.1　this is test<&>_
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlistnum
     actual = compile_block("//emlistnum[this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
     assert_equal %Q(this is test<&>_\n 1: foo\n 2: bar\n\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//emlistnum[this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
+    expected = <<-EOS
+ 1: foo
+ 2: bar
+
+this is test<&>_
+
+EOS
+    assert_equal expected, actual
+  end
+
+  def test_other_lists
+    src = <<-EOS
+//cmd[CMD]{
+foo
+//}
+
+//emlist[EMLIST]{
+foo
+//}
+
+//box[BOX]{
+foo
+//}
+
+//source[SOURCE]{
+foo
+//}
+EOS
+    actual = compile_block(src)
+    expected = <<-EOS
+CMD
+foo
+
+EMLIST
+foo
+
+BOX
+foo
+
+SOURCE
+foo
+
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block(src)
+    expected = <<-EOS
+foo
+
+CMD
+
+foo
+
+EMLIST
+
+foo
+
+BOX
+
+foo
+
+SOURCE
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_bib
@@ -215,6 +306,27 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     assert_equal %Q(aaa\tbbb\nccc\tddd<>&\n\n),
                  actual
+
+    actual = compile_block("//table[foo][FOO]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+表1.1　FOO
+
+aaa\tbbb
+ccc\tddd<>&
+
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//table[foo][FOO]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+aaa\tbbb
+ccc\tddd<>&
+
+表1.1　FOO
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_table
@@ -228,6 +340,11 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
   def test_emtable
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     assert_equal %Q(foo\n\naaa\tbbb\nccc\tddd<>&\n\naaa\tbbb\nccc\tddd<>&\n\n),
+                 actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    assert_equal %Q(aaa\tbbb\nccc\tddd<>&\n\nfoo\n\naaa\tbbb\nccc\tddd<>&\n\n),
                  actual
   end
 
@@ -272,6 +389,10 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
       item
     end
 
+    actual = compile_block("//image[sampleimg][sample photo]{\nfoo\n//}\n")
+    assert_equal %Q(図1.1　sample photo\n\n), actual
+
+    @config['caption_position']['image'] = 'top'
     actual = compile_block("//image[sampleimg][sample photo]{\nfoo\n//}\n")
     assert_equal %Q(図1.1　sample photo\n\n), actual
   end
@@ -401,6 +522,17 @@ EOS
 
 式1.1　The Equivalence of Mass and Energy
 e=mc^2
+
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+
+    @config['caption_position']['equation'] = 'bottom'
+    expected = <<-EOS
+式1.1
+
+e=mc^2
+式1.1　The Equivalence of Mass and Energy
 
 EOS
     actual = compile_block(src)

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -248,6 +248,80 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_other_lists
+    src = <<-EOS
+//cmd[CMD]{
+foo
+//}
+
+//emlist[EMLIST]{
+foo
+//}
+
+//box[BOX]{
+foo
+//}
+
+//source[SOURCE]{
+foo
+//}
+EOS
+    actual = compile_block(src)
+    expected = <<-EOS
+◆→開始:コマンド←◆
+■CMD
+foo
+◆→終了:コマンド←◆
+
+◆→開始:インラインリスト←◆
+■EMLIST
+foo
+◆→終了:インラインリスト←◆
+
+◆→開始:書式←◆
+■BOX
+foo
+◆→終了:書式←◆
+
+◆→開始:ソースコードリスト←◆
+■SOURCE
+foo
+◆→終了:ソースコードリスト←◆
+
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block(src)
+    expected = <<-EOS
+◆→開始:コマンド←◆
+foo
+
+■CMD
+◆→終了:コマンド←◆
+
+◆→開始:インラインリスト←◆
+foo
+
+■EMLIST
+◆→終了:インラインリスト←◆
+
+◆→開始:書式←◆
+foo
+
+■BOX
+◆→終了:書式←◆
+
+◆→開始:ソースコードリスト←◆
+foo
+
+■SOURCE
+◆→終了:ソースコードリスト←◆
+
+EOS
+    assert_equal expected, actual
+  end
+
   def test_bib
     def @chapter.bibpaper(_id)
       Book::BibpaperIndex::Item.new('samplebib', 1, 'sample bib')

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -373,6 +373,11 @@ EOS
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     assert_equal %Q(◆→開始:表←◆\nfoo\n\n★aaa☆\t★bbb☆\nccc\tddd<>&\n◆→終了:表←◆\n\n◆→開始:表←◆\n★aaa☆\t★bbb☆\nccc\tddd<>&\n◆→終了:表←◆\n\n),
                  actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    assert_equal %Q(◆→開始:表←◆\n★aaa☆\t★bbb☆\nccc\tddd<>&\n\nfoo\n◆→終了:表←◆\n\n◆→開始:表←◆\n★aaa☆\t★bbb☆\nccc\tddd<>&\n◆→終了:表←◆\n\n),
+                 actual
   end
 
   def test_major_blocks

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -194,6 +194,19 @@ class TOPBuidlerTest < Test::Unit::TestCase
     end
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
     assert_equal %Q(◆→開始:リスト←◆\nリスト1.1　this is ★test☆<&>_\n\nfoo\nbar\n◆→終了:リスト←◆\n\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
+    expected = <<-EOS
+◆→開始:リスト←◆
+foo
+bar
+
+リスト1.1　this is ★test☆<&>_
+◆→終了:リスト←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum
@@ -202,11 +215,37 @@ class TOPBuidlerTest < Test::Unit::TestCase
     end
     actual = compile_block("//listnum[test][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
     assert_equal %Q(◆→開始:リスト←◆\nリスト1.1　this is ★test☆<&>_\n\n 1: foo\n 2: bar\n◆→終了:リスト←◆\n\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//listnum[test][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
+    expected = <<-EOS
+◆→開始:リスト←◆
+ 1: foo
+ 2: bar
+
+リスト1.1　this is ★test☆<&>_
+◆→終了:リスト←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlistnum
     actual = compile_block("//emlistnum[this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
     assert_equal %Q(◆→開始:インラインリスト←◆\n■this is ★test☆<&>_\n 1: foo\n 2: bar\n◆→終了:インラインリスト←◆\n\n), actual
+
+    @config['caption_position']['list'] = 'bottom'
+    actual = compile_block("//emlistnum[this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
+    expected = <<-EOS
+◆→開始:インラインリスト←◆
+ 1: foo
+ 2: bar
+
+■this is ★test☆<&>_
+◆→終了:インラインリスト←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_bib
@@ -221,6 +260,31 @@ class TOPBuidlerTest < Test::Unit::TestCase
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     assert_equal %Q(◆→開始:表←◆\n★aaa☆\t★bbb☆\nccc\tddd<>&\n◆→終了:表←◆\n\n),
                  actual
+
+    actual = compile_block("//table[foo][FOO]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+◆→開始:表←◆
+表1.1　FOO
+
+★aaa☆\t★bbb☆
+ccc\tddd<>&
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//table[foo][FOO]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+◆→開始:表←◆
+★aaa☆\t★bbb☆
+ccc\tddd<>&
+
+表1.1　FOO
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_table
@@ -280,6 +344,18 @@ class TOPBuidlerTest < Test::Unit::TestCase
 
     actual = compile_block("//image[sampleimg][sample photo]{\nfoo\n//}\n")
     assert_equal %Q(◆→開始:図←◆\n◆→./images/chap1-sampleimg.png←◆\n\n図1.1　sample photo\n◆→終了:図←◆\n\n), actual
+
+    @config['caption_position']['image'] = 'top'
+    actual = compile_block("//image[sampleimg][sample photo]{\nfoo\n//}\n")
+    expected = <<-EOS
+◆→開始:図←◆
+図1.1　sample photo
+
+◆→./images/chap1-sampleimg.png←◆
+◆→終了:図←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric
@@ -429,6 +505,19 @@ EOS
 式1.1　The Equivalence of Mass ▲and☆ Energy
 e=mc^2
 ◆→終了:TeX式←◆
+
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+
+    @config['caption_position']['equation'] = 'bottom'
+    expected = <<-EOS
+式1.1
+
+◆→開始:TeX式←◆
+e=mc^2
+◆→終了:TeX式←◆
+式1.1　The Equivalence of Mass ▲and☆ Energy
 
 EOS
     actual = compile_block(src)

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -279,7 +279,7 @@ class TOPBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo]{\nfoo\n//}\n")
-    assert_equal %Q(◆→開始:図←◆\n図1.1　sample photo\n\n◆→./images/chap1-sampleimg.png←◆\n◆→終了:図←◆\n\n), actual
+    assert_equal %Q(◆→開始:図←◆\n◆→./images/chap1-sampleimg.png←◆\n\n図1.1　sample photo\n◆→終了:図←◆\n\n), actual
   end
 
   def test_image_with_metric
@@ -290,7 +290,7 @@ class TOPBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\nfoo\n//}\n")
-    assert_equal %Q(◆→開始:図←◆\n図1.1　sample photo\n\n◆→./images/chap1-sampleimg.png scale=1.2←◆\n◆→終了:図←◆\n\n), actual
+    assert_equal %Q(◆→開始:図←◆\n◆→./images/chap1-sampleimg.png scale=1.2←◆\n\n図1.1　sample photo\n◆→終了:図←◆\n\n), actual
   end
 
   def test_texequation


### PR DESCRIPTION
#1320 の対応

とりあえずbuilder, latexbuilder で実装の試行から。

判定コードがどうしても冗長ですね…。また、LaTeXのほうは歴史的経緯のv2まわりのマクロ名引き継ぎがあって、ごちゃごちゃめです。
ブロック命令をputsで出しているところに割り込むことになるので、あまり改善の余地はないかも。
