### PR TITLE
TextMakerでimgmathをサポートする

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -184,7 +184,7 @@ secnolevel: 2
 # 各数字の意味は、順にリストの行数、リストの1行字数、テキストの行数、テキストの1行字数、1kバイトごとのページ数
 # page_metric: [40,80,40,80,2]
 
-# EPUBおよびWeb生成における数式の画像化指定
+# EPUB・Web、およびテキスト生成時における数式の画像化指定
 # TeXの数式を画像化するか。省略した場合はnull (作成しない)
 # imgmath: true
 
@@ -211,14 +211,20 @@ secnolevel: 2
   # pdfcrop_cmd: "pdfcrop --hires %i %o"
   # PDFから画像化するコマンドのコマンドライン。プレースホルダは
   # %i: 入力ファイル、%o: 出力ファイル、%O: 出力ファイルから拡張子を除いたもの
-  # %p: 対象ページ番号
-  # pdfcrop_pixelize_cmd: "pdftocairo -png -r 90 -f %p -l %p -singlefile %i %O"
+  # %p: 対象ページ番号、%t: フォーマット
+  # pdfcrop_pixelize_cmd: "pdftocairo -%t -r 90 -f %p -l %p -singlefile %i %O"
   # pdfcrop_pixelize_cmdが複数ページの処理に対応していない場合に単ページ化するか
   # extract_singlepage: null
   # extract_singlepageがtrueの場合に単ページ化するコマンドのコマンドライン
   # pdfextract_cmd: "pdfjam -q --outfile %o %i %p"
   # converterにdvipngを指定したときのdvipngコマンドのコマンドライン
   # dvipng_cmd: "dvipng -T tight -z 9 -p %p -l %p -o %o %i"
+  #
+  # PDFで保存したいときにはたとえば以下のようにする
+  # format: pdf
+  # extract_singlepage: true
+  # pdfextract_cmd: "pdftk A=%i cat A%p output %o"
+  # pdfcrop_pixelize_cmd: "mv %i %o"
 
 # EPUBにおけるページ送りの送り方向、page-progression-directionの値("ltr"|"rtl"|"default")
 # direction: "ltr"
@@ -389,7 +395,3 @@ pdfmaker:
   # 奥付を作成するか。trueを指定するとデフォルトの奥付、ファイル名を指定するとそれがcolophon.htmlとしてコピーされる
   colophon: true
   # pdfmaker:階層を使うものはここまで
-# textmaker:
-  # TeXの数式を画像化するか。省略した場合はnull (作成しない)
-  # imgmath: null
-  # textmaker:階層を使うものはここまで

--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -389,3 +389,7 @@ pdfmaker:
   # 奥付を作成するか。trueを指定するとデフォルトの奥付、ファイル名を指定するとそれがcolophon.htmlとしてコピーされる
   colophon: true
   # pdfmaker:階層を使うものはここまで
+# textmaker:
+  # TeXの数式を画像化するか。省略した場合はnull (作成しない)
+  # imgmath: null
+  # textmaker:階層を使うものはここまで

--- a/doc/format.ja.md
+++ b/doc/format.ja.md
@@ -638,8 +638,8 @@ imgmath_options:
   pdfcrop_cmd: "pdfcrop --hires %i %o"
   # PDFから画像化するコマンドのコマンドライン。プレースホルダは
   # %i: 入力ファイル、%o: 出力ファイル、%O: 出力ファイルから拡張子を除いたもの
-  # %p: 対象ページ番号
-  pdfcrop_pixelize_cmd: "pdftocairo -png -r 90 -f %p -l %p -singlefile %i %O"
+  # %p: 対象ページ番号、%t: フォーマット
+  pdfcrop_pixelize_cmd: "pdftocairo -%t -r 90 -f %p -l %p -singlefile %i %O"
   # pdfcrop_pixelize_cmdが複数ページの処理に対応していない場合に単ページ化するか
   extract_singlepage: null
   # 単ページ化するコマンドのコマンドライン
