### PR TITLE
空のtableをエラーにする

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -165,6 +165,7 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
+      return if rows.empty?
 
       begin
         if caption.present?
@@ -173,7 +174,6 @@ module ReVIEW
       rescue KeyError
         error "no such table: #{id}"
       end
-      return if rows.empty?
       table_begin rows.first.size
       if sepidx
         sepidx.times do

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -165,7 +165,7 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
-      return if rows.empty?
+      error 'no rows in the table' if rows.empty?
 
       begin
         if caption.present?

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -655,6 +655,7 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
+      return if rows.empty?
 
       if id
         puts %Q(<div id="#{normalize_id(id)}" class="table">)
@@ -669,7 +670,6 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin rows.first.size
-      return if rows.empty?
       if sepidx
         sepidx.times do
           tr(rows.shift.map { |s| th(s) })

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -655,7 +655,7 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
-      return if rows.empty?
+      error 'no rows in the table' if rows.empty?
 
       if id
         puts %Q(<div id="#{normalize_id(id)}" class="table">)

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -465,7 +465,7 @@ module ReVIEW
         col2 = rows[rows.length - 1].split(/\t/).length
         col = col2 if col2 > col
       end
-      return if rows.empty?
+      error 'no rows in the table' if rows.empty?
 
       puts '<table>'
 

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -450,7 +450,6 @@ module ReVIEW
       tablewidth = @book.config['tableopt'] ? @book.config['tableopt'].split(',')[0].to_f / @book.config['pt_to_mm_unit'].to_f : nil
       col = 0
 
-      puts '<table>'
       rows = []
       sepidx = nil
       lines.each_with_index do |line, idx|
@@ -466,6 +465,9 @@ module ReVIEW
         col2 = rows[rows.length - 1].split(/\t/).length
         col = col2 if col2 > col
       end
+      return if rows.empty?
+
+      puts '<table>'
 
       cellwidth = []
       if tablewidth
@@ -492,7 +494,6 @@ module ReVIEW
       rescue KeyError
         error "no such table: #{id}"
       end
-      return if rows.empty?
 
       if tablewidth.nil?
         print '<tbody>'

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -606,7 +606,7 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
-      return if rows.empty?
+      error 'no rows in the table' if rows.empty?
 
       begin
         table_header(id, caption) if caption.present?

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -606,13 +606,13 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
+      return if rows.empty?
 
       begin
         table_header(id, caption) if caption.present?
       rescue KeyError
         error "no such table: #{id}"
       end
-      return if rows.empty?
       table_begin(rows.first.size)
       if sepidx
         sepidx.times do

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -250,7 +250,7 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
-      return if rows.empty?
+      error 'no rows in the table' if rows.empty?
 
       begin
         table_header id, caption unless caption.nil?

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -250,6 +250,7 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
+      return if rows.empty?
 
       begin
         table_header id, caption unless caption.nil?
@@ -257,7 +258,6 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin rows.first.size
-      return if rows.empty?
       if sepidx
         sepidx.times do
           tr(rows.shift.map { |s| th(s) })

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -221,7 +221,6 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      blank
       rows = []
       sepidx = nil
       lines.each_with_index do |line, idx|
@@ -234,13 +233,15 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
+      return if rows.empty?
+
+      blank
 
       begin
         table_header(id, caption) if caption.present?
       rescue KeyError
         error "no such table: #{id}"
       end
-      return if rows.empty?
       table_begin rows.first.size
       if sepidx
         sepidx.times do

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -233,7 +233,7 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
-      return if rows.empty?
+      error 'no rows in the table' if rows.empty?
 
       blank
 

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -186,9 +186,6 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      blank
-      puts "◆→開始:#{@titles['table']}←◆"
-
       rows = []
       sepidx = nil
       lines.each_with_index do |line, idx|
@@ -201,13 +198,16 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
+      return if rows.empty?
+
+      blank
+      puts "◆→開始:#{@titles['table']}←◆"
 
       begin
         table_header id, caption if caption.present?
       rescue KeyError
         error "no such table: #{id}"
       end
-      return if rows.empty?
       table_begin rows.first.size
       if sepidx
         sepidx.times do

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -198,7 +198,7 @@ module ReVIEW
         rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
-      return if rows.empty?
+      error 'no rows in the table' if rows.empty?
 
       blank
       puts "◆→開始:#{@titles['table']}←◆"

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1645,6 +1645,13 @@ EOS
                  actual
   end
 
