### PR TITLE
PDFMaker: code_lineとcode_line_numにコードリストの各行の装飾を引き渡し

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -329,12 +329,20 @@ module ReVIEW
     end
     private :highlight_listings?
 
+    def code_line(line, _idx, _id, _caption, _lang)
+      detab(line) + "\n"
+    end
+
+    def code_line_num(line, first_line_num, idx, _id, _caption, _lang)
+      detab((idx + first_line_num).to_s.rjust(2) + ': ' + line) + "\n"
+    end
+
     def emlist(lines, caption = nil, lang = nil)
       blank
       if highlight_listings?
         common_code_block_lst(nil, lines, 'reviewemlistlst', 'title', caption, lang)
       else
-        common_code_block(nil, lines, 'reviewemlist', caption, lang) { |line, _idx| detab(line) + "\n" }
+        common_code_block(nil, lines, 'reviewemlist', caption, lang) { |line, idx| code_line(line, idx, nil, caption, lang) }
       end
     end
 
@@ -344,7 +352,7 @@ module ReVIEW
       if highlight_listings?
         common_code_block_lst(nil, lines, 'reviewemlistnumlst', 'title', caption, lang, first_line_num: first_line_num)
       else
-        common_code_block(nil, lines, 'reviewemlist', caption, lang) { |line, idx| detab((idx + first_line_num).to_s.rjust(2) + ': ' + line) + "\n" }
+        common_code_block(nil, lines, 'reviewemlist', caption, lang) { |line, idx| code_line_num(line, first_line_num, idx, nil, caption, lang) }
       end
     end
 
@@ -353,7 +361,7 @@ module ReVIEW
       if highlight_listings?
         common_code_block_lst(id, lines, 'reviewlistlst', 'caption', caption, lang)
       else
-        common_code_block(id, lines, 'reviewlist', caption, lang) { |line, _idx| detab(line) + "\n" }
+        common_code_block(id, lines, 'reviewlist', caption, lang) { |line, idx| code_line(line, idx, id, caption, lang) }
       end
     end
 
@@ -363,7 +371,7 @@ module ReVIEW
       if highlight_listings?
         common_code_block_lst(id, lines, 'reviewlistnumlst', 'caption', caption, lang, first_line_num: first_line_num)
       else
-        common_code_block(id, lines, 'reviewlist', caption, lang) { |line, idx| detab((idx + first_line_num).to_s.rjust(2) + ': ' + line) + "\n" }
+        common_code_block(id, lines, 'reviewlist', caption, lang) { |line, idx| code_line_num(line, first_line_num, idx, id, caption, lang) }
       end
     end
 
@@ -372,7 +380,7 @@ module ReVIEW
         common_code_block_lst(nil, lines, 'reviewcmdlst', 'title', caption, lang)
       else
         blank
-        common_code_block(nil, lines, 'reviewcmd', caption, lang) { |line, _idx| detab(line) + "\n" }
+        common_code_block(nil, lines, 'reviewcmd', caption, lang) { |line, idx| code_line(line, idx, nil, caption, lang) }
       end
     end
 
@@ -449,7 +457,7 @@ module ReVIEW
       if highlight_listings?
         common_code_block_lst(nil, lines, 'reviewsourcelst', 'title', caption, lang)
       else
-        common_code_block(nil, lines, 'reviewsource', caption, lang) { |line, _idx| detab(line) + "\n" }
+        common_code_block(nil, lines, 'reviewsource', caption, lang) { |line, idx| code_line(line, idx, nil, caption, lang) }
       end
     end
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -329,11 +329,11 @@ module ReVIEW
     end
     private :highlight_listings?
 
-    def code_line(line, _idx, _id, _caption, _lang)
+    def code_line(_type, line, _idx, _id, _caption, _lang)
       detab(line) + "\n"
     end
 
-    def code_line_num(line, first_line_num, idx, _id, _caption, _lang)
+    def code_line_num(_type, line, first_line_num, idx, _id, _caption, _lang)
       detab((idx + first_line_num).to_s.rjust(2) + ': ' + line) + "\n"
     end
 
@@ -342,7 +342,7 @@ module ReVIEW
       if highlight_listings?
         common_code_block_lst(nil, lines, 'reviewemlistlst', 'title', caption, lang)
       else
-        common_code_block(nil, lines, 'reviewemlist', caption, lang) { |line, idx| code_line(line, idx, nil, caption, lang) }
+        common_code_block(nil, lines, 'reviewemlist', caption, lang) { |line, idx| code_line('emlist', line, idx, nil, caption, lang) }
       end
     end
 
@@ -352,7 +352,7 @@ module ReVIEW
       if highlight_listings?
         common_code_block_lst(nil, lines, 'reviewemlistnumlst', 'title', caption, lang, first_line_num: first_line_num)
       else
-        common_code_block(nil, lines, 'reviewemlist', caption, lang) { |line, idx| code_line_num(line, first_line_num, idx, nil, caption, lang) }
+        common_code_block(nil, lines, 'reviewemlist', caption, lang) { |line, idx| code_line_num('emlistnum', line, first_line_num, idx, nil, caption, lang) }
       end
     end
 
@@ -361,7 +361,7 @@ module ReVIEW
       if highlight_listings?
         common_code_block_lst(id, lines, 'reviewlistlst', 'caption', caption, lang)
       else
-        common_code_block(id, lines, 'reviewlist', caption, lang) { |line, idx| code_line(line, idx, id, caption, lang) }
+        common_code_block(id, lines, 'reviewlist', caption, lang) { |line, idx| code_line('list', line, idx, id, caption, lang) }
       end
     end
 
@@ -371,7 +371,7 @@ module ReVIEW
       if highlight_listings?
         common_code_block_lst(id, lines, 'reviewlistnumlst', 'caption', caption, lang, first_line_num: first_line_num)
       else
-        common_code_block(id, lines, 'reviewlist', caption, lang) { |line, idx| code_line_num(line, first_line_num, idx, id, caption, lang) }
+        common_code_block(id, lines, 'reviewlist', caption, lang) { |line, idx| code_line_num('listnum', line, first_line_num, idx, id, caption, lang) }
       end
     end
 
@@ -380,7 +380,7 @@ module ReVIEW
         common_code_block_lst(nil, lines, 'reviewcmdlst', 'title', caption, lang)
       else
         blank
-        common_code_block(nil, lines, 'reviewcmd', caption, lang) { |line, idx| code_line(line, idx, nil, caption, lang) }
+        common_code_block(nil, lines, 'reviewcmd', caption, lang) { |line, idx| code_line('cmd', line, idx, nil, caption, lang) }
       end
     end
 
@@ -457,7 +457,7 @@ module ReVIEW
       if highlight_listings?
         common_code_block_lst(nil, lines, 'reviewsourcelst', 'title', caption, lang)
       else
-        common_code_block(nil, lines, 'reviewsource', caption, lang) { |line, idx| code_line(line, idx, nil, caption, lang) }
+        common_code_block(nil, lines, 'reviewsource', caption, lang) { |line, idx| code_line('source', line, idx, nil, caption, lang) }
       end
     end
 


### PR DESCRIPTION
ハイライトを使用しない場合に、行番号なし版および行番号あり版それぞれRe:VIEW側で面倒を見ていますが、コード各行に対する処理(タブとりや行番号付け)をメソッドとして切り出しました。

挙動としては従来と変わりませんが、挙動overrideしたいときに個々のコードリストメソッドを書き換えなくてもcode_line, code_line_numの書き換えだけで済むようになります。
(冗長ながらtype,id,caption,langも渡しているのは書き換え前提としているためです。)