### PR TITLE
テストコードで期待値が複数行でわかりにくい箇所にはヒアドキュメントを使う

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -384,6 +384,10 @@ Layout/SpaceInsideStringInterpolation:
 Layout/TrailingBlankLines:
   Enabled: true
 
+Layout/TrailingWhitespace:
+  Enabled: true
+  AllowInHeredoc: true
+
 #### Metrics
 
 Metrics/BlockNesting:

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -191,7 +191,15 @@ class HTMLBuidlerTest < Test::Unit::TestCase
 
   def test_inline_in_table
     actual = compile_block("//table{\n@<b>{1}\t@<i>{2}\n------------\n@<b>{3}\t@<i>{4}<>&\n//}\n")
-    assert_equal %Q(<div class="table">\n<table>\n<tr><th><b>1</b></th><th><i>2</i></th></tr>\n<tr><td><b>3</b></td><td><i>4</i>&lt;&gt;&amp;</td></tr>\n</table>\n</div>\n), actual
+    expected = <<-EOS
+<div class="table">
+<table>
+<tr><th><b>1</b></th><th><i>2</i></th></tr>
+<tr><td><b>3</b></td><td><i>4</i>&lt;&gt;&amp;</td></tr>
+</table>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_br
@@ -430,32 +438,59 @@ EOS
 
   def test_quote
     actual = compile_block("//quote{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(<blockquote><p>foobar</p>\n<p>buz</p></blockquote>\n), actual
+    expected = <<-EOS
+<blockquote><p>foobar</p>
+<p>buz</p></blockquote>
+EOS
+    assert_equal expected, actual
   end
 
   def test_memo
     actual = compile_block("//memo[this is @<b>{test}<&>_]{\ntest1\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<div class="memo">\n<p class="caption">this is <b>test</b>&lt;&amp;&gt;_</p>\n<p>test1</p>\n<p>test<i>2</i></p>\n</div>\n), actual
+    expected = <<-EOS
+<div class="memo">
+<p class="caption">this is <b>test</b>&lt;&amp;&gt;_</p>
+<p>test1</p>
+<p>test<i>2</i></p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_blankline
     actual = compile_block("//blankline\nfoo\n")
-    assert_equal %Q(<p><br /></p>\n<p>foo</p>\n), actual
+    expected = <<-EOS
+<p><br /></p>
+<p>foo</p>
+EOS
+    assert_equal expected, actual
   end
 
   def test_noindent
     actual = compile_block("//noindent\nfoo\nbar\n\nfoo2\nbar2\n")
-    assert_equal %Q(<p class="noindent">foobar</p>\n<p>foo2bar2</p>\n), actual
+    expected = <<-EOS
+<p class="noindent">foobar</p>
+<p>foo2bar2</p>
+EOS
+    assert_equal expected, actual
   end
 
   def test_flushright
     actual = compile_block("//flushright{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(<p class="flushright">foobar</p>\n<p class="flushright">buz</p>\n), actual
+    expected = <<-EOS
+<p class="flushright">foobar</p>
+<p class="flushright">buz</p>
+EOS
+    assert_equal expected, actual
   end
 
   def test_centering
     actual = compile_block("//centering{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(<p class="center">foobar</p>\n<p class="center">buz</p>\n), actual
+    expected = <<-EOS
+<p class="center">foobar</p>
+<p class="center">buz</p>
+EOS
+    assert_equal expected, actual
   end
 
   def test_image
@@ -466,7 +501,15 @@ EOS
     end
 
     actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
-    assert_equal %Q(<div id="sampleimg" class="image">\n<img src="images/chap1-sampleimg.png" alt="sample photo" />\n<p class="caption">\n図1.1: sample photo\n</p>\n</div>\n), actual
+    expected = <<-EOS
+<div id="sampleimg" class="image">
+<img src="images/chap1-sampleimg.png" alt="sample photo" />
+<p class="caption">
+図1.1: sample photo
+</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric
@@ -477,7 +520,15 @@ EOS
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
-    assert_equal %Q(<div id="sampleimg" class="image">\n<img src="images/chap1-sampleimg.png" alt="sample photo" class="width-120per" />\n<p class="caption">\n図1.1: sample photo\n</p>\n</div>\n), actual
+    expected = <<-EOS
+<div id="sampleimg" class="image">
+<img src="images/chap1-sampleimg.png" alt="sample photo" class="width-120per" />
+<p class="caption">
+図1.1: sample photo
+</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric2
@@ -488,7 +539,15 @@ EOS
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
-    assert_equal %Q(<div id="sampleimg" class="image">\n<img src="images/chap1-sampleimg.png" alt="sample photo" class="width-120per sample" />\n<p class="caption">\n図1.1: sample photo\n</p>\n</div>\n), actual
+    expected = <<-EOS
+<div id="sampleimg" class="image">
+<img src="images/chap1-sampleimg.png" alt="sample photo" class="width-120per sample" />
+<p class="caption">
+図1.1: sample photo
+</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_tricky_id
@@ -499,7 +558,15 @@ EOS
     end
 
     actual = compile_block("//image[123 あ_;][sample photo]{\n//}\n")
-    assert_equal %Q(<div id="id_123-_E3_81_82___3B" class="image">\n<img src="images/chap1-123 あ_;.png" alt="sample photo" />\n<p class="caption">\n図1.1: sample photo\n</p>\n</div>\n), actual
+    expected = <<-EOS
+<div id="id_123-_E3_81_82___3B" class="image">
+<img src="images/chap1-123 あ_;.png" alt="sample photo" />
+<p class="caption">
+図1.1: sample photo
+</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage
@@ -510,7 +577,15 @@ EOS
     end
 
     actual = compile_block("//indepimage[sampleimg][sample photo]\n")
-    assert_equal %Q(<div id="sampleimg" class="image">\n<img src="images/chap1-sampleimg.png" alt="sample photo" />\n<p class="caption">\n図: sample photo\n</p>\n</div>\n), actual
+    expected = <<-EOS
+<div id="sampleimg" class="image">
+<img src="images/chap1-sampleimg.png" alt="sample photo" />
+<p class="caption">
+図: sample photo
+</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_without_caption
@@ -521,7 +596,12 @@ EOS
     end
 
     actual = compile_block("//indepimage[sampleimg]\n")
-    assert_equal %Q(<div id="sampleimg" class="image">\n<img src="images/chap1-sampleimg.png" alt="" />\n</div>\n), actual
+    expected = <<-EOS
+<div id="sampleimg" class="image">
+<img src="images/chap1-sampleimg.png" alt="" />
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric
@@ -532,7 +612,15 @@ EOS
     end
 
     actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
-    assert_equal %Q(<div id="sampleimg" class="image">\n<img src="images/chap1-sampleimg.png" alt="sample photo" class="width-120per" />\n<p class="caption">\n図: sample photo\n</p>\n</div>\n), actual
+    expected = <<-EOS
+<div id="sampleimg" class="image">
+<img src="images/chap1-sampleimg.png" alt="sample photo" class="width-120per" />
+<p class="caption">
+図: sample photo
+</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric2
@@ -543,7 +631,15 @@ EOS
     end
 
     actual = compile_block(%Q(//indepimage[sampleimg][sample photo][scale=1.2, html::class="sample",latex::ignore=params]\n))
-    assert_equal %Q(<div id="sampleimg" class="image">\n<img src="images/chap1-sampleimg.png" alt="sample photo" class="width-120per sample" />\n<p class="caption">\n図: sample photo\n</p>\n</div>\n), actual
+    expected = <<-EOS
+<div id="sampleimg" class="image">
+<img src="images/chap1-sampleimg.png" alt="sample photo" class="width-120per sample" />
+<p class="caption">
+図: sample photo
+</p>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_without_caption_but_with_metric
@@ -554,28 +650,74 @@ EOS
     end
 
     actual = compile_block("//indepimage[sampleimg][][scale=1.2]\n")
-    assert_equal %Q(<div id="sampleimg" class="image">\n<img src="images/chap1-sampleimg.png" alt="" class="width-120per" />\n</div>\n), actual
+    expected = <<-EOS
+<div id="sampleimg" class="image">
+<img src="images/chap1-sampleimg.png" alt="" class="width-120per" />
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist
     actual = compile_block(": foo\n  foo.\n  bar.\n")
-    assert_equal %Q(<dl>\n<dt>foo</dt>\n<dd>foo.bar.</dd>\n</dl>\n), actual
+    expected = <<-EOS
+<dl>
+<dt>foo</dt>
+<dd>foo.bar.</dd>
+</dl>
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_with_bracket
     actual = compile_block(": foo[bar]\n    foo.\n    bar.\n")
-    assert_equal %Q(<dl>\n<dt>foo[bar]</dt>\n<dd>foo.bar.</dd>\n</dl>\n), actual
+    expected = <<-EOS
+<dl>
+<dt>foo[bar]</dt>
+<dd>foo.bar.</dd>
+</dl>
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_with_comment
     source = ": title\n  body\n\#@ comment\n\#@ comment\n: title2\n  body2\n"
     actual = compile_block(source)
-    assert_equal %Q(<dl>\n<dt>title</dt>\n<dd>body</dd>\n<dt>title2</dt>\n<dd>body2</dd>\n</dl>\n), actual
+    expected = <<-EOS
+<dl>
+<dt>title</dt>
+<dd>body</dd>
+<dt>title2</dt>
+<dd>body2</dd>
+</dl>
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_beforeulol
     actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")
-    assert_equal %Q(<dl>\n<dt>foo</dt>\n<dd>foo.</dd>\n</dl>\n<p>para</p>\n<dl>\n<dt>foo</dt>\n<dd>foo.</dd>\n</dl>\n<ol>\n<li>bar</li>\n</ol>\n<dl>\n<dt>foo</dt>\n<dd>foo.</dd>\n</dl>\n<ul>\n<li>bar</li>\n</ul>\n), actual
+    expected = <<-EOS
+<dl>
+<dt>foo</dt>
+<dd>foo.</dd>
+</dl>
+<p>para</p>
+<dl>
+<dt>foo</dt>
+<dd>foo.</dd>
+</dl>
+<ol>
+<li>bar</li>
+</ol>
+<dl>
+<dt>foo</dt>
+<dd>foo.</dd>
+</dl>
+<ul>
+<li>bar</li>
+</ul>
+EOS
+    assert_equal expected, actual
   end
 
   def test_list
@@ -583,7 +725,17 @@ EOS
       Book::ListIndex::Item.new('samplelist', 1)
     end
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<div id="samplelist" class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list">test1\ntest1.5\n\ntest<i>2</i>\n</pre>\n</div>\n), actual
+    expected = <<-EOS
+<div id="samplelist" class="caption-code">
+<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>
+<pre class="list">test1
+test1.5
+
+test<i>2</i>
+</pre>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_list
@@ -706,7 +858,17 @@ end
     @book.config['highlight']['html'] = 'rouge'
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
 
-    assert_equal %Q(<div id="samplelist" class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list highlight">test1\ntest1.5\n\ntest&lt;i&gt;2&lt;/i&gt;\n</pre>\n</div>\n), actual
+    expected = <<-EOS
+<div id="samplelist" class="caption-code">
+<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>
+<pre class="list highlight">test1
+test1.5
+
+test&lt;i&gt;2&lt;/i&gt;
+</pre>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_list_rouge_lang
@@ -751,7 +913,18 @@ EOS
     @book.config['highlight']['html'] = 'rouge'
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_][]{\ndef foo(a1, a2=:test)\n  (1..3).times{|i| a.include?(:foo)}\n  return true\nend\n\n//}\n")
 
-    assert_equal %Q(<div id="samplelist" class="caption-code">\n<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>\n<pre class="list highlight">def foo(a1, a2=:test)\n  (1..3).times{|i| a.include?(:foo)}\n  return true\nend\n\n</pre>\n</div>\n), actual
+    expected = <<-EOS
+<div id="samplelist" class="caption-code">
+<p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>
+<pre class="list highlight">def foo(a1, a2=:test)
+  (1..3).times{|i| a.include?(:foo)}
+  return true
+end
+
+</pre>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum
@@ -990,12 +1163,28 @@ EOB
 
   def test_emlist_caption
     actual = compile_block("//emlist[cap1]{\nlineA\nlineB\n//}\n")
-    assert_equal %Q(<div class="emlist-code">\n<p class="caption">cap1</p>\n<pre class="emlist">lineA\nlineB\n</pre>\n</div>\n), actual
+    expected = <<-EOS
+<div class="emlist-code">
+<p class="caption">cap1</p>
+<pre class="emlist">lineA
+lineB
+</pre>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_with_tab
     actual = compile_block("//emlist{\n\tlineA\n\t\tlineB\n\tlineC\n//}\n")
-    assert_equal %Q(<div class="emlist-code">\n<pre class="emlist">        lineA\n                lineB\n        lineC\n</pre>\n</div>\n), actual
+    expected = <<-EOS
+<div class="emlist-code">
+<pre class="emlist">        lineA
+                lineB
+        lineC
+</pre>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlistnum
@@ -1042,12 +1231,27 @@ EOS
   def test_emlist_with_4tab
     @config['tabwidth'] = 4
     actual = compile_block("//emlist{\n\tlineA\n\t\tlineB\n\tlineC\n//}\n")
-    assert_equal %Q(<div class="emlist-code">\n<pre class="emlist">    lineA\n        lineB\n    lineC\n</pre>\n</div>\n), actual
+    expected = <<-EOS
+<div class="emlist-code">
+<pre class="emlist">    lineA
+        lineB
+    lineC
+</pre>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd
     actual = compile_block("//cmd{\nlineA\nlineB\n//}\n")
-    assert_equal %Q(<div class="cmd-code">\n<pre class="cmd">lineA\nlineB\n</pre>\n</div>\n), actual
+    expected = <<-EOS
+<div class="cmd-code">
+<pre class="cmd">lineA
+lineB
+</pre>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd_pygments
@@ -1059,12 +1263,27 @@ EOS
     @book.config['highlight'] = {}
     @book.config['highlight']['html'] = 'pygments'
     actual = compile_block("//cmd{\nlineA\nlineB\n//}\n")
-    assert_equal %Q(<div class="cmd-code">\n<pre class="cmd"><span style="color: #888888">lineA</span>\n<span style="color: #888888">lineB</span>\n</pre>\n</div>\n), actual
+    expected = <<-EOS
+<div class="cmd-code">
+<pre class="cmd"><span style="color: #888888">lineA</span>
+<span style="color: #888888">lineB</span>
+</pre>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd_caption
     actual = compile_block("//cmd[cap1]{\nlineA\nlineB\n//}\n")
-    assert_equal %Q(<div class="cmd-code">\n<p class="caption">cap1</p>\n<pre class="cmd">lineA\nlineB\n</pre>\n</div>\n), actual
+    expected = <<-EOS
+<div class="cmd-code">
+<p class="caption">cap1</p>
+<pre class="cmd">lineA
+lineB
+</pre>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_texequation
@@ -1153,7 +1372,12 @@ EOS
     end
 
     actual = compile_block("//bibpaper[samplebib][sample bib @<b>{bold}]{\na\nb\n//}\n")
-    assert_equal %Q(<div class="bibpaper">\n<a id="bib-samplebib">[1]</a> sample bib <b>bold</b>\n<p>ab</p></div>\n), actual
+    expected = <<-EOS
+<div class="bibpaper">
+<a id="bib-samplebib">[1]</a> sample bib <b>bold</b>
+<p>ab</p></div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_bibpaper_normalized
@@ -1162,7 +1386,12 @@ EOS
     end
 
     actual = compile_block("//bibpaper[sample=bib][sample bib @<b>{bold}]{\na\nb\n//}\n")
-    assert_equal %Q(<div class="bibpaper">\n<a id="bib-id_sample_3Dbib">[1]</a> sample bib <b>bold</b>\n<p>ab</p></div>\n), actual
+    expected = <<-EOS
+<div class="bibpaper">
+<a id="bib-id_sample_3Dbib">[1]</a> sample bib <b>bold</b>
+<p>ab</p></div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_bibpaper_with_anchor
@@ -1171,7 +1400,12 @@ EOS
     end
 
     actual = compile_block("//bibpaper[samplebib][sample bib @<href>{http://example.jp}]{\na\nb\n//}\n")
-    assert_equal %Q(<div class="bibpaper">\n<a id="bib-samplebib">[1]</a> sample bib <a href="http://example.jp" class="link">http://example.jp</a>\n<p>ab</p></div>\n), actual
+    expected = <<-EOS
+<div class="bibpaper">
+<a id="bib-samplebib">[1]</a> sample bib <a href="http://example.jp" class="link">http://example.jp</a>
+<p>ab</p></div>
+EOS
+    assert_equal expected, actual
   end
 
   def column_helper(review)
@@ -1279,7 +1513,12 @@ EOS
   * AAA
   * BBB
 EOS
-    expected = "<ul>\n<li>AAA</li>\n<li>BBB</li>\n</ul>\n"
+    expected = <<-EOS
+<ul>
+<li>AAA</li>
+<li>BBB</li>
+</ul>
+EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
@@ -1291,7 +1530,12 @@ EOS
   * BBB
     -BB
 EOS
-    expected = "<ul>\n<li>AAA-AA</li>\n<li>BBB-BB</li>\n</ul>\n"
+    expected = <<-EOS
+<ul>
+<li>AAA-AA</li>
+<li>BBB-BB</li>
+</ul>
+EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
@@ -1641,8 +1885,15 @@ EOS
 
   def test_table
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal %Q(<div class="table">\n<table>\n<tr><th>aaa</th><th>bbb</th></tr>\n<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>\n</table>\n</div>\n),
-                 actual
+    expected = <<-EOS
+<div class="table">
+<table>
+<tr><th>aaa</th><th>bbb</th></tr>
+<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>
+</table>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_table
@@ -1655,8 +1906,22 @@ EOS
 
   def test_emtable
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal %Q(<div class="table">\n<p class="caption">foo</p>\n<table>\n<tr><th>aaa</th><th>bbb</th></tr>\n<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>\n</table>\n</div>\n<div class="table">\n<table>\n<tr><th>aaa</th><th>bbb</th></tr>\n<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>\n</table>\n</div>\n),
-                 actual
+    expected = <<-EOS
+<div class="table">
+<p class="caption">foo</p>
+<table>
+<tr><th>aaa</th><th>bbb</th></tr>
+<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>
+</table>
+</div>
+<div class="table">
+<table>
+<tr><th>aaa</th><th>bbb</th></tr>
+<tr><td>ccc</td><td>ddd&lt;&gt;&amp;</td></tr>
+</table>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_imgtable
@@ -1667,41 +1932,118 @@ EOS
     end
 
     actual = compile_block("//imgtable[sampleimg][test for imgtable]{\n//}\n")
-    expected = %Q(<div id="sampleimg" class="imgtable image">\n<p class="caption">表1.1: test for imgtable</p>\n<img src="images/chap1-sampleimg.png" alt="test for imgtable" />\n</div>\n)
+    expected = <<-EOS
+<div id="sampleimg" class="imgtable image">
+<p class="caption">表1.1: test for imgtable</p>
+<img src="images/chap1-sampleimg.png" alt="test for imgtable" />
+</div>
+EOS
     assert_equal expected, actual
   end
 
   def test_major_blocks
     actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
-    expected = %Q(<div class="note">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="note">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    expected = <<-EOS
+<div class="note">
+<p>A</p>
+<p>B</p>
+</div>
+<div class="note">
+<p class="caption">caption</p>
+<p>A</p>
+</div>
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
-    expected = %Q(<div class="memo">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="memo">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    expected = <<-EOS
+<div class="memo">
+<p>A</p>
+<p>B</p>
+</div>
+<div class="memo">
+<p class="caption">caption</p>
+<p>A</p>
+</div>
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
-    expected = %Q(<div class="info">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="info">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    expected = <<-EOS
+<div class="info">
+<p>A</p>
+<p>B</p>
+</div>
+<div class="info">
+<p class="caption">caption</p>
+<p>A</p>
+</div>
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
-    expected = %Q(<div class="important">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="important">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    expected = <<-EOS
+<div class="important">
+<p>A</p>
+<p>B</p>
+</div>
+<div class="important">
+<p class="caption">caption</p>
+<p>A</p>
+</div>
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
-    expected = %Q(<div class="caution">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="caution">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    expected = <<-EOS
+<div class="caution">
+<p>A</p>
+<p>B</p>
+</div>
+<div class="caution">
+<p class="caption">caption</p>
+<p>A</p>
+</div>
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
-    expected = %Q(<div class="notice">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="notice">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    expected = <<-EOS
+<div class="notice">
+<p>A</p>
+<p>B</p>
+</div>
+<div class="notice">
+<p class="caption">caption</p>
+<p>A</p>
+</div>
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
-    expected = %Q(<div class="warning">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="warning">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    expected = <<-EOS
+<div class="warning">
+<p>A</p>
+<p>B</p>
+</div>
+<div class="warning">
+<p class="caption">caption</p>
+<p>A</p>
+</div>
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
-    expected = %Q(<div class="tip">\n<p>A</p>\n<p>B</p>\n</div>\n<div class="tip">\n<p class="caption">caption</p>\n<p>A</p>\n</div>\n)
+    expected = <<-EOS
+<div class="tip">
+<p>A</p>
+<p>B</p>
+</div>
+<div class="tip">
+<p class="caption">caption</p>
+<p>A</p>
+</div>
+EOS
     assert_equal expected, actual
   end
 

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -266,18 +266,39 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
   def test_emlist_listinfo
     @config['listinfo'] = true
     actual = compile_block("//emlist[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<list type='emlist'><caption aid:pstyle='emlist-title'>this is <b>test</b>&lt;&amp;&gt;_</caption><pre><listinfo line="1" begin="1">test1\n</listinfo><listinfo line="2">test1.5\n</listinfo><listinfo line="3">\n</listinfo><listinfo line="4" end="4">test<i>2</i>\n</listinfo></pre></list>), actual
+    expected = <<-EOS.chomp
+<list type='emlist'><caption aid:pstyle='emlist-title'>this is <b>test</b>&lt;&amp;&gt;_</caption><pre><listinfo line="1" begin="1">test1
+</listinfo><listinfo line="2">test1.5
+</listinfo><listinfo line="3">
+</listinfo><listinfo line="4" end="4">test<i>2</i>
+</listinfo></pre></list>
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_with_tab
     actual = compile_block("//emlist[this is @<b>{test}<&>_]{\n\ttest1\n\t\ttest1.5\n\n\ttest@<i>{2}\n//}\n")
-    assert_equal %Q(<list type='emlist'><caption aid:pstyle='emlist-title'>this is <b>test</b>&lt;&amp;&gt;_</caption><pre>        test1\n                test1.5\n\n        test<i>2</i>\n</pre></list>), actual
+    expected = <<-EOS.chomp
+<list type='emlist'><caption aid:pstyle='emlist-title'>this is <b>test</b>&lt;&amp;&gt;_</caption><pre>        test1
+                test1.5
+
+        test<i>2</i>
+</pre></list>
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_with_4tab
     @config['tabwidth'] = 4
     actual = compile_block("//emlist[this is @<b>{test}<&>_]{\n\ttest1\n\t\ttest1.5\n\n\ttest@<i>{2}\n//}\n")
-    assert_equal %Q(<list type='emlist'><caption aid:pstyle='emlist-title'>this is <b>test</b>&lt;&amp;&gt;_</caption><pre>    test1\n        test1.5\n\n    test<i>2</i>\n</pre></list>), actual
+    expected = <<-EOS.chomp
+<list type='emlist'><caption aid:pstyle='emlist-title'>this is <b>test</b>&lt;&amp;&gt;_</caption><pre>    test1
+        test1.5
+
+    test<i>2</i>
+</pre></list>
+EOS
+    assert_equal expected, actual
   end
 
   def test_list
@@ -285,7 +306,14 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
       Book::ListIndex::Item.new('samplelist', 1)
     end
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<codelist><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption><pre>test1\ntest1.5\n\ntest<i>2</i>\n</pre></codelist>), actual
+    expected = <<-EOS.chomp
+<codelist><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption><pre>test1
+test1.5
+
+test<i>2</i>
+</pre></codelist>
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum
@@ -293,7 +321,14 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
       Book::ListIndex::Item.new('samplelist', 1)
     end
     actual = compile_block("//listnum[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<codelist><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption><pre><span type='lineno'> 1: </span>test1\n<span type='lineno'> 2: </span>test1.5\n<span type='lineno'> 3: </span>\n<span type='lineno'> 4: </span>test<i>2</i>\n</pre></codelist>), actual
+    expected = <<-EOS.chomp
+<codelist><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption><pre><span type='lineno'> 1: </span>test1
+<span type='lineno'> 2: </span>test1.5
+<span type='lineno'> 3: </span>
+<span type='lineno'> 4: </span>test<i>2</i>
+</pre></codelist>
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum_linenum
@@ -301,7 +336,14 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
       Book::ListIndex::Item.new('samplelist', 1)
     end
     actual = compile_block("//firstlinenum[100]\n//listnum[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<codelist><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption><pre><span type='lineno'>100: </span>test1\n<span type='lineno'>101: </span>test1.5\n<span type='lineno'>102: </span>\n<span type='lineno'>103: </span>test<i>2</i>\n</pre></codelist>), actual
+    expected = <<-EOS.chomp
+<codelist><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption><pre><span type='lineno'>100: </span>test1
+<span type='lineno'>101: </span>test1.5
+<span type='lineno'>102: </span>
+<span type='lineno'>103: </span>test<i>2</i>
+</pre></codelist>
+EOS
+    assert_equal expected, actual
   end
 
   def test_list_listinfo
@@ -310,25 +352,53 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     end
     @config['listinfo'] = true
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<codelist><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption><pre><listinfo line="1" begin="1">test1\n</listinfo><listinfo line="2">test1.5\n</listinfo><listinfo line="3">\n</listinfo><listinfo line="4" end="4">test<i>2</i>\n</listinfo></pre></codelist>), actual
+    expected = <<-EOS.chomp
+<codelist><caption>リスト1.1　this is <b>test</b>&lt;&amp;&gt;_</caption><pre><listinfo line="1" begin="1">test1
+</listinfo><listinfo line="2">test1.5
+</listinfo><listinfo line="3">
+</listinfo><listinfo line="4" end="4">test<i>2</i>
+</listinfo></pre></codelist>
+EOS
+    assert_equal expected, actual
   end
 
   def test_insn
     @config['listinfo'] = true
     actual = compile_block("//insn[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<insn><floattitle type="insn">this is <b>test</b>&lt;&amp;&gt;_</floattitle><listinfo line="1" begin="1">test1\n</listinfo><listinfo line="2">test1.5\n</listinfo><listinfo line="3">\n</listinfo><listinfo line="4" end="4">test<i>2</i>\n</listinfo></insn>), actual
+    expected = <<-EOS.chomp
+<insn><floattitle type="insn">this is <b>test</b>&lt;&amp;&gt;_</floattitle><listinfo line="1" begin="1">test1
+</listinfo><listinfo line="2">test1.5
+</listinfo><listinfo line="3">
+</listinfo><listinfo line="4" end="4">test<i>2</i>
+</listinfo></insn>
+EOS
+    assert_equal expected, actual
   end
 
   def test_box
     @config['listinfo'] = true
     actual = compile_block("//box[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<box><caption aid:pstyle="box-title">this is <b>test</b>&lt;&amp;&gt;_</caption><listinfo line="1" begin="1">test1\n</listinfo><listinfo line="2">test1.5\n</listinfo><listinfo line="3">\n</listinfo><listinfo line="4" end="4">test<i>2</i>\n</listinfo></box>), actual
+    expected = <<-EOS.chomp
+<box><caption aid:pstyle="box-title">this is <b>test</b>&lt;&amp;&gt;_</caption><listinfo line="1" begin="1">test1
+</listinfo><listinfo line="2">test1.5
+</listinfo><listinfo line="3">
+</listinfo><listinfo line="4" end="4">test<i>2</i>
+</listinfo></box>
+EOS
+    assert_equal expected, actual
   end
 
   def test_box_non_listinfo
     @config['listinfo'] = nil
     actual = compile_block("//box[this is @<b>{test}<&>_]{\ntest1\ntest1.5\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<box><caption aid:pstyle="box-title">this is <b>test</b>&lt;&amp;&gt;_</caption>test1\ntest1.5\n\ntest<i>2</i>\n</box>), actual
+    expected = <<-EOS.chomp
+<box><caption aid:pstyle="box-title">this is <b>test</b>&lt;&amp;&gt;_</caption>test1
+test1.5
+
+test<i>2</i>
+</box>
+EOS
+    assert_equal expected, actual
   end
 
   def test_flushright

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -39,34 +39,62 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def test_headline_level1
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q(\\chapter{this is test.}\n\\label{chap:chap1}\n), actual
+    expected = <<-EOS
+\\chapter{this is test.}
+\\label{chap:chap1}
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level1_without_secno
     @config['secnolevel'] = 0
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q(\\chapter*{this is test.}\n\\addcontentsline{toc}{chapter}{this is test.}\n\\label{chap:chap1}\n), actual
+    expected = <<-EOS
+\\chapter*{this is test.}
+\\addcontentsline{toc}{chapter}{this is test.}
+\\label{chap:chap1}
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level1_with_inlinetag
     actual = compile_block(%Q(={test} this @<b>{is} test.<&"_>\n))
-    assert_equal %Q(\\chapter{this \\reviewbold{is} test.\\textless{}\\&"\\textunderscore{}\\textgreater{}}\n\\label{chap:chap1}\n), actual
+    expected = <<-EOS
+\\chapter{this \\reviewbold{is} test.\\textless{}\\&"\\textunderscore{}\\textgreater{}}
+\\label{chap:chap1}
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level2
     actual = compile_block("=={test} this is test.\n")
-    assert_equal %Q(\\section{this is test.}\n\\label{sec:1-1}\n\\label{test}\n), actual
+    expected = <<-EOS
+\\section{this is test.}
+\\label{sec:1-1}
+\\label{test}
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level3
     actual = compile_block("==={test} this is test.\n")
-    assert_equal %Q(\\subsection*{this is test.}\n\\label{sec:1-0-1}\n\\label{test}\n), actual
+    expected = <<-EOS
+\\subsection*{this is test.}
+\\label{sec:1-0-1}
+\\label{test}
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level3_with_secno
     @config['secnolevel'] = 3
     actual = compile_block("==={test} this is test.\n")
-    assert_equal %Q(\\subsection{this is test.}\n\\label{sec:1-0-1}\n\\label{test}\n), actual
+    expected = <<-EOS
+\\subsection{this is test.}
+\\label{sec:1-0-1}
+\\label{test}
+EOS
+    assert_equal expected, actual
   end
 
   def test_label
@@ -280,46 +308,137 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def test_dlist
     actual = compile_block(": foo\n  foo.\n  bar.\n")
-    assert_equal %Q(\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\nbar.\n\\end{description}\n), actual
+    expected = <<-EOS
+
+\\begin{description}
+\\item[foo] \\mbox{} \\\\
+foo.
+bar.
+\\end{description}
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_with_bracket
     actual = compile_block(": foo[bar]\n    foo.\n    bar.\n")
-    assert_equal %Q(\n\\begin{description}\n\\item[foo\\lbrack{}bar\\rbrack{}] \\mbox{} \\\\\nfoo.\nbar.\n\\end{description}\n), actual
+    expected = <<-EOS
+
+\\begin{description}
+\\item[foo\\lbrack{}bar\\rbrack{}] \\mbox{} \\\\
+foo.
+bar.
+\\end{description}
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_beforeulol
     actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")
-    assert_equal %Q(\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\n\\end{description}\n\npara\n\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\n\\end{description}\n\n\\begin{enumerate}\n\\item bar\n\\end{enumerate}\n\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\n\\end{description}\n\n\\begin{itemize}\n\\item bar\n\\end{itemize}\n), actual
+    expected = <<-EOS
+
+\\begin{description}
+\\item[foo] \\mbox{} \\\\
+foo.
+\\end{description}
+
+para
+
+\\begin{description}
+\\item[foo] \\mbox{} \\\\
+foo.
+\\end{description}
+
+\\begin{enumerate}
+\\item bar
+\\end{enumerate}
+
+\\begin{description}
+\\item[foo] \\mbox{} \\\\
+foo.
+\\end{description}
+
+\\begin{itemize}
+\\item bar
+\\end{itemize}
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd
     actual = compile_block("//cmd{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewlistblock}\n\\begin{reviewcmd}\nfoo\nbar\n\nbuz\n\\end{reviewcmd}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewlistblock}
+\\begin{reviewcmd}
+foo
+bar
+
+buz
+\\end{reviewcmd}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd_caption
     actual = compile_block("//cmd[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewlistblock}\n\\reviewcmdcaption{cap1}\n\\begin{reviewcmd}\nfoo\nbar\n\nbuz\n\\end{reviewcmd}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewlistblock}
+\\reviewcmdcaption{cap1}
+\\begin{reviewcmd}
+foo
+bar
+
+buz
+\\end{reviewcmd}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd_lst
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//cmd{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\begin{reviewcmdlst}[language={}]\nfoo\nbar\n\nbuz\n\\end{reviewcmdlst}\n), actual
+    expected = <<-EOS
+\\begin{reviewcmdlst}[language={}]
+foo
+bar
+
+buz
+\\end{reviewcmdlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist
     actual = compile_block("//emlist{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewlistblock}\n\\begin{reviewemlist}\nfoo\nbar\n\nbuz\n\\end{reviewemlist}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewlistblock}
+\\begin{reviewemlist}
+foo
+bar
+
+buz
+\\end{reviewemlist}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_lst
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//emlist[][sql]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
-    assert_equal %Q(\n\\begin{reviewemlistlst}[language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewemlistlst}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewemlistlst}[language={sql}]
+SELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'
+\\end{reviewemlistlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_lst_without_lang
@@ -327,45 +446,124 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     @book.config['highlight']['latex'] = 'listings'
     @book.config['highlight']['lang'] = 'sql'
     actual = compile_block("//emlist[]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
-    assert_equal %Q(\n\\begin{reviewemlistlst}[language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewemlistlst}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewemlistlst}[language={sql}]
+SELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'
+\\end{reviewemlistlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_caption
     actual = compile_block("//emlist[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewlistblock}\n\\reviewemlistcaption{cap1}\n\\begin{reviewemlist}\nfoo\nbar\n\nbuz\n\\end{reviewemlist}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewlistblock}
+\\reviewemlistcaption{cap1}
+\\begin{reviewemlist}
+foo
+bar
+
+buz
+\\end{reviewemlist}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_empty_caption
     actual = compile_block("//emlist[]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewlistblock}\n\\begin{reviewemlist}\nfoo\nbar\n\nbuz\n\\end{reviewemlist}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewlistblock}
+\\begin{reviewemlist}
+foo
+bar
+
+buz
+\\end{reviewemlist}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_with_tab
     actual = compile_block("//emlist{\n\tfoo\n\t\tbar\n\n\tbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewlistblock}\n\\begin{reviewemlist}\n        foo\n                bar\n\n        buz\n\\end{reviewemlist}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewlistblock}
+\\begin{reviewemlist}
+        foo
+                bar
+
+        buz
+\\end{reviewemlist}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_with_tab4
     @config['tabwidth'] = 4
     actual = compile_block("//emlist{\n\tfoo\n\t\tbar\n\n\tbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewlistblock}\n\\begin{reviewemlist}\n    foo\n        bar\n\n    buz\n\\end{reviewemlist}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewlistblock}
+\\begin{reviewemlist}
+    foo
+        bar
+
+    buz
+\\end{reviewemlist}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlistnum_caption
     actual = compile_block("//emlistnum[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewlistblock}\n\\reviewemlistcaption{cap1}\n\\begin{reviewemlist}\n 1: foo\n 2: bar\n 3: \n 4: buz\n\\end{reviewemlist}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewlistblock}
+\\reviewemlistcaption{cap1}
+\\begin{reviewemlist}
+ 1: foo
+ 2: bar
+ 3: 
+ 4: buz
+\\end{reviewemlist}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_list
     actual = compile_block("//list[id1][cap1]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\begin{reviewlistblock}\n\\reviewlistcaption{リスト1.1: cap1}\n\\begin{reviewlist}\nfoo\nbar\n\nbuz\n\\end{reviewlist}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistblock}
+\\reviewlistcaption{リスト1.1: cap1}
+\\begin{reviewlist}
+foo
+bar
+
+buz
+\\end{reviewlist}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_list_lst
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//list[id1][cap1][sql]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
-    assert_equal %Q(\\begin{reviewlistlst}[caption={cap1},language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewlistlst}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistlst}[caption={cap1},language={sql}]
+SELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'
+\\end{reviewlistlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_list_lst_with_lang
@@ -373,78 +571,206 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     @book.config['highlight']['latex'] = 'listings'
     @book.config['highlight']['lang'] = 'sql'
     actual = compile_block("//list[id1][cap1]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
-    assert_equal %Q(\\begin{reviewlistlst}[caption={cap1},language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewlistlst}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistlst}[caption={cap1},language={sql}]
+SELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'
+\\end{reviewlistlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum
     actual = compile_block("//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
-    assert_equal %Q(\\begin{reviewlistblock}\n\\reviewlistcaption{リスト1.1: ruby}\n\\begin{reviewlist}\n 1: class Foo\n 2:   def foo\n 3:     bar\n 4: \n 5:     buz\n 6:   end\n 7: end\n\\end{reviewlist}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistblock}
+\\reviewlistcaption{リスト1.1: ruby}
+\\begin{reviewlist}
+ 1: class Foo
+ 2:   def foo
+ 3:     bar
+ 4: 
+ 5:     buz
+ 6:   end
+ 7: end
+\\end{reviewlist}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum_linenum
     actual = compile_block("//firstlinenum[100]\n//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
-    assert_equal %Q(\\begin{reviewlistblock}\n\\reviewlistcaption{リスト1.1: ruby}\n\\begin{reviewlist}\n100: class Foo\n101:   def foo\n102:     bar\n103: \n104:     buz\n105:   end\n106: end\n\\end{reviewlist}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistblock}
+\\reviewlistcaption{リスト1.1: ruby}
+\\begin{reviewlist}
+100: class Foo
+101:   def foo
+102:     bar
+103: 
+104:     buz
+105:   end
+106: end
+\\end{reviewlist}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum_lst
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
-    assert_equal %Q(\\begin{reviewlistnumlst}[caption={ruby},language={}]\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n\\end{reviewlistnumlst}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistnumlst}[caption={ruby},language={}]
+class Foo
+  def foo
+    bar
+
+    buz
+  end
+end
+\\end{reviewlistnumlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum_lst_linenum
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//firstlinenum[100]\n//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
-    assert_equal %Q(\\begin{reviewlistnumlst}[caption={ruby},language={},firstnumber=100]\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n\\end{reviewlistnumlst}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistnumlst}[caption={ruby},language={},firstnumber=100]
+class Foo
+  def foo
+    bar
+
+    buz
+  end
+end
+\\end{reviewlistnumlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_source
     actual = compile_block("//source[foo/bar/test.rb]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\begin{reviewlistblock}\n\\reviewsourcecaption{foo/bar/test.rb}\n\\begin{reviewsource}\nfoo\nbar\n\nbuz\n\\end{reviewsource}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistblock}
+\\reviewsourcecaption{foo/bar/test.rb}
+\\begin{reviewsource}
+foo
+bar
+
+buz
+\\end{reviewsource}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_source_empty_caption
     actual = compile_block("//source[]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\begin{reviewlistblock}\n\\begin{reviewsource}\nfoo\nbar\n\nbuz\n\\end{reviewsource}\n\\end{reviewlistblock}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistblock}
+\\begin{reviewsource}
+foo
+bar
+
+buz
+\\end{reviewsource}
+\\end{reviewlistblock}
+EOS
+    assert_equal expected, actual
   end
 
   def test_source_lst
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//source[foo/bar/test.rb]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\begin{reviewsourcelst}[title={foo/bar/test.rb},language={}]\nfoo\nbar\n\nbuz\n\\end{reviewsourcelst}\n), actual
+    expected = <<-EOS
+\\begin{reviewsourcelst}[title={foo/bar/test.rb},language={}]
+foo
+bar
+
+buz
+\\end{reviewsourcelst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_quote
     actual = compile_block("//quote{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{quote}\nfoobar\n\nbuz\n\\end{quote}\n), actual
+    expected = <<-EOS
+
+\\begin{quote}
+foobar
+
+buz
+\\end{quote}
+EOS
+    assert_equal expected, actual
   end
 
   def test_memo
     actual = compile_block("//memo[this is @<b>{test}<&>_]{\ntest1\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(\\begin{reviewmemo}[this is \\reviewbold{test}\\textless{}\\&\\textgreater{}\\textunderscore{}]\ntest1\n\ntest\\reviewit{2}\n\\end{reviewmemo}\n), actual
+    expected = <<-EOS
+\\begin{reviewmemo}[this is \\reviewbold{test}\\textless{}\\&\\textgreater{}\\textunderscore{}]
+test1
+
+test\\reviewit{2}
+\\end{reviewmemo}
+EOS
+    assert_equal expected, actual
   end
 
   def test_flushright
     actual = compile_block("//flushright{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{flushright}\nfoobar\n\nbuz\n\\end{flushright}\n), actual
+    expected = <<-EOS
+
+\\begin{flushright}
+foobar
+
+buz
+\\end{flushright}
+EOS
+    assert_equal expected, actual
   end
 
   def test_centering
     actual = compile_block("//centering{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{center}\nfoobar\n\nbuz\n\\end{center}\n), actual
+    expected = <<-EOS
+
+\\begin{center}
+foobar
+
+buz
+\\end{center}
+EOS
+    assert_equal expected, actual
   end
 
   def test_blankline
     actual = compile_block("//blankline\nfoo\n")
-    assert_equal %Q(\\vspace*{\\baselineskip}\n\nfoo\n), actual
+    expected = <<-EOS
+\\vspace*{\\baselineskip}
+
+foo
+EOS
+    assert_equal expected, actual
   end
 
   def test_noindent
     actual = compile_block("//noindent\nfoo\nbar\n\nfoo2\nbar2\n")
-    assert_equal %Q(\\noindent\nfoo\nbar\n\nfoo2\nbar2\n), actual
+    expected = <<-EOS
+\\noindent
+foo
+bar
+
+foo2
+bar2
+EOS
+    assert_equal expected, actual
   end
 
   def test_image
@@ -455,7 +781,14 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\reviewimagecaption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric
@@ -466,7 +799,14 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}
+\\reviewimagecaption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric_width
@@ -478,7 +818,14 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
     @config['image_scale2width'] = true
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}
+\\reviewimagecaption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric2
@@ -489,7 +836,14 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}
+\\reviewimagecaption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric2_width
@@ -501,7 +855,14 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
     @config['image_scale2width'] = true
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=1.2\\maxwidth,ignore=params]{./images/chap1-sampleimg.png}\n\\reviewimagecaption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[width=1.2\\maxwidth,ignore=params]{./images/chap1-sampleimg.png}
+\\reviewimagecaption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage
@@ -512,7 +873,13 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//indepimage[sampleimg][sample photo]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\reviewindepimagecaption{図: sample photo}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_without_caption
@@ -524,7 +891,12 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
     # FIXME: indepimage's caption should not be with a counter.
     actual = compile_block("//indepimage[sampleimg]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric
@@ -535,7 +907,13 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}
+\\reviewindepimagecaption{図: sample photo}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric_width
@@ -547,7 +925,13 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
     @config['image_scale2width'] = true
     actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}
+\\reviewindepimagecaption{図: sample photo}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric2
@@ -558,7 +942,13 @@ class LATEXBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block(%Q(//indepimage[sampleimg][sample photo][scale=1.2, html::class="sample",latex::ignore=params]\n))
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}
+\\reviewindepimagecaption{図: sample photo}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_without_caption_but_with_metric
@@ -570,30 +960,71 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
     # FIXME: indepimage's caption should not be with a counter.
     actual = compile_block("//indepimage[sampleimg][][scale=1.2]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_table
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal "\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
-                 actual
+    expected = <<-EOS
+\\begin{reviewtable}{|l|l|}
+\\hline
+\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline
+ccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
   end
 
   def test_customize_cellwidth
     actual = compile_block("//tsize[2,3,5]\n//table{\nA\tB\tC\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}
+\\hline
+\\reviewth{A} & B & C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
 
     actual = compile_block("//tsize[|latex,html|2,3,5]\n//table{\nA\tB\tC\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}
+\\hline
+\\reviewth{A} & B & C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
 
     actual = compile_block("//tsize[|html|2,3,5]\n//table{\nA\tB\tC\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|l|l|l|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|l|l|l|}
+\\hline
+\\reviewth{A} & B & C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
 
     actual = compile_block("//tsize[|latex|2,3,5]\n//table{\nA\tB\tC\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}
+\\hline
+\\reviewth{A} & B & C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
 
     actual = compile_block("//tsize[|latex||p{5mm}|cr|]\n//table{\nA\tB\tC\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|p{5mm}|cr|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|p{5mm}|cr|}
+\\hline
+\\reviewth{A} & B & C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
   end
 
   def test_separate_tsize
@@ -609,16 +1040,47 @@ class LATEXBuidlerTest < Test::Unit::TestCase
 
   def test_break_tablecell
     actual = compile_block("//tsize[|latex||p{10mm}|cp{10mm}|]\n//table{\nA@<br>{}A\tB@<br>{}B\tC@<br>{}C\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|p{10mm}|cp{10mm}|}\n\\hline\n\\reviewth{A\\newline{}A} & \\shortstack[l]{B\\\\\nB} & C\\newline{}C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|p{10mm}|cp{10mm}|}
+\\hline
+\\reviewth{A\\newline{}A} & \\shortstack[l]{B\\\\
+B} & C\\newline{}C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
 
     actual = compile_block("//tsize[|latex||p{10mm}|cp{10mm}|]\n//table{\n1@<br>{}1\t2@<br>{}2\t3\n------------\nA@<br>{}A\tB@<br>{}B\tC@<br>{}C\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|p{10mm}|cp{10mm}|}\n\\hline\n\\reviewth{1\\newline{}1} & \\reviewth{\\shortstack[l]{2\\\\\n2}} & \\reviewth{3} \\\\  \\hline\nA\\newline{}A & \\shortstack[l]{B\\\\\nB} & C\\newline{}C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|p{10mm}|cp{10mm}|}
+\\hline
+\\reviewth{1\\newline{}1} & \\reviewth{\\shortstack[l]{2\\\\
+2}} & \\reviewth{3} \\\\  \\hline
+A\\newline{}A & \\shortstack[l]{B\\\\
+B} & C\\newline{}C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emtable
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal "\\begin{table}%%\n\\reviewtablecaption*{foo}\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n\\end{table}\n\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
-                 actual
+    expected = <<-EOS
+\\begin{table}%%
+\\reviewtablecaption*{foo}
+\\begin{reviewtable}{|l|l|}
+\\hline
+\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline
+ccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline
+\\end{reviewtable}
+\\end{table}
+
+\\begin{reviewtable}{|l|l|}
+\\hline
+\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline
+ccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
   end
 
   def test_imgtable
@@ -656,7 +1118,14 @@ EOS
     end
 
     actual = compile_block("//bibpaper[samplebib][sample bib @<b>{bold}]{\na\nb\n//}\n")
-    assert_equal %Q([1] sample bib \\reviewbold{bold}\n\\label{bib:samplebib}\n\nab\n\n), actual
+    expected = <<-EOS
+[1] sample bib \\reviewbold{bold}
+\\label{bib:samplebib}
+
+ab
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_bibpaper_without_body
@@ -665,7 +1134,12 @@ EOS
     end
 
     actual = compile_block("//bibpaper[samplebib][sample bib]\n")
-    assert_equal %Q([1] sample bib\n\\label{bib:samplebib}\n\n), actual
+    expected = <<-EOS
+[1] sample bib
+\\label{bib:samplebib}
+
+EOS
+    assert_equal expected, actual
   end
 
   def column_helper(review)
@@ -878,35 +1352,107 @@ EOS
 
   def test_major_blocks
     actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewnote}\nA\n\nB\n\\end{reviewnote}\n\\begin{reviewnote}[caption]\nA\n\\end{reviewnote}\n)
+    expected = <<-EOS
+\\begin{reviewnote}
+A
+
+B
+\\end{reviewnote}
+\\begin{reviewnote}[caption]
+A
+\\end{reviewnote}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewmemo}\nA\n\nB\n\\end{reviewmemo}\n\\begin{reviewmemo}[caption]\nA\n\\end{reviewmemo}\n)
+    expected = <<-EOS
+\\begin{reviewmemo}
+A
+
+B
+\\end{reviewmemo}
+\\begin{reviewmemo}[caption]
+A
+\\end{reviewmemo}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewinfo}\nA\n\nB\n\\end{reviewinfo}\n\\begin{reviewinfo}[caption]\nA\n\\end{reviewinfo}\n)
+    expected = <<-EOS
+\\begin{reviewinfo}
+A
+
+B
+\\end{reviewinfo}
+\\begin{reviewinfo}[caption]
+A
+\\end{reviewinfo}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewimportant}\nA\n\nB\n\\end{reviewimportant}\n\\begin{reviewimportant}[caption]\nA\n\\end{reviewimportant}\n)
+    expected = <<-EOS
+\\begin{reviewimportant}
+A
+
+B
+\\end{reviewimportant}
+\\begin{reviewimportant}[caption]
+A
+\\end{reviewimportant}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewcaution}\nA\n\nB\n\\end{reviewcaution}\n\\begin{reviewcaution}[caption]\nA\n\\end{reviewcaution}\n)
+    expected = <<-EOS
+\\begin{reviewcaution}
+A
+
+B
+\\end{reviewcaution}
+\\begin{reviewcaution}[caption]
+A
+\\end{reviewcaution}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewnotice}\nA\n\nB\n\\end{reviewnotice}\n\\begin{reviewnotice}[caption]\nA\n\\end{reviewnotice}\n)
+    expected = <<-EOS
+\\begin{reviewnotice}
+A
+
+B
+\\end{reviewnotice}
+\\begin{reviewnotice}[caption]
+A
+\\end{reviewnotice}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewwarning}\nA\n\nB\n\\end{reviewwarning}\n\\begin{reviewwarning}[caption]\nA\n\\end{reviewwarning}\n)
+    expected = <<-EOS
+\\begin{reviewwarning}
+A
+
+B
+\\end{reviewwarning}
+\\begin{reviewwarning}[caption]
+A
+\\end{reviewwarning}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewtip}\nA\n\nB\n\\end{reviewtip}\n\\begin{reviewtip}[caption]\nA\n\\end{reviewtip}\n)
+    expected = <<-EOS
+\\begin{reviewtip}
+A
+
+B
+\\end{reviewtip}
+\\begin{reviewtip}[caption]
+A
+\\end{reviewtip}
+EOS
     assert_equal expected, actual
   end
 

--- a/test/test_latexbuilder_v2.rb
+++ b/test/test_latexbuilder_v2.rb
@@ -29,34 +29,62 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
 
   def test_headline_level1
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q(\\chapter{this is test.}\n\\label{chap:chap1}\n), actual
+    expected = <<-EOS
+\\chapter{this is test.}
+\\label{chap:chap1}
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level1_without_secno
     @config['secnolevel'] = 0
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q(\\chapter*{this is test.}\n\\addcontentsline{toc}{chapter}{this is test.}\n\\label{chap:chap1}\n), actual
+    expected = <<-EOS
+\\chapter*{this is test.}
+\\addcontentsline{toc}{chapter}{this is test.}
+\\label{chap:chap1}
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level1_with_inlinetag
     actual = compile_block(%Q(={test} this @<b>{is} test.<&"_>\n))
-    assert_equal %Q(\\chapter{this \\textbf{is} test.\\textless{}\\&"\\textunderscore{}\\textgreater{}}\n\\label{chap:chap1}\n), actual
+    expected = <<-EOS
+\\chapter{this \\textbf{is} test.\\textless{}\\&"\\textunderscore{}\\textgreater{}}
+\\label{chap:chap1}
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level2
     actual = compile_block("=={test} this is test.\n")
-    assert_equal %Q(\\section{this is test.}\n\\label{sec:1-1}\n\\label{test}\n), actual
+    expected = <<-EOS
+\\section{this is test.}
+\\label{sec:1-1}
+\\label{test}
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level3
     actual = compile_block("==={test} this is test.\n")
-    assert_equal %Q(\\subsection*{this is test.}\n\\label{sec:1-0-1}\n\\label{test}\n), actual
+    expected = <<-EOS
+\\subsection*{this is test.}
+\\label{sec:1-0-1}
+\\label{test}
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level3_with_secno
     @config['secnolevel'] = 3
     actual = compile_block("==={test} this is test.\n")
-    assert_equal %Q(\\subsection{this is test.}\n\\label{sec:1-0-1}\n\\label{test}\n), actual
+    expected = <<-EOS
+\\subsection{this is test.}
+\\label{sec:1-0-1}
+\\label{test}
+EOS
+    assert_equal expected, actual
   end
 
   def test_label
@@ -249,46 +277,131 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
 
   def test_dlist
     actual = compile_block(": foo\n  foo.\n  bar.\n")
-    assert_equal %Q(\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\nbar.\n\\end{description}\n), actual
+    expected = <<-EOS
+
+\\begin{description}
+\\item[foo] \\mbox{} \\\\
+foo.
+bar.
+\\end{description}
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_with_bracket
     actual = compile_block(": foo[bar]\n    foo.\n    bar.\n")
-    assert_equal %Q(\n\\begin{description}\n\\item[foo\\lbrack{}bar\\rbrack{}] \\mbox{} \\\\\nfoo.\nbar.\n\\end{description}\n), actual
+    expected = <<-EOS
+
+\\begin{description}
+\\item[foo\\lbrack{}bar\\rbrack{}] \\mbox{} \\\\
+foo.
+bar.
+\\end{description}
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_beforeulol
     actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")
-    assert_equal %Q(\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\n\\end{description}\n\npara\n\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\n\\end{description}\n\n\\begin{enumerate}\n\\item bar\n\\end{enumerate}\n\n\\begin{description}\n\\item[foo] \\mbox{} \\\\\nfoo.\n\\end{description}\n\n\\begin{itemize}\n\\item bar\n\\end{itemize}\n), actual
+    expected = <<-EOS
+
+\\begin{description}
+\\item[foo] \\mbox{} \\\\
+foo.
+\\end{description}
+
+para
+
+\\begin{description}
+\\item[foo] \\mbox{} \\\\
+foo.
+\\end{description}
+
+\\begin{enumerate}
+\\item bar
+\\end{enumerate}
+
+\\begin{description}
+\\item[foo] \\mbox{} \\\\
+foo.
+\\end{description}
+
+\\begin{itemize}
+\\item bar
+\\end{itemize}
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd
     actual = compile_block("//cmd{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewcmd}\nfoo\nbar\n\nbuz\n\\end{reviewcmd}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewcmd}
+foo
+bar
+
+buz
+\\end{reviewcmd}
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd_caption
     actual = compile_block("//cmd[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\reviewcmdcaption{cap1}\n\\begin{reviewcmd}\nfoo\nbar\n\nbuz\n\\end{reviewcmd}\n), actual
+    expected = <<-EOS
+
+\\reviewcmdcaption{cap1}
+\\begin{reviewcmd}
+foo
+bar
+
+buz
+\\end{reviewcmd}
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd_lst
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//cmd{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\vspace{-1.5em}\\begin{reviewcmdlst}[title={\\relax},language={}]\nfoo\nbar\n\nbuz\n\\end{reviewcmdlst}\n), actual
+    expected = <<-EOS
+\\vspace{-1.5em}\\begin{reviewcmdlst}[title={\\relax},language={}]
+foo
+bar
+
+buz
+\\end{reviewcmdlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist
     actual = compile_block("//emlist{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewemlist}\nfoo\nbar\n\nbuz\n\\end{reviewemlist}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewemlist}
+foo
+bar
+
+buz
+\\end{reviewemlist}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_lst
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//emlist[][sql]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
-    assert_equal %Q(\n\\vspace{-1.5em}\\begin{reviewemlistlst}[title={\\relax},language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewemlistlst}\n), actual
+    expected = <<-EOS
+
+\\vspace{-1.5em}\\begin{reviewemlistlst}[title={\\relax},language={sql}]
+SELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'
+\\end{reviewemlistlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_lst_without_lang
@@ -296,45 +409,112 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
     @book.config['highlight']['latex'] = 'listings'
     @book.config['highlight']['lang'] = 'sql'
     actual = compile_block("//emlist[]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
-    assert_equal %Q(\n\\vspace{-1.5em}\\begin{reviewemlistlst}[title={\\relax},language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewemlistlst}\n), actual
+    expected = <<-EOS
+
+\\vspace{-1.5em}\\begin{reviewemlistlst}[title={\\relax},language={sql}]
+SELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'
+\\end{reviewemlistlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_caption
     actual = compile_block("//emlist[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\reviewemlistcaption{cap1}\n\\begin{reviewemlist}\nfoo\nbar\n\nbuz\n\\end{reviewemlist}\n), actual
+    expected = <<-EOS
+
+\\reviewemlistcaption{cap1}
+\\begin{reviewemlist}
+foo
+bar
+
+buz
+\\end{reviewemlist}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_empty_caption
     actual = compile_block("//emlist[]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewemlist}\nfoo\nbar\n\nbuz\n\\end{reviewemlist}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewemlist}
+foo
+bar
+
+buz
+\\end{reviewemlist}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_with_tab
     actual = compile_block("//emlist{\n\tfoo\n\t\tbar\n\n\tbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewemlist}\n        foo\n                bar\n\n        buz\n\\end{reviewemlist}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewemlist}
+        foo
+                bar
+
+        buz
+\\end{reviewemlist}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlist_with_tab4
     @config['tabwidth'] = 4
     actual = compile_block("//emlist{\n\tfoo\n\t\tbar\n\n\tbuz\n//}\n")
-    assert_equal %Q(\n\\begin{reviewemlist}\n    foo\n        bar\n\n    buz\n\\end{reviewemlist}\n), actual
+    expected = <<-EOS
+
+\\begin{reviewemlist}
+    foo
+        bar
+
+    buz
+\\end{reviewemlist}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlistnum_caption
     actual = compile_block("//emlistnum[cap1]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\reviewemlistcaption{cap1}\n\\begin{reviewemlist}\n 1: foo\n 2: bar\n 3: \n 4: buz\n\\end{reviewemlist}\n), actual
+    expected = <<-EOS
+
+\\reviewemlistcaption{cap1}
+\\begin{reviewemlist}
+ 1: foo
+ 2: bar
+ 3: 
+ 4: buz
+\\end{reviewemlist}
+EOS
+    assert_equal expected, actual
   end
 
   def test_list
     actual = compile_block("//list[id1][cap1]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\reviewlistcaption{リスト1.1: cap1}\n\\begin{reviewlist}\nfoo\nbar\n\nbuz\n\\end{reviewlist}\n), actual
+    expected = <<-EOS
+\\reviewlistcaption{リスト1.1: cap1}
+\\begin{reviewlist}
+foo
+bar
+
+buz
+\\end{reviewlist}
+EOS
+    assert_equal expected, actual
   end
 
   def test_list_lst
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//list[id1][cap1][sql]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
-    assert_equal %Q(\\begin{reviewlistlst}[caption={cap1},language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewlistlst}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistlst}[caption={cap1},language={sql}]
+SELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'
+\\end{reviewlistlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_list_lst_with_lang
@@ -342,78 +522,199 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
     @book.config['highlight']['latex'] = 'listings'
     @book.config['highlight']['lang'] = 'sql'
     actual = compile_block("//list[id1][cap1]{\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n//}\n")
-    assert_equal %Q(\\begin{reviewlistlst}[caption={cap1},language={sql}]\nSELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'\n\\end{reviewlistlst}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistlst}[caption={cap1},language={sql}]
+SELECT COUNT(*) FROM tests WHERE tests.no > 10 AND test.name LIKE 'ABC%'
+\\end{reviewlistlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum
     actual = compile_block("//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
-    assert_equal %Q(\\reviewlistcaption{リスト1.1: ruby}\n\\begin{reviewlist}\n 1: class Foo\n 2:   def foo\n 3:     bar\n 4: \n 5:     buz\n 6:   end\n 7: end\n\\end{reviewlist}\n), actual
+    expected = <<-EOS
+\\reviewlistcaption{リスト1.1: ruby}
+\\begin{reviewlist}
+ 1: class Foo
+ 2:   def foo
+ 3:     bar
+ 4: 
+ 5:     buz
+ 6:   end
+ 7: end
+\\end{reviewlist}
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum_linenum
     actual = compile_block("//firstlinenum[100]\n//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
-    assert_equal %Q(\\reviewlistcaption{リスト1.1: ruby}\n\\begin{reviewlist}\n100: class Foo\n101:   def foo\n102:     bar\n103: \n104:     buz\n105:   end\n106: end\n\\end{reviewlist}\n), actual
+    expected = <<-EOS
+\\reviewlistcaption{リスト1.1: ruby}
+\\begin{reviewlist}
+100: class Foo
+101:   def foo
+102:     bar
+103: 
+104:     buz
+105:   end
+106: end
+\\end{reviewlist}
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum_lst
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
-    assert_equal %Q(\\begin{reviewlistnumlst}[caption={ruby},language={}]\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n\\end{reviewlistnumlst}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistnumlst}[caption={ruby},language={}]
+class Foo
+  def foo
+    bar
+
+    buz
+  end
+end
+\\end{reviewlistnumlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum_lst_linenum
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//firstlinenum[100]\n//listnum[test1][ruby]{\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n//}\n")
-    assert_equal %Q(\\begin{reviewlistnumlst}[caption={ruby},language={},firstnumber=100]\nclass Foo\n  def foo\n    bar\n\n    buz\n  end\nend\n\\end{reviewlistnumlst}\n), actual
+    expected = <<-EOS
+\\begin{reviewlistnumlst}[caption={ruby},language={},firstnumber=100]
+class Foo
+  def foo
+    bar
+
+    buz
+  end
+end
+\\end{reviewlistnumlst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_source
     actual = compile_block("//source[foo/bar/test.rb]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\reviewsourcecaption{foo/bar/test.rb}\n\\begin{reviewsource}\nfoo\nbar\n\nbuz\n\\end{reviewsource}\n), actual
+    expected = <<-EOS
+\\reviewsourcecaption{foo/bar/test.rb}
+\\begin{reviewsource}
+foo
+bar
+
+buz
+\\end{reviewsource}
+EOS
+    assert_equal expected, actual
   end
 
   def test_source_empty_caption
     actual = compile_block("//source[]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\begin{reviewsource}\nfoo\nbar\n\nbuz\n\\end{reviewsource}\n), actual
+    expected = <<-EOS
+\\begin{reviewsource}
+foo
+bar
+
+buz
+\\end{reviewsource}
+EOS
+    assert_equal expected, actual
   end
 
   def test_source_lst
     @book.config['highlight'] = {}
     @book.config['highlight']['latex'] = 'listings'
     actual = compile_block("//source[foo/bar/test.rb]{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\\begin{reviewsourcelst}[title={foo/bar/test.rb},language={}]\nfoo\nbar\n\nbuz\n\\end{reviewsourcelst}\n), actual
+    expected = <<-EOS
+\\begin{reviewsourcelst}[title={foo/bar/test.rb},language={}]
+foo
+bar
+
+buz
+\\end{reviewsourcelst}
+EOS
+    assert_equal expected, actual
   end
 
   def test_quote
     actual = compile_block("//quote{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{quote}\nfoobar\n\nbuz\n\\end{quote}\n), actual
+    expected = <<-EOS
+
+\\begin{quote}
+foobar
+
+buz
+\\end{quote}
+EOS
+    assert_equal expected, actual
   end
 
   def test_memo
     actual = compile_block("//memo[this is @<b>{test}<&>_]{\ntest1\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(\\begin{reviewminicolumn}\n\\reviewminicolumntitle{this is \\textbf{test}\\textless{}\\&\\textgreater{}\\textunderscore{}}\ntest1\n\ntest\\textit{2}\n\\end{reviewminicolumn}\n), actual
+    expected = <<-EOS
+\\begin{reviewminicolumn}
+\\reviewminicolumntitle{this is \\textbf{test}\\textless{}\\&\\textgreater{}\\textunderscore{}}
+test1
+
+test\\textit{2}
+\\end{reviewminicolumn}
+EOS
+    assert_equal expected, actual
   end
 
   def test_flushright
     actual = compile_block("//flushright{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{flushright}\nfoobar\n\nbuz\n\\end{flushright}\n), actual
+    expected = <<-EOS
+
+\\begin{flushright}
+foobar
+
+buz
+\\end{flushright}
+EOS
+    assert_equal expected, actual
   end
 
   def test_centering
     actual = compile_block("//centering{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n\\begin{center}\nfoobar\n\nbuz\n\\end{center}\n), actual
+    expected = <<-EOS
+
+\\begin{center}
+foobar
+
+buz
+\\end{center}
+EOS
+    assert_equal expected, actual
   end
 
   def test_blankline
     actual = compile_block("//blankline\nfoo\n")
-    assert_equal %Q(\\vspace*{\\baselineskip}\n\nfoo\n), actual
+    expected = <<-EOS
+\\vspace*{\\baselineskip}
+
+foo
+EOS
+    assert_equal expected, actual
   end
 
   def test_noindent
     actual = compile_block("//noindent\nfoo\nbar\n\nfoo2\nbar2\n")
-    assert_equal %Q(\\noindent\nfoo\nbar\n\nfoo2\nbar2\n), actual
+    expected = <<-EOS
+\\noindent
+foo
+bar
+
+foo2
+bar2
+EOS
+    assert_equal expected, actual
   end
 
   def test_image
@@ -424,7 +725,14 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\caption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\caption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric
@@ -435,7 +743,14 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\caption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[scale=1.2]{./images/chap1-sampleimg.png}
+\\caption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric_width
@@ -447,7 +762,14 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
 
     @config['image_scale2width'] = true
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}\n\\caption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}
+\\caption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric2
@@ -458,7 +780,14 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}\n\\caption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}
+\\caption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric2_width
@@ -470,7 +799,14 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
 
     @config['image_scale2width'] = true
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=1.2\\maxwidth,ignore=params]{./images/chap1-sampleimg.png}\n\\caption{sample photo}\n\\label{image:chap1:sampleimg}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[width=1.2\\maxwidth,ignore=params]{./images/chap1-sampleimg.png}
+\\caption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage
@@ -481,7 +817,13 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
     end
 
     actual = compile_block("//indepimage[sampleimg][sample photo]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\reviewindepimagecaption{図: sample photo}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_without_caption
@@ -493,7 +835,12 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
 
     # FIXME: indepimage's caption should not be with a counter.
     actual = compile_block("//indepimage[sampleimg]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric
@@ -504,7 +851,13 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
     end
 
     actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[scale=1.2]{./images/chap1-sampleimg.png}
+\\reviewindepimagecaption{図: sample photo}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric_width
@@ -516,7 +869,13 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
 
     @config['image_scale2width'] = true
     actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[width=1.2\\maxwidth]{./images/chap1-sampleimg.png}
+\\reviewindepimagecaption{図: sample photo}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric2
@@ -527,7 +886,13 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
     end
 
     actual = compile_block(%Q(//indepimage[sampleimg][sample photo][scale=1.2, html::class="sample",latex::ignore=params]\n))
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}\n\\reviewindepimagecaption{図: sample photo}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[scale=1.2,ignore=params]{./images/chap1-sampleimg.png}
+\\reviewindepimagecaption{図: sample photo}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_indepimage_without_caption_but_with_metric
@@ -539,36 +904,92 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
 
     # FIXME: indepimage's caption should not be with a counter.
     actual = compile_block("//indepimage[sampleimg][][scale=1.2]\n")
-    assert_equal %Q(\\begin{reviewimage}%%sampleimg\n\\includegraphics[scale=1.2]{./images/chap1-sampleimg.png}\n\\end{reviewimage}\n), actual
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\includegraphics[scale=1.2]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_table
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal "\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
-                 actual
+    expected = <<-EOS
+\\begin{reviewtable}{|l|l|}
+\\hline
+\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline
+ccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
   end
 
   def test_customize_cellwidth
     actual = compile_block("//tsize[2,3,5]\n//table{\nA\tB\tC\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}
+\\hline
+\\reviewth{A} & B & C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
 
     actual = compile_block("//tsize[|latex,html|2,3,5]\n//table{\nA\tB\tC\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}
+\\hline
+\\reviewth{A} & B & C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
 
     actual = compile_block("//tsize[|html|2,3,5]\n//table{\nA\tB\tC\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|l|l|l|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|l|l|l|}
+\\hline
+\\reviewth{A} & B & C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
 
     actual = compile_block("//tsize[|latex|2,3,5]\n//table{\nA\tB\tC\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|p{2mm}|p{3mm}|p{5mm}|}
+\\hline
+\\reviewth{A} & B & C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
 
     actual = compile_block("//tsize[|latex||p{5mm}|cr|]\n//table{\nA\tB\tC\n//}\n")
-    assert_equal %Q(\\begin{reviewtable}{|p{5mm}|cr|}\n\\hline\n\\reviewth{A} & B & C \\\\  \\hline\n\\end{reviewtable}\n), actual
+    expected = <<-EOS
+\\begin{reviewtable}{|p{5mm}|cr|}
+\\hline
+\\reviewth{A} & B & C \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
   end
 
   def test_emtable
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal "\\begin{table}[h]%%\n\\reviewtablecaption*{foo}\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n\\end{table}\n\n\\begin{reviewtable}{|l|l|}\n\\hline\n\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline\nccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline\n\\end{reviewtable}\n",
-                 actual
+    expected = <<-EOS
+\\begin{table}[h]%%
+\\reviewtablecaption*{foo}
+\\begin{reviewtable}{|l|l|}
+\\hline
+\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline
+ccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline
+\\end{reviewtable}
+\\end{table}
+
+\\begin{reviewtable}{|l|l|}
+\\hline
+\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline
+ccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
   end
 
   def test_imgtable
@@ -606,7 +1027,14 @@ EOS
     end
 
     actual = compile_block("//bibpaper[samplebib][sample bib @<b>{bold}]{\na\nb\n//}\n")
-    assert_equal %Q([1] sample bib \\textbf{bold}\n\\label{bib:samplebib}\n\nab\n\n), actual
+    expected = <<-EOS
+[1] sample bib \\textbf{bold}
+\\label{bib:samplebib}
+
+ab
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_bibpaper_without_body
@@ -615,7 +1043,12 @@ EOS
     end
 
     actual = compile_block("//bibpaper[samplebib][sample bib]\n")
-    assert_equal %Q([1] sample bib\n\\label{bib:samplebib}\n\n), actual
+    expected = <<-EOS
+[1] sample bib
+\\label{bib:samplebib}
+
+EOS
+    assert_equal expected, actual
   end
 
   def column_helper(review)
@@ -834,35 +1267,115 @@ EOS
 
   def test_major_blocks
     actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    expected = <<-EOS
+\\begin{reviewminicolumn}
+A
+
+B
+\\end{reviewminicolumn}
+\\begin{reviewminicolumn}
+\\reviewminicolumntitle{caption}
+A
+\\end{reviewminicolumn}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    expected = <<-EOS
+\\begin{reviewminicolumn}
+A
+
+B
+\\end{reviewminicolumn}
+\\begin{reviewminicolumn}
+\\reviewminicolumntitle{caption}
+A
+\\end{reviewminicolumn}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    expected = <<-EOS
+\\begin{reviewminicolumn}
+A
+
+B
+\\end{reviewminicolumn}
+\\begin{reviewminicolumn}
+\\reviewminicolumntitle{caption}
+A
+\\end{reviewminicolumn}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    expected = <<-EOS
+\\begin{reviewminicolumn}
+A
+
+B
+\\end{reviewminicolumn}
+\\begin{reviewminicolumn}
+\\reviewminicolumntitle{caption}
+A
+\\end{reviewminicolumn}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    expected = <<-EOS
+\\begin{reviewminicolumn}
+A
+
+B
+\\end{reviewminicolumn}
+\\begin{reviewminicolumn}
+\\reviewminicolumntitle{caption}
+A
+\\end{reviewminicolumn}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    expected = <<-EOS
+\\begin{reviewminicolumn}
+A
+
+B
+\\end{reviewminicolumn}
+\\begin{reviewminicolumn}
+\\reviewminicolumntitle{caption}
+A
+\\end{reviewminicolumn}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    expected = <<-EOS
+\\begin{reviewminicolumn}
+A
+
+B
+\\end{reviewminicolumn}
+\\begin{reviewminicolumn}
+\\reviewminicolumntitle{caption}
+A
+\\end{reviewminicolumn}
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
-    expected = %Q(\\begin{reviewminicolumn}\nA\n\nB\n\\end{reviewminicolumn}\n\\begin{reviewminicolumn}\n\\reviewminicolumntitle{caption}\nA\n\\end{reviewminicolumn}\n)
+    expected = <<-EOS
+\\begin{reviewminicolumn}
+A
+
+B
+\\end{reviewminicolumn}
+\\begin{reviewminicolumn}
+\\reviewminicolumntitle{caption}
+A
+\\end{reviewminicolumn}
+EOS
     assert_equal expected, actual
   end
 

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -9,10 +9,7 @@ class MARKDOWNBuilderTest < Test::Unit::TestCase
 
   def setup
     @builder = MARKDOWNBuilder.new
-    @config = {
-      'secnolevel' => 2,
-      'stylesheet' => nil
-    }
+    @config = ReVIEW::Configure.values
     @book = Book::Base.new('.')
     @book.config = @config
     @compiler = ReVIEW::Compiler.new(@builder)
@@ -23,17 +20,37 @@ class MARKDOWNBuilderTest < Test::Unit::TestCase
 
   def test_quote
     actual = compile_block("//quote{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(\n> foobar\n> \n> buz\n\n), actual
+    expected = <<-EOS
+
+> foobar
+> 
+> buz
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_memo
     actual = compile_block("//memo[this is @<b>{test}<&>_]{\ntest1\n\ntest@<i>{2}\n//}\n")
-    assert_equal %Q(<div class="memo">\n<p class="caption">this is **test**<&>_</p>\ntest1\ntest*2*\n</div>\n), actual
+    expected = <<-EOS
+<div class="memo">
+<p class="caption">this is **test**<&>_</p>
+test1
+test*2*
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_noindent
     actual = compile_block("//noindent\nfoo\nbar\n\nfoo2\nbar2\n")
-    assert_equal %Q(<p class="noindent">foobar</p>\n\nfoo2bar2\n\n), actual
+    expected = <<-EOS
+<p class="noindent">foobar</p>
+
+foo2bar2
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_em
@@ -78,23 +95,49 @@ EOS
 
   def test_cmd
     actual = compile_block("//cmd{\nlineA\nlineB\n//}\n")
-    assert_equal "```shell-session\nlineA\nlineB\n```\n", actual
+    expected = <<-EOS
+```shell-session
+lineA
+lineB
+```
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist
     actual = compile_block(": foo\n  foo.\n  bar.\n")
-    assert_equal %Q(<dl>\n<dt>foo</dt>\n<dd>foo.bar.</dd>\n</dl>\n), actual
+    expected = <<-EOS
+<dl>
+<dt>foo</dt>
+<dd>foo.bar.</dd>
+</dl>
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_with_bracket
     actual = compile_block(": foo[bar]\n    foo.\n    bar.\n")
-    assert_equal %Q(<dl>\n<dt>foo[bar]</dt>\n<dd>foo.bar.</dd>\n</dl>\n), actual
+    expected = <<-EOS
+<dl>
+<dt>foo[bar]</dt>
+<dd>foo.bar.</dd>
+</dl>
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_with_comment
     source = ": title\n  body\n\#@ comment\n\#@ comment\n: title2\n  body2\n"
     actual = compile_block(source)
-    assert_equal %Q(<dl>\n<dt>title</dt>\n<dd>body</dd>\n<dt>title2</dt>\n<dd>body2</dd>\n</dl>\n), actual
+    expected = <<-EOS
+<dl>
+<dt>title</dt>
+<dd>body</dd>
+<dt>title2</dt>
+<dd>body2</dd>
+</dl>
+EOS
+    assert_equal expected, actual
   end
 
   def test_comment
@@ -166,11 +209,17 @@ BBB
 
   def test_table
     actual = compile_block("//table{\ntestA\ttestB\n------------\ncontentA\tcontentB\n//}\n")
-    assert_equal "|testA|testB|\n|:--|:--|\n|contentA|contentB|\n\n", actual
+    expected = <<-EOS
+|testA|testB|
+|:--|:--|
+|contentA|contentB|
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_ruby
     actual = compile_block('@<ruby>{謳,うた}い文句')
-    assert_equal "<ruby><rb>謳</rb><rp>（</rp><rt>うた</rt><rp>）</rp></ruby>い文句\n\n", actual
+    assert_equal "<ruby>謳<rp>（</rp><rt>うた</rt><rp>）</rp></ruby>い文句\n\n", actual
   end
 end

--- a/test/test_md2inaobuilder.rb
+++ b/test/test_md2inaobuilder.rb
@@ -9,10 +9,7 @@ class MD2INAOBuilderTest < Test::Unit::TestCase
 
   def setup
     @builder = MD2INAOBuilder.new
-    @config = {
-      'secnolevel' => 2,
-      'stylesheet' => nil
-    }
+    @config = ReVIEW::Configure.values
     @book = Book::Base.new('.')
     @book.config = @config
     @compiler = ReVIEW::Compiler.new(@builder)
@@ -24,17 +21,33 @@ class MD2INAOBuilderTest < Test::Unit::TestCase
 
   def test_paragraph
     actual = compile_block('Hello, world!')
-    assert_equal "　Hello, world!\n\n", actual
+    expected = <<-EOS
+　Hello, world!
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_cmd
     actual = compile_block("//cmd{\nlineA\nlineB\n//}\n")
-    assert_equal "!!! cmd\nlineA\nlineB\n\n", actual
+    expected = <<-EOS
+!!! cmd
+lineA
+lineB
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist
     actual = compile_block(": foo\n  foo.\n  bar.\n")
-    assert_equal "<dl>\n<dt>foo</dt>\n<dd>foo.bar.</dd>\n</dl>\n", actual
+    expected = <<-EOS
+<dl>
+<dt>foo</dt>
+<dd>foo.bar.</dd>
+</dl>
+EOS
+    assert_equal expected, actual
   end
 
   def test_list

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -143,12 +143,34 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
 
   def test_inline_in_table
     actual = compile_block("//table{\n★1☆\t▲2☆\n------------\n★3☆\t▲4☆<>&\n//}\n")
-    assert_equal %Q(★1☆\t▲2☆\n★3☆\t▲4☆<>&\n\n), actual
+    expected = <<-EOS
+★1☆\t▲2☆
+★3☆\t▲4☆<>&
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_beforeulol
     actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")
-    assert_equal %Q(foo\nfoo.\n\npara\n\nfoo\nfoo.\n\n1　bar\n\nfoo\nfoo.\n\nbar\n\n), actual
+    expected = <<-EOS
+foo
+foo.
+
+para
+
+foo
+foo.
+
+1　bar
+
+foo
+foo.
+
+bar
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_paragraph
@@ -163,12 +185,21 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
 
   def test_flushright
     actual = compile_block("//flushright{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(foobar\nbuz\n\n), actual
+    expected = <<-EOS
+foobar
+buz
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_noindent
     actual = compile_block("//noindent\nfoo\nbar\n\nfoo2\nbar2\n")
-    assert_equal %Q(foobar\nfoo2bar2\n), actual
+    expected = <<-EOS
+foobar
+foo2bar2
+EOS
+    assert_equal expected, actual
   end
 
   def test_comment
@@ -187,7 +218,14 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
       Book::ListIndex::Item.new('test', 1)
     end
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
-    assert_equal %Q(リスト1.1　this is test<&>_\n\nfoo\nbar\n\n), actual
+    expected = <<-EOS
+リスト1.1　this is test<&>_
+
+foo
+bar
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum
@@ -195,12 +233,25 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
       Book::ListIndex::Item.new('test', 1)
     end
     actual = compile_block("//listnum[test][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
-    assert_equal %Q(リスト1.1　this is test<&>_\n\n 1: foo\n 2: bar\n\n), actual
+    expected = <<-EOS
+リスト1.1　this is test<&>_
+
+ 1: foo
+ 2: bar
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlistnum
     actual = compile_block("//emlistnum[this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
-    assert_equal %Q(this is test<&>_\n 1: foo\n 2: bar\n\n), actual
+    expected = <<-EOS
+this is test<&>_
+ 1: foo
+ 2: bar
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_bib
@@ -213,8 +264,12 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
 
   def test_table
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal %Q(aaa\tbbb\nccc\tddd<>&\n\n),
-                 actual
+    expected = <<-EOS
+aaa\tbbb
+ccc\tddd<>&
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_table
@@ -227,41 +282,106 @@ class PLAINTEXTBuidlerTest < Test::Unit::TestCase
 
   def test_emtable
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal %Q(foo\n\naaa\tbbb\nccc\tddd<>&\n\naaa\tbbb\nccc\tddd<>&\n\n),
-                 actual
+    expected = <<-EOS
+foo
+
+aaa\tbbb
+ccc\tddd<>&
+
+aaa\tbbb
+ccc\tddd<>&
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_major_blocks
     actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
-    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    expected = <<-EOS
+A
+B
+
+caption
+A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
-    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    expected = <<-EOS
+A
+B
+
+caption
+A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
-    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    expected = <<-EOS
+A
+B
+
+caption
+A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
-    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    expected = <<-EOS
+A
+B
+
+caption
+A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
-    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    expected = <<-EOS
+A
+B
+
+caption
+A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
-    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    expected = <<-EOS
+A
+B
+
+caption
+A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
-    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    expected = <<-EOS
+A
+B
+
+caption
+A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
-    expected = %Q(A\nB\n\ncaption\nA\n\n)
+    expected = <<-EOS
+A
+B
+
+caption
+A
+
+EOS
     assert_equal expected, actual
   end
 

--- a/test/test_rstbuilder.rb
+++ b/test/test_rstbuilder.rb
@@ -30,29 +30,66 @@ class RSTBuidlerTest < Test::Unit::TestCase
 
   def test_headline_level1
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q(.. _test:\n\n==========================\nthis is test.\n==========================\n\n), actual
+    expected = <<-EOS
+.. _test:
+
+==========================
+this is test.
+==========================
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level1_without_secno
     @config['secnolevel'] = 0
     actual = compile_block("={test} this is test.\n")
-    assert_equal %Q(.. _test:\n\n==========================\nthis is test.\n==========================\n\n), actual
+    expected = <<-EOS
+.. _test:
+
+==========================
+this is test.
+==========================
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level2
     actual = compile_block("=={test} this is test.\n")
-    assert_equal %Q(.. _test:\n\nthis is test.\n==========================\n\n), actual
+    expected = <<-EOS
+.. _test:
+
+this is test.
+==========================
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level3
     actual = compile_block("==={test} this is test.\n")
-    assert_equal %Q(.. _test:\n\nthis is test.\n--------------------------\n\n), actual
+    expected = <<-EOS
+.. _test:
+
+this is test.
+--------------------------
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_headline_level3_with_secno
     @config['secnolevel'] = 3
     actual = compile_block("==={test} this is test.\n")
-    assert_equal %Q(.. _test:\n\nthis is test.\n--------------------------\n\n), actual
+    expected = <<-EOS
+.. _test:
+
+this is test.
+--------------------------
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_href
@@ -143,12 +180,28 @@ class RSTBuidlerTest < Test::Unit::TestCase
 
   def test_inline_in_table
     actual = compile_block("//table{\n★1☆\t▲2☆\n------------\n★3☆\t▲4☆<>&\n//}\n")
-    assert_equal %Q(   * - ★1☆\n     - ▲2☆\n   * - ★3☆\n     - ▲4☆<>&\n\n), actual
+    expected = <<-EOS
+   * - ★1☆
+     - ▲2☆
+   * - ★3☆
+     - ▲4☆<>&
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_emtable
     actual = compile_block("//emtable[foo]{\nA\n//}\n//emtable{\nA\n//}")
-    assert_equal %Q(.. list-table:: foo\n   :header-rows: 1\n\n   * - A\n\n   * - A\n\n), actual
+    expected = <<-EOS
+.. list-table:: foo
+   :header-rows: 1
+
+   * - A
+
+   * - A
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_paragraph
@@ -163,12 +216,25 @@ class RSTBuidlerTest < Test::Unit::TestCase
 
   def test_flushright
     actual = compile_block("//flushright{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(.. flushright::\n\n   foobar\nbuz\n\n), actual
+    expected = <<-EOS
+.. flushright::
+
+   foobar
+buz
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_noindent
     actual = compile_block("//noindent\nfoo\nbar\n\nfoo2\nbar2\n")
-    assert_equal %Q(foobar\n\nfoo2bar2\n\n), actual
+    expected = <<-EOS
+foobar
+
+foo2bar2
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_comment
@@ -187,7 +253,13 @@ class RSTBuidlerTest < Test::Unit::TestCase
       Book::ListIndex::Item.new('test', 1)
     end
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
-    assert_equal %Q(.. _samplelist:\n\n-foo\n-bar\n), actual
+    expected = <<-EOS
+.. _samplelist:
+
+-foo
+-bar
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum
@@ -195,45 +267,150 @@ class RSTBuidlerTest < Test::Unit::TestCase
       Book::ListIndex::Item.new('test', 1)
     end
     actual = compile_block("//listnum[test][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
-    assert_equal %Q(.. _test:\n\n1\n2\n\n), actual
+    expected = <<-EOS
+.. _test:
+
+1
+2
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlistnum
     actual = compile_block("//emlistnum[this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
-    assert_equal %Q(this is @<b>{test}<&>_\n\n.. code-block:: none\n   :linenos:\n\n   foo\n   bar\n\n), actual
+    expected = <<-EOS
+this is @<b>{test}<&>_
+
+.. code-block:: none
+   :linenos:
+
+   foo
+   bar
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_major_blocks
     actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
-    expected = %Q(.. note::\n\n   A\nB\n\n.. note::\n\n   caption\n   A\n\n)
+    expected = <<-EOS
+.. note::
+
+   A
+B
+
+.. note::
+
+   caption
+   A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
-    expected = %Q(.. memo::\n\n   A\nB\n\n.. memo::\n\n   caption\n   A\n\n)
+    expected = <<-EOS
+.. memo::
+
+   A
+B
+
+.. memo::
+
+   caption
+   A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
-    expected = %Q(.. info::\n\n   A\nB\n\n.. info::\n\n   caption\n   A\n\n)
+    expected = <<-EOS
+.. info::
+
+   A
+B
+
+.. info::
+
+   caption
+   A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
-    expected = %Q(.. important::\n\n   A\nB\n\n.. important::\n\n   caption\n   A\n\n)
+    expected = <<-EOS
+.. important::
+
+   A
+B
+
+.. important::
+
+   caption
+   A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
-    expected = %Q(.. caution::\n\n   A\nB\n\n.. caution::\n\n   caption\n   A\n\n)
+    expected = <<-EOS
+.. caution::
+
+   A
+B
+
+.. caution::
+
+   caption
+   A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
-    expected = %Q(.. notice::\n\n   A\nB\n\n.. notice::\n\n   caption\n   A\n\n)
+    expected = <<-EOS
+.. notice::
+
+   A
+B
+
+.. notice::
+
+   caption
+   A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
-    expected = %Q(.. warning::\n\n   A\nB\n\n.. warning::\n\n   caption\n   A\n\n)
+    expected = <<-EOS
+.. warning::
+
+   A
+B
+
+.. warning::
+
+   caption
+   A
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
-    expected = %Q(.. tip::\n\n   A\nB\n\n.. tip::\n\n   caption\n   A\n\n)
+    expected = <<-EOS
+.. tip::
+
+   A
+B
+
+.. tip::
+
+   caption
+   A
+
+EOS
     assert_equal expected, actual
   end
 
@@ -245,7 +422,15 @@ class RSTBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo]{\nfoo\n//}\n")
-    assert_equal %Q(.. _sampleimg:\n\n.. figure:: images/-/sampleimg.png\n\n   sample photo\n\n), actual
+    expected = <<-EOS
+.. _sampleimg:
+
+.. figure:: images/-/sampleimg.png
+
+   sample photo
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric
@@ -256,7 +441,16 @@ class RSTBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\nfoo\n//}\n")
-    assert_equal %Q(.. _sampleimg:\n\n.. figure:: images/-/sampleimg.png\n   :scale:120.0%\n\n   sample photo\n\n), actual
+    expected = <<-EOS
+.. _sampleimg:
+
+.. figure:: images/-/sampleimg.png
+   :scale:120.0%
+
+   sample photo
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_texequation

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -142,12 +142,36 @@ class TOPBuidlerTest < Test::Unit::TestCase
 
   def test_inline_in_table
     actual = compile_block("//table{\n★1☆\t▲2☆\n------------\n★3☆\t▲4☆<>&\n//}\n")
-    assert_equal %Q(◆→開始:表←◆\n★★1☆☆\t★▲2☆☆\n★3☆\t▲4☆<>&\n◆→終了:表←◆\n\n), actual
+    expected = <<-EOS
+◆→開始:表←◆
+★★1☆☆\t★▲2☆☆
+★3☆\t▲4☆<>&
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_dlist_beforeulol
     actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")
-    assert_equal %Q(★foo☆\n\tfoo.\n\npara\n\n★foo☆\n\tfoo.\n\n1\tbar\n\n★foo☆\n\tfoo.\n\n●\tbar\n\n), actual
+    expected = <<-EOS
+★foo☆
+\tfoo.
+
+para
+
+★foo☆
+\tfoo.
+
+1\tbar
+
+★foo☆
+\tfoo.
+
+●\tbar
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_paragraph
@@ -162,7 +186,14 @@ class TOPBuidlerTest < Test::Unit::TestCase
 
   def test_flushright
     actual = compile_block("//flushright{\nfoo\nbar\n\nbuz\n//}\n")
-    assert_equal %Q(◆→開始:右寄せ←◆\nfoobar\nbuz\n◆→終了:右寄せ←◆\n\n), actual
+    expected = <<-EOS
+◆→開始:右寄せ←◆
+foobar
+buz
+◆→終了:右寄せ←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_blankline
@@ -172,7 +203,12 @@ class TOPBuidlerTest < Test::Unit::TestCase
 
   def test_noindent
     actual = compile_block("//noindent\nfoo\nbar\n\nfoo2\nbar2\n")
-    assert_equal %Q(◆→DTP連絡:次の1行インデントなし←◆\nfoobar\nfoo2bar2\n), actual
+    expected = <<-EOS
+◆→DTP連絡:次の1行インデントなし←◆
+foobar
+foo2bar2
+EOS
+    assert_equal expected, actual
   end
 
   def test_comment
@@ -193,7 +229,16 @@ class TOPBuidlerTest < Test::Unit::TestCase
       Book::ListIndex::Item.new('test', 1)
     end
     actual = compile_block("//list[samplelist][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
-    assert_equal %Q(◆→開始:リスト←◆\nリスト1.1　this is ★test☆<&>_\n\nfoo\nbar\n◆→終了:リスト←◆\n\n), actual
+    expected = <<-EOS
+◆→開始:リスト←◆
+リスト1.1　this is ★test☆<&>_
+
+foo
+bar
+◆→終了:リスト←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_listnum
@@ -201,12 +246,29 @@ class TOPBuidlerTest < Test::Unit::TestCase
       Book::ListIndex::Item.new('test', 1)
     end
     actual = compile_block("//listnum[test][this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
-    assert_equal %Q(◆→開始:リスト←◆\nリスト1.1　this is ★test☆<&>_\n\n 1: foo\n 2: bar\n◆→終了:リスト←◆\n\n), actual
+    expected = <<-EOS
+◆→開始:リスト←◆
+リスト1.1　this is ★test☆<&>_
+
+ 1: foo
+ 2: bar
+◆→終了:リスト←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_emlistnum
     actual = compile_block("//emlistnum[this is @<b>{test}<&>_]{\nfoo\nbar\n//}\n")
-    assert_equal %Q(◆→開始:インラインリスト←◆\n■this is ★test☆<&>_\n 1: foo\n 2: bar\n◆→終了:インラインリスト←◆\n\n), actual
+    expected = <<-EOS
+◆→開始:インラインリスト←◆
+■this is ★test☆<&>_
+ 1: foo
+ 2: bar
+◆→終了:インラインリスト←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_bib
@@ -219,8 +281,14 @@ class TOPBuidlerTest < Test::Unit::TestCase
 
   def test_table
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal %Q(◆→開始:表←◆\n★aaa☆\t★bbb☆\nccc\tddd<>&\n◆→終了:表←◆\n\n),
-                 actual
+    expected = <<-EOS
+◆→開始:表←◆
+★aaa☆\t★bbb☆
+ccc\tddd<>&
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_table
@@ -233,41 +301,142 @@ class TOPBuidlerTest < Test::Unit::TestCase
 
   def test_emtable
     actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
-    assert_equal %Q(◆→開始:表←◆\nfoo\n\n★aaa☆\t★bbb☆\nccc\tddd<>&\n◆→終了:表←◆\n\n◆→開始:表←◆\n★aaa☆\t★bbb☆\nccc\tddd<>&\n◆→終了:表←◆\n\n),
-                 actual
+    expected = <<-EOS
+◆→開始:表←◆
+foo
+
+★aaa☆\t★bbb☆
+ccc\tddd<>&
+◆→終了:表←◆
+
+◆→開始:表←◆
+★aaa☆\t★bbb☆
+ccc\tddd<>&
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_major_blocks
     actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
-    expected = %Q(◆→開始:ノート←◆\nA\nB\n◆→終了:ノート←◆\n\n◆→開始:ノート←◆\n■caption\nA\n◆→終了:ノート←◆\n\n)
+    expected = <<-EOS
+◆→開始:ノート←◆
+A
+B
+◆→終了:ノート←◆
+
+◆→開始:ノート←◆
+■caption
+A
+◆→終了:ノート←◆
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//memo{\nA\n\nB\n//}\n//memo[caption]{\nA\n//}")
-    expected = %Q(◆→開始:メモ←◆\nA\nB\n◆→終了:メモ←◆\n\n◆→開始:メモ←◆\n■caption\nA\n◆→終了:メモ←◆\n\n)
+    expected = <<-EOS
+◆→開始:メモ←◆
+A
+B
+◆→終了:メモ←◆
+
+◆→開始:メモ←◆
+■caption
+A
+◆→終了:メモ←◆
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//info{\nA\n\nB\n//}\n//info[caption]{\nA\n//}")
-    expected = %Q(◆→開始:情報←◆\nA\nB\n◆→終了:情報←◆\n\n◆→開始:情報←◆\n■caption\nA\n◆→終了:情報←◆\n\n)
+    expected = <<-EOS
+◆→開始:情報←◆
+A
+B
+◆→終了:情報←◆
+
+◆→開始:情報←◆
+■caption
+A
+◆→終了:情報←◆
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//important{\nA\n\nB\n//}\n//important[caption]{\nA\n//}")
-    expected = %Q(◆→開始:重要←◆\nA\nB\n◆→終了:重要←◆\n\n◆→開始:重要←◆\n■caption\nA\n◆→終了:重要←◆\n\n)
+    expected = <<-EOS
+◆→開始:重要←◆
+A
+B
+◆→終了:重要←◆
+
+◆→開始:重要←◆
+■caption
+A
+◆→終了:重要←◆
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//caution{\nA\n\nB\n//}\n//caution[caption]{\nA\n//}")
-    expected = %Q(◆→開始:警告←◆\nA\nB\n◆→終了:警告←◆\n\n◆→開始:警告←◆\n■caption\nA\n◆→終了:警告←◆\n\n)
+    expected = <<-EOS
+◆→開始:警告←◆
+A
+B
+◆→終了:警告←◆
+
+◆→開始:警告←◆
+■caption
+A
+◆→終了:警告←◆
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//notice{\nA\n\nB\n//}\n//notice[caption]{\nA\n//}")
-    expected = %Q(◆→開始:注意←◆\nA\nB\n◆→終了:注意←◆\n\n◆→開始:注意←◆\n■caption\nA\n◆→終了:注意←◆\n\n)
+    expected = <<-EOS
+◆→開始:注意←◆
+A
+B
+◆→終了:注意←◆
+
+◆→開始:注意←◆
+■caption
+A
+◆→終了:注意←◆
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//warning{\nA\n\nB\n//}\n//warning[caption]{\nA\n//}")
-    expected = %Q(◆→開始:危険←◆\nA\nB\n◆→終了:危険←◆\n\n◆→開始:危険←◆\n■caption\nA\n◆→終了:危険←◆\n\n)
+    expected = <<-EOS
+◆→開始:危険←◆
+A
+B
+◆→終了:危険←◆
+
+◆→開始:危険←◆
+■caption
+A
+◆→終了:危険←◆
+
+EOS
     assert_equal expected, actual
 
     actual = compile_block("//tip{\nA\n\nB\n//}\n//tip[caption]{\nA\n//}")
-    expected = %Q(◆→開始:TIP←◆\nA\nB\n◆→終了:TIP←◆\n\n◆→開始:TIP←◆\n■caption\nA\n◆→終了:TIP←◆\n\n)
+    expected = <<-EOS
+◆→開始:TIP←◆
+A
+B
+◆→終了:TIP←◆
+
+◆→開始:TIP←◆
+■caption
+A
+◆→終了:TIP←◆
+
+EOS
     assert_equal expected, actual
   end
 
@@ -279,7 +448,15 @@ class TOPBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo]{\nfoo\n//}\n")
-    assert_equal %Q(◆→開始:図←◆\n図1.1　sample photo\n\n◆→./images/chap1-sampleimg.png←◆\n◆→終了:図←◆\n\n), actual
+    expected = <<-EOS
+◆→開始:図←◆
+図1.1　sample photo
+
+◆→./images/chap1-sampleimg.png←◆
+◆→終了:図←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric
@@ -290,12 +467,27 @@ class TOPBuidlerTest < Test::Unit::TestCase
     end
 
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\nfoo\n//}\n")
-    assert_equal %Q(◆→開始:図←◆\n図1.1　sample photo\n\n◆→./images/chap1-sampleimg.png scale=1.2←◆\n◆→終了:図←◆\n\n), actual
+    expected = <<-EOS
+◆→開始:図←◆
+図1.1　sample photo
+
+◆→./images/chap1-sampleimg.png scale=1.2←◆
+◆→終了:図←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_texequation
     actual = compile_block("//texequation{\n\\sin\n1^{2}\n//}\n")
-    assert_equal %Q(◆→開始:TeX式←◆\n\\sin\n1^{2}\n◆→終了:TeX式←◆\n\n), actual
+    expected = <<-EOS
+◆→開始:TeX式←◆
+\\sin
+1^{2}
+◆→終了:TeX式←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_w


### PR DESCRIPTION
#1327 の前段階として、expectedに複数行を含んでいてわかりにくそうな箇所をヒアドキュメント化することにします。
