### PR TITLE
add Builder#highlight? for all builders

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -71,6 +71,10 @@ module ReVIEW
     end
     private :builder_init_file
 
+    def highlight?
+      false
+    end
+
     def result
       @output.string
     end

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -324,6 +324,11 @@ module ReVIEW
 
     alias_method :lead, :read
 
+    def highlight?
+      @book.config['highlight'] &&
+        @book.config['highlight']['latex']
+    end
+
     def highlight_listings?
       @book.config['highlight'] && @book.config['highlight']['latex'] == 'listings'
     end


### PR DESCRIPTION
`Builder#highlight?` をHTMLBuilder以外でも使えるようにする修正です。