### PR TITLE
use coltext=white instead of \color

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -32,8 +32,8 @@
  {\end{alltt}\end{tcolorbox}}
 
 \newenvironment{reviewcmd}{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=black!99,colframe=black!99,boxrule=0mm,arc=0mm]\begin{alltt}\begingroup\color{white}\ignorespaces}%
- {\endgroup\end{alltt}\end{tcolorbox}}
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=black!99,coltext=white,colframe=black!99,boxrule=0mm,arc=0mm]\begin{alltt}}%
+ {\end{alltt}\end{tcolorbox}}
 
 % 図
 \newenvironment{reviewimage}{%


### PR DESCRIPTION
#1363 の対応

review-jlreqのtcolorboxの前景文字色について、
\colorのかわりにcoltext=whiteを使います。

review-jsbookのほうはtcolorboxを使っていないので影響しません。