@@ -671,6 +671,17 @@ imgmath_options:
   pdfcrop_pixelize_cmd: "magick -density 200x200 %i %o"
   # sipsを利用する例
   pdfcrop_pixelize_cmd: "sips -s format png --out %o %i"
+```
+
+textmaker 向けに PDF 形式の数式ファイルを作成したいときには、たとえば以下のように設定します（ページの抽出には pdftk を利用）。
+
+```
+imgmath: true
+imgmath_options:
+  format: pdf
+  extract_singlepage: true
+  pdfextract_cmd: "pdftk A=%i cat A%p output %o"
+  pdfcrop_pixelize_cmd: "mv %i %o"
 ```
 
 Re:VIEW 2 以前の dvipng の設定に合わせるには、次のようにします。

--- a/doc/format.md
+++ b/doc/format.md
@@ -682,8 +682,8 @@ imgmath_options:
   pdfcrop_cmd: "pdfcrop --hires %i %o"
   # imaging command.
   # %i: filename for input %o: filename for output %O: filename for output without the extension
-  # %p: page number
-  pdfcrop_pixelize_cmd: "pdftocairo -png -r 90 -f %p -l %p -singlefile %i %O"
+  # %p: page number, %t: format
+  pdfcrop_pixelize_cmd: "pdftocairo -%t -r 90 -f %p -l %p -singlefile %i %O"
   # whether to generate a single PDF page for pdfcrop_pixelize_cmd.
   extract_singlepage: null
   # command line to generate a single PDF page file.
@@ -715,6 +715,17 @@ imgmath_options:
   pdfcrop_pixelize_cmd: "magick -density 200x200 %i %o"
   # use sips
   pdfcrop_pixelize_cmd: "sips -s format png --out %o %i"
+```
+
+To create PDF math images:
+
+```
+imgmath: true
+imgmath_options:
+  format: pdf
+  extract_singlepage: true
+  pdfextract_cmd: "pdftk A=%i cat A%p output %o"
+  pdfcrop_pixelize_cmd: "mv %i %o"
 ```
 
 To set the same setting as Re:VIEW 2:

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2018 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
+# Copyright (c) 2012-2019 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -90,6 +90,10 @@ module ReVIEW
           'makeindex_mecab' => true,
           'makeindex_mecab_opts' => '-Oyomi'
         },
+        # for TextMaker
+        'textmaker' => {
+          'imgmath' => nil
+        },
         'imgmath_options' => {
           'format' => 'png',
           'converter' => 'pdfcrop', # dvipng | pdfcrop
@@ -99,7 +103,7 @@ module ReVIEW
           'preamble_file' => nil,
           'fontsize' => 10,
           'lineheight' => 10 * 1.2,
-          'pdfcrop_pixelize_cmd' => 'pdftocairo -png -r 90 -f %p -l %p -singlefile %i %O',
+          'pdfcrop_pixelize_cmd' => 'pdftocairo -%t -r 90 -f %p -l %p -singlefile %i %O',
           'dvipng_cmd' => 'dvipng -T tight -z 9 -p %p -l %p -o %o %i'
         }
       ]

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -90,10 +90,6 @@ module ReVIEW
           'makeindex_mecab' => true,
           'makeindex_mecab_opts' => '-Oyomi'
         },
