### PR TITLE
MARKDOWNBuilder: support listnum

### DIFF
--- a/NEWS.ja.md
+++ b/NEWS.ja.md
@@ -31,6 +31,7 @@
 * 箇条書きや文献リストで複数行の英単語が連結されてしまうのを回避しました (ただし PDFMaker のみ) ([#1312])
 * 空の表があったときにエラーを出すようにしました ([#1325])
 * いくつかのテスト対象を追加しました ([#1327], [#1328])
+* MARKDOWNBuilder: ``//listnum``に対応しました ([#1336])
 
 ## ドキュメント
 * 見出しのレベルの説明の誤りを修正しました ([#1309])
@@ -70,6 +71,7 @@
 [#1325]: https://github.com/kmuto/review/issues/1325
 [#1327]: https://github.com/kmuto/review/issues/1327
 [#1328]: https://github.com/kmuto/review/pull/1328
+[#1336]: https://github.com/kmuto/review/pull/1336
 
 # Version 3.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,7 @@
 * avoid multi-lined English words being combined without a space in bullets and bibliographic list (only in PDFMaker, at this time) ([#1312])
 * raise an error when table is empty ([#1325])
 * add some tests ([#1327], [#1328])
+* MARKDOWNBilder: support `//listnum` ([#1336])
 
 ## Docs
 * fixed the description about header levels ([#1309])
@@ -70,6 +71,7 @@
 [#1325]: https://github.com/kmuto/review/issues/1325
 [#1327]: https://github.com/kmuto/review/issues/1327
 [#1328]: https://github.com/kmuto/review/pull/1328
+[#1336]: https://github.com/kmuto/review/pull/1336
 
 # Version 3.1.0
 ## Breaking Changes

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -80,6 +80,13 @@ module ReVIEW
       puts '```'
     end
 
+    def listnum_body(lines, _lang)
+      lines.each_with_index do |line, i|
+        puts((i + 1).to_s.rjust(2) + ": #{detab(line)}")
+      end
+      puts '```'
+    end
+
     def ul_begin
       blank if @ul_indent == 0
       @ul_indent += 1

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -187,6 +187,23 @@ BBB
     EOS
   end
 
+  def test_listnum
+    def @chapter.list(_id)
+      Book::ListIndex::Item.new('test', 1)
+    end
+    actual = compile_block("//listnum[test][this is @<b>{test}<&>_]{\nfoo\nbar\n\tbuz\n//}\n")
+    expected = <<-EOS
+リスト1.1 this is **test**<&>_
+
+```
+ 1: foo
+ 2: bar
+ 3:         buz
+```
+EOS
+    assert_equal expected, actual
+  end
+
   def test_emlist_lang
     actual = compile_block(<<-EOS)
 //emlist[caption][ruby]{


### PR DESCRIPTION
ぎりぎりのタイミングですが、``//listnum``のサンプルがコケたので追加しておきます。