+  def test_empty_table
+    actual = compile_block("//table{\n//}\n")
+    assert_equal '', actual
+    actual = compile_block("//table{\n------------\n//}\n")
+    assert_equal '', actual
+  end
+
   def test_inline_table
     def @chapter.table(_id)
       Book::TableIndex::Item.new('sampletable', 1)

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1968,10 +1968,11 @@ EOS
   end
 
   def test_empty_table
-    actual = compile_block("//table{\n//}\n")
-    assert_equal '', actual
-    actual = compile_block("//table{\n------------\n//}\n")
-    assert_equal '', actual
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "//table{\n//}\n" }
+    assert_equal ':2: error: no rows in the table', e.message
+
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "//table{\n------------\n//}\n" }
+    assert_equal ':3: error: no rows in the table', e.message
   end
 
   def test_inline_table

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -134,10 +134,11 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
   end
 
   def test_empty_table
-    actual = compile_block("//table{\n//}\n")
-    assert_equal '', actual
-    actual = compile_block("//table{\n------------\n//}\n")
-    assert_equal '', actual
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "//table{\n//}\n" }
+    assert_equal ':2: error: no rows in the table', e.message
+
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "//table{\n------------\n//}\n" }
+    assert_equal ':3: error: no rows in the table', e.message
   end
 
   def test_emtable

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -133,6 +133,13 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.458">A</td></tbody></table>), actual
   end
 
+  def test_empty_table
+    actual = compile_block("//table{\n//}\n")
+    assert_equal '', actual
+    actual = compile_block("//table{\n------------\n//}\n")
+    assert_equal '', actual
+  end
+
   def test_emtable
     actual = compile_block("//emtable[foo]{\nA\n//}\n//emtable{\nA\n//}")
     assert_equal %Q(<table><caption>foo</caption><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table><table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table>), actual

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -579,6 +579,13 @@ class LATEXBuidlerTest < Test::Unit::TestCase
                  actual
   end
 
+  def test_empty_table
+    actual = compile_block("//table{\n//}\n")
+    assert_equal '', actual
+    actual = compile_block("//table{\n------------\n//}\n")
+    assert_equal '', actual
+  end
+
   def test_customize_cellwidth
     actual = compile_block("//tsize[2,3,5]\n//table{\nA\tB\tC\n//}\n")
     assert_equal %Q(\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -995,10 +995,11 @@ EOS
   end
 
   def test_empty_table
-    actual = compile_block("//table{\n//}\n")
-    assert_equal '', actual
-    actual = compile_block("//table{\n------------\n//}\n")
-    assert_equal '', actual
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "//table{\n//}\n" }
+    assert_equal ':2: error: no rows in the table', e.message
+
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "//table{\n------------\n//}\n" }
+    assert_equal ':3: error: no rows in the table', e.message
   end
 
   def test_customize_cellwidth

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -367,10 +367,11 @@ EOS
   end
 
   def test_empty_table
-    actual = compile_block("//table{\n//}\n")
-    assert_equal '', actual
-    actual = compile_block("//table{\n------------\n//}\n")
-    assert_equal '', actual
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "//table{\n//}\n" }
+    assert_equal ':2: error: no rows in the table', e.message
+
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "//table{\n------------\n//}\n" }
+    assert_equal ':3: error: no rows in the table', e.message
   end
 
   def test_inline_table

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -217,6 +217,13 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
                  actual
   end
 
+  def test_empty_table
+    actual = compile_block("//table{\n//}\n")
+    assert_equal '', actual
+    actual = compile_block("//table{\n------------\n//}\n")
+    assert_equal '', actual
+  end
+
   def test_inline_table
     def @chapter.table(_id)
       Book::TableIndex::Item.new('sampletable', 1)

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -404,10 +404,11 @@ EOS
   end
 
   def test_empty_table
-    actual = compile_block("//table{\n//}\n")
-    assert_equal '', actual
-    actual = compile_block("//table{\n------------\n//}\n")
-    assert_equal '', actual
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "//table{\n//}\n" }
+    assert_equal ':2: error: no rows in the table', e.message
+
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block "//table{\n------------\n//}\n" }
+    assert_equal ':3: error: no rows in the table', e.message
   end
 
   def test_inline_table

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -223,6 +223,13 @@ class TOPBuidlerTest < Test::Unit::TestCase
                  actual
   end
 
+  def test_empty_table
+    actual = compile_block("//table{\n//}\n")
+    assert_equal '', actual
+    actual = compile_block("//table{\n------------\n//}\n")
+    assert_equal '', actual
+  end
+
   def test_inline_table
     def @chapter.table(_id)
       Book::TableIndex::Item.new('sampletable', 1)


### PR DESCRIPTION
#1325 の対応です。
`return if rows.empty?` を早期に実行して開始部に至らないようにします。