### PR TITLE
refactor: remove unescape() in all builders

### DIFF
--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -41,7 +41,7 @@ module ReVIEW
     end
 
     def highlight?
-      @book.config['highlight'] &&
+      @book && @book.config['highlight'] &&
         @book.config['highlight']['html']
     end
 

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -82,7 +82,7 @@ module ReVIEW
       begin
         require 'pygments'
         begin
-          Pygments.highlight(unescape(body),
+          Pygments.highlight(body,
                              options: options,
                              formatter: format,
                              lexer: lexer)
@@ -128,7 +128,7 @@ module ReVIEW
         return body
       end
 
-      text = unescape(body)
+      text = body
       formatter.format(lexer.lex(text))
     end
 

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -128,8 +128,7 @@ module ReVIEW
         return body
       end
 
-      text = body
-      formatter.format(lexer.lex(text))
+      formatter.format(lexer.lex(body))
     end
 
     def normalize_id(id)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -427,7 +427,7 @@ module ReVIEW
       if title == 'title' && caption.blank? && @book.config.check_version('2', exception: false)
         print '\vspace{-1.5em}'
       end
-      body = lines.inject('') { |i, j| i + detab(unescape(j)) + "\n" }
+      body = lines.inject('') { |i, j| i + detab(j) + "\n" }
       args = make_code_block_args(title, caption, lang, first_line_num: first_line_num)
       puts %Q(\\begin{#{command}}[#{args}])
       print body


### PR DESCRIPTION
* highlighting code block should not be escaped, but allowed to use inline markup in.

----

#1371 の続きです。これと合わせると、`unescape()`が廃止されます。
これは、エスケープが必要ないところではcompiler/builderの段階でエスケープされていないようになるものです。
