### PR TITLE
@bookが空になっていることによるコンパイルエラーの修正

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -28,13 +28,6 @@ module ReVIEW
 
     def compile(chap)
       @chapter = chap
-      @non_parsed_commands = %i[embed texequation graph]
-      if @strategy.highlight?
-        @non_escaped_commands = %i[list emlist listnum emlistnum cmd]
-      else
-        @non_escaped_commands = []
-      end
-      @command_name_stack = []
       do_compile
       @strategy.result
     end
@@ -231,6 +224,15 @@ module ReVIEW
     def do_compile
       f = LineInput.new(StringIO.new(@chapter.content))
       @strategy.bind(self, @chapter, Location.new(@chapter.basename, f))
+
+      @non_parsed_commands = %i[embed texequation graph]
+      if @strategy.highlight?
+        @non_escaped_commands = %i[list emlist listnum emlistnum cmd]
+      else
+        @non_escaped_commands = []
+      end
+      @command_name_stack = []
+
       tagged_section_init
       while f.next?
         case f.peek

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -41,7 +41,7 @@ module ReVIEW
     end
 
     def highlight?
-      @book && @book.config['highlight'] &&
+      @book.config['highlight'] &&
         @book.config['highlight']['html']
     end
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -325,7 +325,7 @@ module ReVIEW
     alias_method :lead, :read
 
     def highlight?
-      @book.config['highlight'] &&
+      @book && @book.config['highlight'] &&
         @book.config['highlight']['latex']
     end
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -325,7 +325,7 @@ module ReVIEW
     alias_method :lead, :read
 
     def highlight?
-      @book && @book.config['highlight'] &&
+      @book.config['highlight'] &&
         @book.config['highlight']['latex']
     end
 


### PR DESCRIPTION
#1376 の修正。

#1374 の修正です。
bindをしないと`@book`が初期化されないので、do_compileのほうにhighlightチェックのロジックを移動しました。

587d4cf76 が原因をアラートしていたのに隠してしまっていましたね…。とりあえずこれはrevertしました。