### PR TITLE
PDFMaker: -halt-on-errorオプションをデフォルトに追加

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -328,7 +328,7 @@ epubmaker:
 # texcommand: "uplatex"
 #
 # LaTeXのコマンドに渡すオプションを指定する
-# texoptions: "-interaction=nonstopmode -file-line-error"
+# texoptions: "-interaction=nonstopmode -file-line-error -halt-on-error"
 #
 # LaTeX用のdvi変換コマンドを指定する(dvipdfmx)
 # dvicommand: "dvipdfmx"

--- a/doc/pdfmaker.ja.md
+++ b/doc/pdfmaker.ja.md
@@ -121,7 +121,7 @@ LaTeX コンパイラコマンドおよびオプションについて、Re:VIEW 
 
 ```yaml
 texcommand: uplatex
-texoptions: "-interaction=nonstopmode -file-line-error"
+texoptions: "-interaction=nonstopmode -file-line-error -halt-on-error"
 texdocumentclass: ["jsbook", "uplatex,oneside"]
 dvicommand: dvipdfmx
 dvioptions: "-d 5"

--- a/doc/pdfmaker.md
+++ b/doc/pdfmaker.md
@@ -100,7 +100,7 @@ Default settings of Re:VIEW is below:
 
 ```yaml
 texcommand: uplatex
-texoptions: "-interaction=nonstopmode -file-line-error"
+texoptions: "-interaction=nonstopmode -file-line-error -halt-on-error"
 texdocumentclass: ["review-jsbook", "uplatex,twoside"]
 dvicommand: dvipdfmx
 dvioptions: "-d 5"

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -76,7 +76,7 @@ module ReVIEW
         'image_scale2width' => true,
         'footnotetext' => nil,
         'texcommand' => 'uplatex',
-        'texoptions' => '-interaction=nonstopmode -file-line-error',
+        'texoptions' => '-interaction=nonstopmode -file-line-error -halt-on-error',
         '_texdocumentclass' => ['review-jsbook', ''],
         'dvicommand' => 'dvipdfmx',
         'dvioptions' => '-d 5 -z 9',

--- a/lib/review/update.rb
+++ b/lib/review/update.rb
@@ -27,7 +27,7 @@ module ReVIEW
     TEX_DOCUMENTCLASS_BAD = ['jsbook', nil]
     TEX_DOCUMENTCLASS_OPTS = 'media=print,paper=a5'
     TEX_COMMAND = 'uplatex'
-    TEX_OPTIONS = '-interaction=nonstopmode -file-line-error'
+    TEX_OPTIONS = '-interaction=nonstopmode -file-line-error -halt-on-error'
     DVI_COMMAND = 'dvipdfmx'
     DVI_OPTIONS = '-d 5 -z 9'
 

--- a/test/test_update.rb
+++ b/test/test_update.rb
@@ -389,7 +389,7 @@ EOT
     assert_match(/has options/, io.string)
     cont = <<EOT
 texcommand: "/Program Files/up-latex"
-texoptions: "-interaction=nonstopmode -file-line-error --shell-escape -v"
+texoptions: "-interaction=nonstopmode -file-line-error -halt-on-error --shell-escape -v"
 EOT
     assert_equal cont, File.read(File.join(@tmpdir, 'config.yml'))
   end


### PR DESCRIPTION
現状の`-interaction=nonstopmode -file-line-error`だと、エラーが出てもとりあえず進んで、でもエラーなので結局異常終了してしまい、原因がずっと上のほうでわからない ということになりがちです。

どうせTeXのエラーになったらRe:VIEWの場合はどうしようもないので、`-halt-on-error`を追加して、エラー即終了にしたいと思います。

```
28] [29] [30] [31] [32] [33] [34] [35] [36] [37] [38] [39] [40] [41] [42]
[43] [44] [45]

./domain.tex:647: LaTeX Error: Counter too large.

See the LaTeX manual or LaTeX Companion for explanation.
Type  H <return>  for immediate help.
 ...                                              
                                                  
l.647 ...otetext[28]{\url{https://radix.website/}}
                                                  
Output written on __REVIEW_BOOK__.dvi (45 pages, 152988 bytes).
Transcript written on __REVIEW_BOOK__.log.

rake aborted!
Command failed with status (1): [review-pdfmaker config.yml...]
lib/tasks/review.rake:96:in `block in <top (required)>'
Tasks: TOP => pdf => book.pdf
(See full trace by running task with --trace)
```