### PR TITLE
各ビルダのtableメソッドのリファクタリング

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -162,7 +162,7 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin(rows.first.size)
-      table_tr(sepidx, rows)
+      table_rows(sepidx, rows)
       table_end
     end
 
@@ -181,7 +181,7 @@ module ReVIEW
       [sepidx, rows]
     end
 
-    def table_tr(sepidx, rows)
+    def table_rows(sepidx, rows)
       if sepidx
         sepidx.times do
           tr(rows.shift.map { |s| th(s) })

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -642,20 +642,7 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      rows = []
-      sepidx = nil
-      lines.each_with_index do |line, idx|
-        if /\A[\=\-]{12}/ =~ line
-          # just ignore
-          # error "too many table separator" if sepidx
-          sepidx ||= idx
-          next
-        end
-        rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
-      end
-      rows = adjust_n_cols(rows)
-      error 'no rows in the table' if rows.empty?
-
+      sepidx, rows = parse_table_rows(lines)
       if id
         puts %Q(<div id="#{normalize_id(id)}" class="table">)
       else
@@ -669,19 +656,7 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin rows.first.size
-      if sepidx
-        sepidx.times do
-          tr(rows.shift.map { |s| th(s) })
-        end
-        rows.each do |cols|
-          tr(cols.map { |s| td(s) })
-        end
-      else
-        rows.each do |cols|
-          h, *cs = *cols
-          tr([th(h)] + cs.map { |s| td(s) })
-        end
-      end
+      table_tr(sepidx, rows)
       table_end
       puts '</div>'
     end

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -656,7 +656,7 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin(rows.first.size)
-      table_tr(sepidx, rows)
+      table_rows(sepidx, rows)
       table_end
       puts '</div>'
     end

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -642,22 +642,12 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      sepidx, rows = parse_table_rows(lines)
       if id
         puts %Q(<div id="#{normalize_id(id)}" class="table">)
       else
         puts %Q(<div class="table">)
       end
-      begin
-        if caption.present?
-          table_header(id, caption)
-        end
-      rescue KeyError
-        error "no such table: #{id}"
-      end
-      table_begin(rows.first.size)
-      table_rows(sepidx, rows)
-      table_end
+      super(lines, id, caption)
       puts '</div>'
     end
 

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -469,7 +469,7 @@ module ReVIEW
       else
         print %Q(<tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="#{rows.length}" aid:tcols="#{@col}">)
       end
-      table_tr(sepidx, rows)
+      table_rows(sepidx, rows)
       puts '</tbody></table>'
       @tsize = nil
     end
@@ -494,7 +494,7 @@ module ReVIEW
       [sepidx, rows]
     end
 
-    def table_tr(sepidx, rows)
+    def table_rows(sepidx, rows)
       cellwidth = []
       if @tablewidth
         if @tsize.nil?

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -449,47 +449,14 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      tablewidth = @book.config['tableopt'] ? @book.config['tableopt'].split(',')[0].to_f / @book.config['pt_to_mm_unit'].to_f : nil
-      col = 0
-
-      rows = []
-      sepidx = nil
-      lines.each_with_index do |line, idx|
-        if /\A[\=\-]{12}/ =~ line
-          sepidx ||= idx
-          next
-        end
-        if tablewidth
-          rows.push(line.gsub(/\t\.\t/, "\tDUMMYCELLSPLITTER\t").gsub(/\t\.\.\t/, "\t.\t").gsub(/\t\.\Z/, "\tDUMMYCELLSPLITTER").gsub(/\t\.\.\Z/, "\t.").gsub(/\A\./, ''))
-        else
-          rows.push(line.gsub(/\t\.\t/, "\t\t").gsub(/\t\.\.\t/, "\t.\t").gsub(/\t\.\Z/, "\t").gsub(/\t\.\.\Z/, "\t.").gsub(/\A\./, ''))
-        end
-        col2 = rows[rows.length - 1].split(/\t/).length
-        col = col2 if col2 > col
+      @tablewidth = nil
+      if @book.config['tableopt']
+        @tablewidth = @book.config['tableopt'].split(',')[0].to_f / @book.config['pt_to_mm_unit'].to_f
       end
