### PR TITLE
File.open時に「rt」フラグで改行コードをLFに統一する

### DIFF
--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -190,7 +190,7 @@ module ReVIEW
 
         catalogfile_path = filename_join(@basedir, config['catalogfile'])
         if File.file? catalogfile_path
-          @catalog = File.open(catalogfile_path, 'r:BOM|utf-8') { |f| Catalog.new(f) }
+          @catalog = File.open(catalogfile_path, 'rt:BOM|utf-8') { |f| Catalog.new(f) }
         end
         if @catalog
           @catalog.validate!(@config, basedir)
@@ -352,7 +352,7 @@ module ReVIEW
 
       def mkpart_from_namelistfile(path)
         chaps = []
-        File.read(path, mode: 'r:BOM|utf-8').split.each_with_index do |name, idx|
+        File.read(path, mode: 'rt:BOM|utf-8').split.each_with_index do |name, idx|
           if path =~ /PREDEF/
             chaps << mkchap(name)
           else
@@ -394,7 +394,7 @@ module ReVIEW
           end
         end
         res = ''
-        File.open(filename_join(@basedir, filename), 'r:BOM|utf-8') do |f|
+        File.open(filename_join(@basedir, filename), 'rt:BOM|utf-8') do |f|
           f.each_line do |line|
             next if /\A#/ =~ line
             line.gsub!(/#.*\Z/, '')

--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009-2017 Minero Aoki, Kenshi Muto
+# Copyright (c) 2009-2019 Minero Aoki, Kenshi Muto
 #               2002-2008 Minero Aoki
 #
 # This program is free software.
@@ -35,7 +35,7 @@ module ReVIEW
           @content = nil
         end
         if !@content && @path && File.exist?(@path)
-          @content = File.read(@path, mode: 'r:BOM|utf-8')
+          @content = File.read(@path, mode: 'rt:BOM|utf-8')
           @number = nil if %w[nonum nodisp notoc].include?(find_first_header_option)
         end
         @list_index = nil

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2018 Minero Aoki, Kenshi Muto
+# Copyright (c) 2009-2019 Minero Aoki, Kenshi Muto
 #               2002-2008 Minero Aoki
 #
 # This program is free software.
@@ -25,7 +25,7 @@ module ReVIEW
         if io
           @content = io.read
         elsif @path.present? && File.exist?(File.join(@book.config['contentdir'], @path))
-          @content = File.read(File.join(@book.config['contentdir'], @path), mode: 'r:BOM|utf-8')
+          @content = File.read(File.join(@book.config['contentdir'], @path), mode: 'rt:BOM|utf-8')
           @name = File.basename(@name, '.re')
         end
         if file?

--- a/lib/review/preprocessor.rb
+++ b/lib/review/preprocessor.rb
@@ -361,7 +361,7 @@ module ReVIEW
     end
 
     def parse_file(fname)
-      File.open(fname, 'r:BOM|utf-8') do |f|
+      File.open(fname, 'rt:BOM|utf-8') do |f|
         init_errorutils f
         return _parse_file(f)
       end

--- a/lib/review/tocparser.rb
+++ b/lib/review/tocparser.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008-2017 Minero Aoki, Kenshi Muto
+# Copyright (c) 2008-2019 Minero Aoki, Kenshi Muto
 #               2002-2007 Minero Aoki
 #
 # This program is free software.
@@ -15,7 +15,7 @@ require 'review/textbuilder'
 module ReVIEW
   class TOCParser
     def self.parse(chap)
-      stream = StringIO.new(chap.content, 'r:BOM|utf-8')
+      stream = StringIO.new(chap.content, 'rt:BOM|utf-8')
       new.parse(stream, chap).map do |root|
         root.number = chap.number
         root


### PR DESCRIPTION
#1341 の修正です。

書く環境と処理する環境がDocker利用などで異なるときに改行コードの違いが生じてしまうことがあるので、処理側でLFに統一させることにします。
