### PR TITLE
gentombow.styとjsbook.clsはテンプレートがreview-jsbookのときだけコピー

### DIFF
--- a/lib/review/init.rb
+++ b/lib/review/init.rb
@@ -62,7 +62,7 @@ module ReVIEW
       opts.on('-l', '--locale', 'generate locale.yml file.') do
         @locale = true
       end
-      opts.on('--latex-template name', 'specify LaTeX template name. (default: review-jsbook)') do |tname|
+      opts.on('-t', '--latex-template name', 'specify LaTeX template name. (default: review-jsbook)') do |tname|
         @template = tname
       end
       opts.on('', '--epub-version VERSION', 'define EPUB version.') do |version|
@@ -166,10 +166,13 @@ EOS
       tdir = File.join(@review_dir, 'templates/latex', @template)
       @logger.error "#{tdir} not found." unless File.exist?(tdir)
       FileUtils.cp(Dir.glob(File.join(tdir, '*.*')), texmacrodir)
-      # provide jsbook from vendor/. current version is 2018/06/23
-      FileUtils.cp(File.join(@review_dir, 'vendor/jsclasses/jsbook.cls'), File.join(texmacrodir, 'jsbook.cls'))
-      # provide gentombow from vendor/. current version is 2018/08/30 v0.9j
-      FileUtils.cp(File.join(@review_dir, 'vendor/gentombow/gentombow.sty'), File.join(texmacrodir, 'gentombow.sty'))
+
+      if @template == 'review-jsbook'
+        # provide jsbook from vendor/. current version is 2018/06/23
+        FileUtils.cp(File.join(@review_dir, 'vendor/jsclasses/jsbook.cls'), File.join(texmacrodir, 'jsbook.cls'))
+        # provide gentombow from vendor/. current version is 2018/08/30 v0.9j
+        FileUtils.cp(File.join(@review_dir, 'vendor/gentombow/gentombow.sty'), File.join(texmacrodir, 'gentombow.sty'))
+      end
     end
 
     def generate_rakefile(dir)


### PR DESCRIPTION
#1381 の修正

ついでにreview-initに`-t`ショートオプションも付けることにしました。