-      error 'no rows in the table' if rows.empty?
+      @col = 0
 
+      sepidx, rows = parse_table_rows(lines)
       puts '<table>'
-
-      cellwidth = []
-      if tablewidth
-        if @tsize.nil?
-          col.times { |n| cellwidth[n] = tablewidth / col }
-        else
-          cellwidth = @tsize.split(/\s*,\s*/)
-          totallength = 0
-          cellwidth.size.times do |n|
-            cellwidth[n] = cellwidth[n].to_f / @book.config['pt_to_mm_unit'].to_f
-            totallength += cellwidth[n]
-            warn "total length exceeds limit for table: #{id}" if totallength > tablewidth
-          end
-          if cellwidth.size < col
-            cw = (tablewidth - totallength) / (col - cellwidth.size)
-            warn "auto cell sizing exceeds limit for table: #{id}" if cw <= 0
-            (cellwidth.size..(col - 1)).each { |i| cellwidth[i] = cw }
-          end
-        end
-      end
 
       begin
         table_header id, caption if caption.present?
@@ -497,15 +464,60 @@ module ReVIEW
         error "no such table: #{id}"
       end
 
-      if tablewidth.nil?
+      if @tablewidth.nil?
         print '<tbody>'
       else
-        print %Q(<tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="#{rows.length}" aid:tcols="#{col}">)
+        print %Q(<tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="#{rows.length}" aid:tcols="#{@col}">)
+      end
+      table_tr sepidx, rows
+      puts '</tbody></table>'
+      @tsize = nil
+    end
+
+    def parse_table_rows(lines)
+      sepidx = nil
+      rows = []
+      lines.each_with_index do |line, idx|
+        if /\A[\=\-]{12}/ =~ line
+          sepidx ||= idx
+          next
+        end
+        if @tablewidth
+          rows.push(line.gsub(/\t\.\t/, "\tDUMMYCELLSPLITTER\t").gsub(/\t\.\.\t/, "\t.\t").gsub(/\t\.\Z/, "\tDUMMYCELLSPLITTER").gsub(/\t\.\.\Z/, "\t.").gsub(/\A\./, ''))
+        else
+          rows.push(line.gsub(/\t\.\t/, "\t\t").gsub(/\t\.\.\t/, "\t.\t").gsub(/\t\.\Z/, "\t").gsub(/\t\.\.\Z/, "\t.").gsub(/\A\./, ''))
+        end
+        col2 = rows[rows.length - 1].split(/\t/).length
+        @col = col2 if col2 > @col
+      end
+      error 'no rows in the table' if rows.empty?
+      [sepidx, rows]
+    end
+
+    def table_tr(sepidx, rows)
+      cellwidth = []
+      if @tablewidth
+        if @tsize.nil?
+          @col.times { |n| cellwidth[n] = @tablewidth / @col }
+        else
+          cellwidth = @tsize.split(/\s*,\s*/)
+          totallength = 0
+          cellwidth.size.times do |n|
+            cellwidth[n] = cellwidth[n].to_f / @book.config['pt_to_mm_unit'].to_f
+            totallength += cellwidth[n]
+            warn "total length exceeds limit for table: #{id}" if totallength > @tablewidth
+          end
+          if cellwidth.size < @col
+            cw = (@tablewidth - totallength) / (@col - cellwidth.size)
+            warn "auto cell sizing exceeds limit for table: #{id}" if cw <= 0
+            (cellwidth.size..(@col - 1)).each { |i| cellwidth[i] = cw }
+          end
+        end
       end
 
       if sepidx
         sepidx.times do |y|