-        # for TextMaker
-        'textmaker' => {
-          'imgmath' => nil
-        },
         'imgmath_options' => {
           'format' => 'png',
           'converter' => 'pdfcrop', # dvipng | pdfcrop

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -12,7 +12,6 @@ require 'review/htmlutils'
 require 'review/template'
 require 'review/textutils'
 require 'review/webtocprinter'
-require 'digest'
 require 'tmpdir'
 require 'open3'
 
@@ -1217,17 +1216,6 @@ module ReVIEW
 
     def olnum(num)
       @ol_num = num.to_i
-    end
-
-    def defer_math_image(str, path, key)
-      # for Re:VIEW >3
-      File.open(File.join(File.dirname(path), '__IMGMATH_BODY__.tex'), 'a+') do |f|
-        f.puts str
-        f.puts '\\clearpage'
-      end
-      File.open(File.join(File.dirname(path), '__IMGMATH_BODY__.map'), 'a+') do |f|
-        f.puts key
-      end
     end
 
     def make_math_image(str, path, fontsize = 12)

--- a/lib/review/makerhelper.rb
+++ b/lib/review/makerhelper.rb
@@ -66,8 +66,8 @@ module ReVIEW
     end
     module_function :copy_images_to_dir
 
-    def cleanup_mathimg
-      math_dir = "./#{@config['imagedir']}/_review_math"
+    def cleanup_mathimg(path = '_review_math')
+      math_dir = "./#{@config['imagedir']}/#{path}"
       if @config['imgmath'] && Dir.exist?(math_dir)
         FileUtils.rm_rf(math_dir)
       end
@@ -141,6 +141,7 @@ EOB
     end
 
     def make_math_images_pdfcrop(dir, tex_path, math_dir)
+      # rubocop:disable Metrics/BlockLength
       Dir.chdir(dir) do
         dvi_path = '__IMGMATH__.dvi'
         pdf_path = '__IMGMATH__.pdf'
@@ -155,7 +156,6 @@ EOB
             raise CompileError
           end
         end
-
         args = @config['imgmath_options']['pdfcrop_cmd'].shellsplit
         args.map! do |m|
           m.sub('%i', pdf_path).
@@ -201,6 +201,7 @@ EOB
             args = @config['imgmath_options']['pdfcrop_pixelize_cmd'].shellsplit
             args.map! do |m|
               m.sub('%i', pdf_path2).
+                sub('%t', @config['imgmath_options']['format']).
                 sub('%o', File.join(math_dir, "_gen_#{key}.#{@config['imgmath_options']['format']}")).
                 sub('%O', File.join(math_dir, "_gen_#{key}")).
                 sub('%p', page.to_s)
@@ -213,6 +214,7 @@ EOB
           end
         end
       end
+      # rubocop:enable Metrics/BlockLength
     end
 
     def make_math_images_dvipng(dir, tex_path, math_dir)

--- a/lib/review/textmaker.rb
+++ b/lib/review/textmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2018 Kenshi Muto
+# Copyright (c) 2018-2019 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -15,9 +15,12 @@ require 'review/book'
 require 'review/yamlloader'
 require 'review/topbuilder'
 require 'review/version'
+require 'review/makerhelper'
 
 module ReVIEW
   class TEXTMaker
+    include MakerHelper
+
     attr_accessor :config, :basedir
 
     def initialize
@@ -65,6 +68,7 @@ module ReVIEW
     end
 
     def remove_old_files(path)
+      cleanup_mathimg('_review_math_text')
       FileUtils.rm_rf(path)
     end
 
@@ -80,6 +84,7 @@ module ReVIEW
       rescue => e
         error "yaml error #{e.message}"
       end
+
       # YAML configs will be overridden by command line options.
       @config.deep_merge!(cmd_config)
       I18n.setup(@config['language'])
@@ -88,6 +93,11 @@ module ReVIEW
       rescue ApplicationError => e
         raise if @config['debug']
         error(e.message)
+      end
+
+      math_dir = "./#{@config['imagedir']}/_review_math_text"
+      if @config['textmaker']['imgmath'] && File.exist?(File.join(math_dir, '__IMGMATH_BODY__.tex'))
+        make_math_images(math_dir)
       end
     end
 

--- a/lib/review/textmaker.rb
+++ b/lib/review/textmaker.rb
@@ -96,7 +96,7 @@ module ReVIEW
       end
 
       math_dir = "./#{@config['imagedir']}/_review_math_text"
-      if @config['textmaker']['imgmath'] && File.exist?(File.join(math_dir, '__IMGMATH_BODY__.tex'))
+      if @config['imgmath'] && File.exist?(File.join(math_dir, '__IMGMATH_BODY__.tex'))
         make_math_images(math_dir)
       end
     end

--- a/lib/review/textutils.rb
+++ b/lib/review/textutils.rb
@@ -1,3 +1,11 @@
+# Copyright (c) 2008-2019 Minero Aoki, Kenshi Muto, Masayoshi Takahashi,
+#                         KADO Masanori
+#               2002-2007 Minero Aoki
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+#
 require 'nkf'
 require 'digest'
 

--- a/lib/review/textutils.rb
+++ b/lib/review/textutils.rb
@@ -1,4 +1,5 @@
 require 'nkf'
+require 'digest'
 
 module ReVIEW
   module TextUtils
@@ -30,6 +31,17 @@ module ReVIEW
         blocked_lines.map! { |i| [pre] + i + [post] }
       end
       blocked_lines.map(&:join)
+    end
+
+    def defer_math_image(str, path, key)
+      # for Re:VIEW >3
+      File.open(File.join(File.dirname(path), '__IMGMATH_BODY__.tex'), 'a+') do |f|
+        f.puts str
+        f.puts '\\clearpage'
+      end
+      File.open(File.join(File.dirname(path), '__IMGMATH_BODY__.map'), 'a+') do |f|
+        f.puts key
+      end
     end
 
     private

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -181,7 +181,7 @@ module ReVIEW
         end
       end
 
-      if @book.config['textmaker'] && @book.config['textmaker']['imgmath']
+      if @book.config['imgmath']
         fontsize = @book.config['imgmath_options']['fontsize'].to_f
         lineheight = @book.config['imgmath_options']['lineheight'].to_f
         math_str = "\\begin{equation*}\n\\fontsize{#{fontsize}}{#{lineheight}}\\selectfont\n#{unescape(lines.join("\n"))}\n\\end{equation*}\n"
@@ -373,7 +373,7 @@ module ReVIEW
     end
 
     def inline_m(str)
-      if @book.config['textmaker'] && @book.config['textmaker']['imgmath']
+      if @book.config['imgmath']
         math_str = '$' + str + '$'
         key = Digest::SHA256.hexdigest(str)
         math_dir = File.join(@book.config['imagedir'], '_review_math_text')

--- a/samples/sample-book/src/lib/tasks/review.rake
+++ b/samples/sample-book/src/lib/tasks/review.rake
@@ -110,4 +110,4 @@ file TEXTROOT => SRC do
   FileUtils.rm_rf [TEXTROOT]
 end
 
-CLEAN.include([BOOK, BOOK_PDF, BOOK_EPUB, BOOK + '-pdf', BOOK + '-epub', WEBROOT, 'images/_review_math', TEXTROOT])
+CLEAN.include([BOOK, BOOK_PDF, BOOK_EPUB, BOOK + '-pdf', BOOK + '-epub', WEBROOT, 'images/_review_math', 'images/_review_math_text', TEXTROOT])


### PR DESCRIPTION
#1338 の対応

- 旧互換のためにtextmaker/imgmathはnullにしている…けどメーカ単位で分けずに親のimgmathパラメータをそのまま使うのでもいいかも(分けたいときはconfig.ymlレベルで分ける)
- pdfcrop_pixelize_cmdがpng固定だったので%tでフォーマット名が入るように
- defer_math_imageは共有のためhtmlbuilderからtextutilsへ
- とりあえず数式フォルダはEPUB側とわけるために `_review_math_text` とした

なお、PDFのまま保持したいときは
```
textmaker:
  imgmath: true
imgmath_options:
  format: pdf
  extract_singlepage: true
  pdfextract_cmd: "pdftk A=%i cat A%p output %o"
  pdfcrop_pixelize_cmd: "mv %i %o"
```
というかんじです(pdfextract_cmdのデフォルトで使っているpdfjamだと、どうもghostscriptのバグで結果がおかしい？)。