### PR TITLE
ul,ol,dd,bibpaperでjoinする前に末尾改行を取り除く

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -257,7 +257,7 @@ module ReVIEW
     end
 
     def ul_item(lines)
-      str = lines.join("\n")
+      str = lines.map(&:chomp).join("\n")
       str.sub!(/\A(\[)/) { '\lbrack{}' }
       puts '\item ' + str
     end
@@ -276,7 +276,7 @@ module ReVIEW
     end
 
     def ol_item(lines, _num)
-      str = lines.join("\n")
+      str = lines.map(&:chomp).join("\n")
       str.sub!(/\A(\[)/) { '\lbrack{}' }
       puts '\item ' + str
     end
@@ -298,7 +298,7 @@ module ReVIEW
     end
 
     def dd(lines)
-      puts lines.join("\n")
+      puts lines.map(&:chomp).join("\n")
     end
 
     def dl_end
@@ -1215,7 +1215,7 @@ module ReVIEW
     end
 
     def bibpaper_bibpaper(_id, _caption, lines)
-      print split_paragraph(lines).join("\n")
+      print split_paragraph(lines).map(&:chomp).join("\n")
       puts ''
     end
 

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1289,6 +1289,27 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_cont_with_br
+    src = <<-EOS
+  * AAA@<br>{}
+    -AA
+  * BBB@<br>{}1@<br>{}
+    -BB
+EOS
+    expected = <<-EOS
+
+\\begin{itemize}
+\\item AAA\\\\
+{-}AA
+\\item BBB\\\\
+1\\\\
+{-}BB
+\\end{itemize}
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+  end
+
   def test_ul_nest1
     src = <<-EOS
   * AAA


### PR DESCRIPTION
#1331 の修正