-          if tablewidth.nil?
+          if @tablewidth.nil?
             puts %Q(<tr type="header">#{rows.shift}</tr>)
           else
             i = 0
@@ -516,9 +528,7 @@ module ReVIEW
           end
         end
       end
-      trputs(tablewidth, rows, cellwidth, sepidx)
-      puts '</tbody></table>'
-      @tsize = nil
+      trputs(@tablewidth, rows, cellwidth, sepidx)
     end
 
     def trputs(tablewidth, rows, cellwidth, sepidx)
@@ -564,7 +574,6 @@ module ReVIEW
     end
 
     def table_end
-      print '<?dtp tablerow last?>'
     end
 
     def emtable(lines, caption = nil)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -593,18 +593,6 @@ module ReVIEW
 
     alias_method :numberlessimage, :indepimage
 
-    def table(lines, id = nil, caption = nil)
-      sepidx, rows = parse_table_rows(lines)
-      begin
-        table_header(id, caption) if caption.present?
-      rescue KeyError
-        error "no such table: #{id}"
-      end
-      table_begin(rows.first.size)
-      table_rows(sepidx, rows)
-      table_end
-    end
-
     def table_rows(sepidx, rows)
       if sepidx
         sepidx.times do

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -594,26 +594,18 @@ module ReVIEW
     alias_method :numberlessimage, :indepimage
 
     def table(lines, id = nil, caption = nil)
-      rows = []
-      sepidx = nil
-      lines.each_with_index do |line, idx|
-        if /\A[\=\{\-\}]{12}/ =~ line
-          # just ignore
-          # error "too many table separator" if sepidx
-          sepidx ||= idx
-          next
-        end
-        rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
-      end
-      rows = adjust_n_cols(rows)
-      error 'no rows in the table' if rows.empty?
-
+      sepidx, rows = parse_table_rows(lines)
       begin
         table_header(id, caption) if caption.present?
       rescue KeyError
         error "no such table: #{id}"
       end
-      table_begin(rows.first.size)
+      table_begin rows.first.size
+      table_tr sepidx, rows
+      table_end
+    end
+
+    def table_tr(sepidx, rows)
       if sepidx
         sepidx.times do
           cno = -1
@@ -640,7 +632,6 @@ module ReVIEW
              end)
         end
       end
-      table_end
     end
 
     def table_header(id, caption)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -601,11 +601,11 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin(rows.first.size)
-      table_tr(sepidx, rows)
+      table_rows(sepidx, rows)
       table_end
     end
 
-    def table_tr(sepidx, rows)
+    def table_rows(sepidx, rows)
       if sepidx
         sepidx.times do
           cno = -1

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -254,11 +254,11 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin(rows.first.size)
-      table_tr(sepidx, rows)
+      table_rows(sepidx, rows)
       table_end
     end
 
-    def table_tr(sepidx, rows)
+    def table_rows(sepidx, rows)
       if sepidx
         sepidx.times do
           tr(rows.shift.map { |s| th(s) })

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -1,3 +1,5 @@
+# Copyright (c) 2013-2019 KADO Masanori, Masayoshi Takahashi, Kenshi Muto
+#
 # This program is free software.
 # You can distribute or modify this program under the terms of
 # the GNU LGPL, Lesser General Public License version 2.1.
@@ -245,26 +247,18 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      rows = []
-      sepidx = nil
-      lines.each_with_index do |line, idx|
-        if /\A[\=\-]{12}/ =~ line
-          # just ignore
-          # error "too many table separator" if sepidx
-          sepidx ||= idx
-          next
-        end
-        rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
-      end
-      rows = adjust_n_cols(rows)
-      error 'no rows in the table' if rows.empty?
-
+      sepidx, rows = parse_table_rows(lines)
       begin
         table_header id, caption unless caption.nil?
       rescue KeyError
         error "no such table: #{id}"
       end
       table_begin rows.first.size
+      table_tr sepidx, rows
+      table_end
+    end
+
+    def table_tr(sepidx, rows)
       if sepidx
         sepidx.times do
           tr(rows.shift.map { |s| th(s) })
@@ -279,7 +273,6 @@ module ReVIEW
           tr([th(h)] + cs.map { |s| td(s) })
         end
       end
-      table_end
     end
 
     def table_header(id, caption)

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -246,18 +246,6 @@ module ReVIEW
       puts '```'
     end
 
