### PR TITLE
reviewcode/reviewttのマクロを直接呼び出しにする

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -167,8 +167,11 @@
 \DeclareRobustCommand{\reviewunderline}[1]{\underline{#1}}% ulemかjumolineで上書き。デフォルトはulemにしている
 \DeclareRobustCommand{\reviewit}[1]{\textit{#1}}
 \DeclareRobustCommand{\reviewbold}[1]{\textbf{#1}}
-\DeclareRobustCommand{\reviewcode}[1]{\texttt{#1}}
-\DeclareRobustCommand{\reviewtt}[1]{\texttt{#1}}
+\let\reviewcode\texttt
+\let\reviewtt\texttt
+% below macro removes a space in an argument unexpectedly
+%\DeclareRobustCommand{\reviewcode}[1]{\texttt{#1}}
+%\DeclareRobustCommand{\reviewtt}[1]{\texttt{#1}}
 \DeclareRobustCommand{\reviewtti}[1]{\texttt{\textit{#1}}}
 \DeclareRobustCommand{\reviewttb}[1]{\texttt{\textbf{#1}}}
 \DeclareRobustCommand{\reviewbou}[1]{\kenten{#1}}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -264,8 +264,11 @@
 \DeclareRobustCommand{\reviewunderline}[1]{\Underline{#1}}
 \DeclareRobustCommand{\reviewit}[1]{\textit{#1}}
 \DeclareRobustCommand{\reviewbold}[1]{\textbf{#1}}
-\DeclareRobustCommand{\reviewcode}[1]{\texttt{#1}}
-\DeclareRobustCommand{\reviewtt}[1]{\texttt{#1}}
+\let\reviewcode\texttt
+\let\reviewtt\texttt
+% below macro removes a space in an argument unexpectedly
+%\DeclareRobustCommand{\reviewcode}[1]{\texttt{#1}}
+%\DeclareRobustCommand{\reviewtt}[1]{\texttt{#1}}
 \DeclareRobustCommand{\reviewtti}[1]{\texttt{\textit{#1}}}
 \DeclareRobustCommand{\reviewttb}[1]{\texttt{\textbf{#1}}}
 \DeclareRobustCommand{\reviewbou}[1]{\kenten{#1}}


### PR DESCRIPTION
現状では、reviewcode, reviewttの中で空白を使うと空白が消えてしまう。
これにはあまり良い解決方法がなさそうだが、letマクロで単純に挙動コピーすることで素のtextttと同じ挙動になるようにする。

（reviewtti, reviewttbについてはマクロで囲んでいるのでやはり空白が消えてしまうが、これはこのパッチでは解決できない。）