### PR TITLE
XXX_header, XXX_bodyのリファクタリング

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -540,6 +540,7 @@ module ReVIEW
 
     def texequation(lines, id = nil, caption = '')
       if id
+        puts %Q(<div id="#{normalize_id(id)}" class="caption-equation">)
         texequation_header id, caption
       end
 
@@ -551,7 +552,6 @@ module ReVIEW
     end
 
     def texequation_header(id, caption)
-      puts %Q(<div id="#{normalize_id(id)}" class="caption-equation">)
       if get_chap
         puts %Q(<p class="caption">#{I18n.t('equation')}#{I18n.t('format_number_header', [get_chap, @chapter.equation(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}</p>)
       else

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -271,7 +271,6 @@ module ReVIEW
     end
 
     def list_header(id, caption, _lang)
-      puts '<codelist>'
       return true unless caption.present?
       if get_chap.nil?
         puts %Q(<caption>#{I18n.t('list')}#{I18n.t('format_number_without_chapter', [@chapter.list(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}</caption>)
@@ -296,10 +295,21 @@ module ReVIEW
       end
     end
 
+    def list(lines, id, caption, lang = nil)
+      puts '<codelist>'
+      begin
+        list_header id, caption, lang
+      rescue KeyError
+        error "no such list: #{id}"
+      end
+      list_body id, lines, lang
+      puts '</codelist>'
+    end
+
     def list_body(_id, lines, _lang)
       print '<pre>'
       codelines_body(lines)
-      puts '</pre></codelist>'
+      print '</pre>'
     end
 
     def emlist(lines, caption = nil, _lang = nil)
@@ -313,6 +323,17 @@ module ReVIEW
         lines2 << detab(%Q(<span type='lineno'>) + (i + first_line_num).to_s.rjust(2) + ': </span>' + line)
       end
       quotedlist lines2, 'emlistnum', caption
+    end
+
+    def listnum(lines, id, caption, lang = nil)
+      puts '<codelist>'
+      begin
+        list_header id, caption, lang
+      rescue KeyError
+        error "no such list: #{id}"
+      end
+      listnum_body lines, lang
+      puts '</codelist>'
     end
 
     def listnum_body(lines, _lang)
@@ -331,7 +352,7 @@ module ReVIEW
         print '</listinfo>' if @book.config['listinfo']
         no += 1
       end
-      puts '</pre></codelist>'
+      print '</pre>'
     end
 
     def cmd(lines, caption = nil)
@@ -1134,25 +1155,31 @@ module ReVIEW
       error "unknown chapter: #{id}"
     end
 
-    def source_header(caption)
+    def source(lines, caption, lang = nil)
       puts '<source>'
+      source_header caption
+      source_body lines, lang
+      puts '</source>'
+    end
+
+    def source_header(caption)
       puts %Q(<caption>#{compile_inline(caption)}</caption>) if caption.present?
     end
 
     def source_body(lines, _lang)
       puts '<pre>'
       codelines_body(lines)
-      puts '</pre></source>'
+      print '</pre>'
     end
 
     def bibpaper(lines, id, caption)
+      puts %Q(<bibitem id="bib-#{id}">)
       bibpaper_header id, caption
       bibpaper_bibpaper id, caption, lines unless lines.empty?
       puts '</bibitem>'
     end
 
     def bibpaper_header(id, caption)
-      puts %Q(<bibitem id="bib-#{id}">)
       puts "<caption><span type='bibno'>[#{@chapter.bibpaper(id).number}] </span>#{compile_inline(caption)}</caption>" if caption.present?
     end
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -32,7 +32,6 @@ module ReVIEW
       @blank_needed = false
       @latex_tsize = nil
       @tsize = nil
-      @table_caption = nil
       @cellwidth = nil
       @ol_num = nil
       @first_line_num = nil
@@ -594,6 +593,14 @@ module ReVIEW
     alias_method :numberlessimage, :indepimage
 
     def table(lines, id = nil, caption = nil)
+      if caption.present?
+        if @book.config.check_version('2', exception: false)
+          puts "\\begin{table}[h]%%#{id}"
+        else
+          puts "\\begin{table}%%#{id}"
+        end
+      end
+
       sepidx, rows = parse_table_rows(lines)
       begin
         table_header(id, caption) if caption.present?
@@ -603,6 +610,10 @@ module ReVIEW
       table_begin rows.first.size
       table_tr sepidx, rows
       table_end
+      if caption.present?
+        puts '\end{table}'
+      end
+      blank
     end
 
     def table_tr(sepidx, rows)
@@ -637,25 +648,13 @@ module ReVIEW
     def table_header(id, caption)
       if id.nil?
         if caption.present?
-          @table_caption = true
           @doc_status[:caption] = true
-          if @book.config.check_version('2', exception: false)
-            puts "\\begin{table}[h]%%#{id}"
-          else
-            puts "\\begin{table}%%#{id}"
-          end
           puts macro('reviewtablecaption*', compile_inline(caption))
           @doc_status[:caption] = nil
         end
       else
         if caption.present?
-          @table_caption = true
           @doc_status[:caption] = true
-          if @book.config.check_version('2', exception: false)
-            puts "\\begin{table}[h]%%#{id}"
-          else
-            puts "\\begin{table}%%#{id}"
-          end
           puts macro('reviewtablecaption', compile_inline(caption))
           @doc_status[:caption] = nil
         end
@@ -758,12 +757,9 @@ module ReVIEW
 
     def table_end
       puts macro('end', 'reviewtable')
-      puts '\end{table}' if @table_caption
-      @table_caption = nil
       @tsize = nil
       @latex_tsize = nil
       @cellwidth = nil
-      blank
     end
 
     def emtable(lines, caption = nil)
@@ -779,9 +775,8 @@ module ReVIEW
 
       begin
         if caption.present?
-          @table_caption = true
-          @doc_status[:caption] = true
           puts "\\begin{table}[h]%%#{id}"
+          @doc_status[:caption] = true
           puts macro('reviewimgtablecaption', compile_inline(caption))
           @doc_status[:caption] = nil
         end
@@ -791,8 +786,9 @@ module ReVIEW
       end
       imgtable_image(id, caption, metric)
 
-      puts '\end{table}' if @table_caption
-      @table_caption = nil
+      if caption.present?
+        puts '\end{table}'
+      end
       blank
     end
 

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -65,24 +65,26 @@ module ReVIEW
       @noindent = true
     end
 
-    def list_header(id, caption, lang)
+    def list_header(id, caption, _lang)
       if get_chap.nil?
         print %Q(リスト#{@chapter.list(id).number} #{compile_inline(caption)}\n\n)
       else
         print %Q(リスト#{get_chap}.#{@chapter.list(id).number} #{compile_inline(caption)}\n\n)
       end
-      lang ||= ''
-      puts "```#{lang}"
     end
 
-    def list_body(_id, lines, _lang)
+    def list_body(_id, lines, lang)
+      lang ||= ''
+      puts "```#{lang}"
       lines.each do |line|
         puts detab(line)
       end
       puts '```'
     end
 
-    def listnum_body(lines, _lang)
+    def listnum_body(lines, lang)
+      lang ||= ''
+      puts "```#{lang}"
       lines.each_with_index do |line, i|
         puts((i + 1).to_s.rjust(2) + ": #{detab(line)}")
       end
@@ -136,9 +138,9 @@ module ReVIEW
 
     def emlist(lines, caption = nil, lang = nil)
       blank
-      if caption
+      if caption.present?
         puts caption
-        print "\n"
+        blank
       end
       lang ||= ''
       puts "```#{lang}"
@@ -238,7 +240,11 @@ module ReVIEW
       'jpg'
     end
 
-    def cmd(lines)
+    def cmd(lines, caption = nil)
+      if caption.present?
+        puts caption
+        blank
+      end
       puts '```shell-session'
       lines.each do |line|
         puts detab(line)

--- a/lib/review/md2inaobuilder.rb
+++ b/lib/review/md2inaobuilder.rb
@@ -11,9 +11,7 @@ module ReVIEW
       puts "\n"
     end
 
-    def list_header(id, caption, lang)
-      lang ||= ''
-      puts "```#{lang}"
+    def list_header(id, caption, _lang)
       print %Q(●リスト#{@chapter.list(id).number}::#{compile_inline(caption)}\n\n)
     end
 

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -137,21 +137,30 @@ module ReVIEW
 
     alias_method :lead, :read
 
-    def list_header(id, caption, _lang)
+    def list(lines, id, caption, lang = nil)
       blank
+      begin
+        list_header id, caption, lang
+      rescue KeyError
+        error "no such list: #{id}"
+      end
+      blank
+      list_body id, lines, lang
+      blank
+    end
+
+    def list_header(id, caption, _lang)
       if get_chap
         puts %Q(#{I18n.t('list')}#{I18n.t('format_number', [get_chap, @chapter.list(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)})
       else
         puts %Q(#{I18n.t('list')}#{I18n.t('format_number_without_chapter', [@chapter.list(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)})
       end
-      blank
     end
 
     def list_body(_id, lines, _lang)
       lines.each do |line|
         puts detab(line)
       end
-      blank
     end
 
     def base_block(_type, lines, caption = nil)
@@ -181,11 +190,22 @@ module ReVIEW
       blank
     end
 
+    def listnum(lines, id, caption, lang = nil)
+      blank
+      begin
+        list_header id, caption, lang
+      rescue KeyError
+        error "no such list: #{id}"
+      end
+      blank
+      listnum_body lines, lang
+      blank
+    end
+
     def listnum_body(lines, _lang)
       lines.each_with_index do |line, i|
         puts((i + 1).to_s.rjust(2) + ": #{line}")
       end
-      blank
     end
 
     def cmd(lines, caption = nil)
@@ -207,17 +227,20 @@ module ReVIEW
     end
 
     def texequation(lines, id = nil, caption = '')
+      blank
+      texequation_header id, caption
+      puts lines.join("\n")
+      blank
+    end
+
+    def texequation_header(id, caption)
       if id
-        blank
         if get_chap
           puts "#{I18n.t('equation')}#{I18n.t('format_number', [get_chap, @chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
         else
           puts "#{I18n.t('equation')}#{I18n.t('format_number_without_chapter', [@chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
         end
       end
-
-      puts lines.join("\n")
-      blank
     end
 
     def table(lines, id = nil, caption = nil)

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -91,23 +91,32 @@ module ReVIEW
 
     alias_method :lead, :read
 
-    def list_header(id, caption, _lang)
+    def list(lines, id, caption, lang = nil)
       blank
       puts "◆→開始:#{@titles['list']}←◆"
+      begin
+        list_header id, caption, lang
+      rescue KeyError
+        error "no such list: #{id}"
+      end
+      blank
+      list_body id, lines, lang
+      puts "◆→終了:#{@titles['list']}←◆"
+      blank
+    end
+
+    def list_header(id, caption, _lang)
       if get_chap
         puts %Q(#{I18n.t('list')}#{I18n.t('format_number', [get_chap, @chapter.list(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)})
       else
         puts %Q(#{I18n.t('list')}#{I18n.t('format_number_without_chapter', [@chapter.list(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)})
       end
-      blank
     end
 
     def list_body(_id, lines, _lang)
       lines.each do |line|
         puts detab(line)
       end
-      puts "◆→終了:#{@titles['list']}←◆"
-      blank
     end
 
     def base_block(type, lines, caption = nil)
@@ -139,12 +148,24 @@ module ReVIEW
       blank
     end
 
+    def listnum(lines, id, caption, lang = nil)
+      blank
+      puts "◆→開始:#{@titles['list']}←◆"
+      begin
+        list_header id, caption, lang
+      rescue KeyError
+        error "no such list: #{id}"
+      end
+      blank
+      listnum_body lines, lang
+      puts "◆→終了:#{@titles['list']}←◆"
+      blank
+    end
+
     def listnum_body(lines, _lang)
       lines.each_with_index do |line, i|
         puts((i + 1).to_s.rjust(2) + ": #{line}")
       end
-      puts "◆→終了:#{@titles['list']}←◆"
-      blank
     end
 
     def image(lines, id, caption, metric = nil)
@@ -152,11 +173,7 @@ module ReVIEW
       metrics = " #{metrics}" if metrics.present?
       blank
       puts "◆→開始:#{@titles['image']}←◆"
-      if get_chap
-        puts "#{I18n.t('image')}#{I18n.t('format_number', [get_chap, @chapter.image(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
-      else
-        puts "#{I18n.t('image')}#{I18n.t('format_number_without_chapter', [@chapter.image(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
-      end
+      image_header id, caption
       blank
       if @chapter.image(id).bound?
         puts "◆→#{@chapter.image(id).path}#{metrics}←◆"
@@ -170,16 +187,18 @@ module ReVIEW
       blank
     end
 
+    def image_header(id, caption)
+      if get_chap
+        puts "#{I18n.t('image')}#{I18n.t('format_number', [get_chap, @chapter.image(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
+      else
+        puts "#{I18n.t('image')}#{I18n.t('format_number_without_chapter', [@chapter.image(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
+      end
+    end
+
     def texequation(lines, id = nil, caption = '')
       blank
       puts "◆→開始:#{@titles['texequation']}←◆"
-      if id
-        if get_chap
-          puts "#{I18n.t('equation')}#{I18n.t('format_number', [get_chap, @chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
-        else
-          puts "#{I18n.t('equation')}#{I18n.t('format_number_without_chapter', [@chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
-        end
-      end
+      texequation_header id, caption
 
       if @book.config['imgmath']
         fontsize = @book.config['imgmath_options']['fontsize'].to_f
@@ -199,6 +218,16 @@ module ReVIEW
       blank
     end
 
+    def texequation_header(id, caption)
+      if id
+        if get_chap
+          puts "#{I18n.t('equation')}#{I18n.t('format_number', [get_chap, @chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
+        else
+          puts "#{I18n.t('equation')}#{I18n.t('format_number_without_chapter', [@chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
+        end
+      end
+    end
+
     def table(lines, id = nil, caption = nil)
       sepidx, rows = parse_table_rows(lines)
       blank
@@ -212,6 +241,9 @@ module ReVIEW
       table_begin rows.first.size
       table_tr sepidx, rows
       table_end
+
+      puts "◆→終了:#{@titles['table']}←◆"
+      blank
     end
 
     def th(str)
@@ -219,8 +251,6 @@ module ReVIEW
     end
 
     def table_end
-      puts "◆→終了:#{@titles['table']}←◆"
-      blank
     end
 
     def comment(lines, comment = nil)

--- a/test/test_md2inaobuilder.rb
+++ b/test/test_md2inaobuilder.rb
@@ -59,9 +59,9 @@ BBB
     EOS
 
     assert_equal <<-EOS, actual
-```
 ●リスト1::caption
 
+```
 AAA
 BBB
 ```


### PR DESCRIPTION
ref #1330 
https://github.com/kmuto/review/wiki/%E3%83%98%E3%83%83%E3%83%80%E3%83%BB%E3%83%95%E3%83%83%E3%82%BF%E3%81%AE%E3%83%AA%E3%83%95%E3%82%A1%E3%82%AF%E3%82%BF%E3%83%AA%E3%83%B3%E3%82%B0%E5%AF%BE%E8%B1%A1%E3%81%AE%E6%A4%9C%E8%A8%8E
のheader/bodyが分離できていない/しづらい ところをまとめてリファクタリングします。

- headerは「キャプションのみ」、bodyは「ボディのみ」を作り、それらを囲むものは親(listやtableなど)のほうに書くようにします。
- 表面上は結果に変わりはないはずですが、review-ext.rbで書き換えていた場合はそれなりに影響します。
- md2inaoのリストキャプションはテストのほうが間違っている気がするので修正しました。