-    def table(lines, id = nil, caption = nil)
-      sepidx, rows = parse_table_rows(lines)
-      begin
-        table_header(id, caption) unless caption.nil?
-      rescue KeyError
-        error "no such table: #{id}"
-      end
-      table_begin(rows.first.size)
-      table_rows(sepidx, rows)
-      table_end
-    end
-
     def table_rows(sepidx, rows)
       if sepidx
         sepidx.times do

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -221,20 +221,7 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      rows = []
-      sepidx = nil
-      lines.each_with_index do |line, idx|
-        if /\A[\=\-]{12}/ =~ line
-          # just ignore
-          # error "too many table separator" if sepidx
-          sepidx ||= idx
-          next
-        end
-        rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
-      end
-      rows = adjust_n_cols(rows)
-      error 'no rows in the table' if rows.empty?
-
+      sepidx, rows = parse_table_rows(lines)
       blank
 
       begin
@@ -243,19 +230,7 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin rows.first.size
-      if sepidx
-        sepidx.times do
-          tr(rows.shift.map { |s| th(s) })
-        end
-        rows.each do |cols|
-          tr(cols.map { |s| td(s) })
-        end
-      else
-        rows.each do |cols|
-          h, *cs = *cols
-          tr([th(h)] + cs.map { |s| td(s) })
-        end
-      end
+      table_tr sepidx, rows
       table_end
     end
 

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -220,18 +220,11 @@ module ReVIEW
       blank
     end
 
-    def table(lines, id = nil, caption = nil)
-      sepidx, rows = parse_table_rows(lines)
-      blank
-
-      begin
-        table_header(id, caption) if caption.present?
-      rescue KeyError
-        error "no such table: #{id}"
+    def table(lines, id = nil, caption = nil, noblank = nil)
+      unless noblank
+        blank
       end
-      table_begin(rows.first.size)
-      table_rows(sepidx, rows)
-      table_end
+      super(lines, id, caption)
     end
 
     def table_header(id, caption)

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -230,7 +230,7 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin(rows.first.size)
-      table_tr(sepidx, rows)
+      table_rows(sepidx, rows)
       table_end
     end
 

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -200,20 +200,7 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      rows = []
-      sepidx = nil
-      lines.each_with_index do |line, idx|
-        if /\A[\=\-]{12}/ =~ line
-          # just ignore
-          # error "too many table separator" if sepidx
-          sepidx ||= idx
-          next
-        end
-        rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
-      end
-      rows = adjust_n_cols(rows)
-      error 'no rows in the table' if rows.empty?
-
+      sepidx, rows = parse_table_rows(lines)
       blank
       puts "◆→開始:#{@titles['table']}←◆"
 
@@ -223,19 +210,7 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin rows.first.size
-      if sepidx
-        sepidx.times do
-          tr(rows.shift.map { |s| th(s) })
-        end
-        rows.each do |cols|
-          tr(cols.map { |s| td(s) })
-        end
-      else
-        rows.each do |cols|
-          h, *cs = *cols
-          tr([th(h)] + cs.map { |s| td(s) })
-        end
-      end
+      table_tr sepidx, rows
       table_end
     end
 

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -210,7 +210,7 @@ module ReVIEW
         error "no such table: #{id}"
       end
       table_begin(rows.first.size)
-      table_tr(sepidx, rows)
+      table_rows(sepidx, rows)
       table_end
     end
 

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -200,18 +200,9 @@ module ReVIEW
     end
 
     def table(lines, id = nil, caption = nil)
-      sepidx, rows = parse_table_rows(lines)
       blank
       puts "◆→開始:#{@titles['table']}←◆"
-
-      begin
-        table_header(id, caption) if caption.present?
-      rescue KeyError
-        error "no such table: #{id}"
-      end
-      table_begin(rows.first.size)
-      table_rows(sepidx, rows)
-      table_end
+      super(lines, id, caption, true)
     end
 
     def th(str)


### PR DESCRIPTION
#1330 の準備の一環として、tableメソッドの整理をしました。

- sepidx解析部分はほとんどのビルダで共通なので、Builder#parse_table_rowsを導入
- その後のtrを各処理する部分もほぼ共通なので、Builder#table_trを導入

ただ、latexbuilderやidgxmlなどでどうしても渡したい固有の変数があり、仕方がないのでインスタンス変数を使って渡すようにしているところもあります。
