### PR TITLE
refactor: move mkchap* and mkpart* into Chapter and Part

### DIFF
--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -255,13 +255,13 @@ module ReVIEW
 
       def prefaces
         if catalog
-          return mkpart_from_namelist(catalog.predef)
+          return Part.mkpart_from_namelist(self, catalog.predef)
         end
 
         begin
           predef_file = filename_join(@basedir, config['predef_file'])
           if File.file?(predef_file)
-            mkpart_from_namelistfile(predef_file)
+            Part.mkpart_from_namelistfile(self, predef_file)
           end
         rescue FileNotFound => e
           raise FileNotFound, "preface #{e.message}"
@@ -271,14 +271,14 @@ module ReVIEW
       def appendix
         if catalog
           names = catalog.appendix
-          chaps = names.each_with_index.map { |n, idx| mkchap_ifexist(n, idx) }.compact
-          return mkpart(chaps)
+          chaps = names.each_with_index.map { |n, idx| Chapter.mkchap_ifexist(self, n, idx) }.compact
+          return Part.mkpart(chaps)
         end
 
         begin
           postdef_file = filename_join(@basedir, config['postdef_file'])
           if File.file?(postdef_file)
-            mkpart_from_namelistfile(postdef_file)
+            Part.mkpart_from_namelistfile(self, postdef_file)
           end
         rescue FileNotFound => e
           raise FileNotFound, "postscript #{e.message}"
@@ -287,7 +287,7 @@ module ReVIEW
 
       def postscripts
         if catalog
-          mkpart_from_namelist(catalog.postdef)
+          Part.mkpart_from_namelist(self, catalog.postdef)
         end
       end
 
@@ -344,42 +344,6 @@ module ReVIEW
           end
         end
         chap
-      end
-
-      def mkpart_from_namelistfile(path)
-        chaps = []
-        File.read(path, mode: 'rt:BOM|utf-8').split.each_with_index do |name, idx|
-          if path =~ /PREDEF/
-            chaps << mkchap(name)
-          else
-            chaps << mkchap(name, idx + 1)
-          end
-        end
-        mkpart(chaps)
-      end
-
-      def mkpart_from_namelist(names)
-        mkpart(names.map { |n| mkchap_ifexist(n) }.compact)
-      end
-
-      def mkpart(chaps)
-        chaps.empty? ? nil : Part.new(self, nil, chaps)
-      end
-
-      def mkchap(name, number = nil)
-        name += ext if File.extname(name).empty?
-        path = File.join(contentdir, name)
-        raise FileNotFound, "file not exist: #{path}" unless File.file?(path)
-        Chapter.new(self, number, name, path)
-      end
-
-      def mkchap_ifexist(name, idx = nil)
-        name += ext if File.extname(name).empty?
-        path = File.join(contentdir, name)
-        if File.file?(path)
-          idx += 1 if idx
-          Chapter.new(self, idx, name, path)
-        end
       end
 
       def read_file(filename)

--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -271,7 +271,7 @@ module ReVIEW
       def appendix
         if catalog
           names = catalog.appendix
-          chaps = names.each_with_index.map { |n, number| Chapter.mkchap_ifexist(self, n, number + 1) }.compact
+          chaps = names.each_with_index.map { |name, number| Chapter.mkchap_ifexist(self, name, number + 1) }.compact
           return Part.mkpart(chaps)
         end
 

--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -271,7 +271,7 @@ module ReVIEW
       def appendix
         if catalog
           names = catalog.appendix
-          chaps = names.each_with_index.map { |n, idx| Chapter.mkchap_ifexist(self, n, idx) }.compact
+          chaps = names.each_with_index.map { |n, number| Chapter.mkchap_ifexist(self, n, number) }.compact
           return Part.mkpart(chaps)
         end
 

--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -271,7 +271,7 @@ module ReVIEW
       def appendix
         if catalog
           names = catalog.appendix
-          chaps = names.each_with_index.map { |n, number| Chapter.mkchap_ifexist(self, n, number) }.compact
+          chaps = names.each_with_index.map { |n, number| Chapter.mkchap_ifexist(self, n, number + 1) }.compact
           return Part.mkpart(chaps)
         end
 

--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -25,12 +25,12 @@ module ReVIEW
         Chapter.new(book, number, name, path)
       end
 
-      def self.mkchap_ifexist(book, name, idx = nil)
+      def self.mkchap_ifexist(book, name, number = nil)
         name += book.ext if File.extname(name).empty?
         path = File.join(book.contentdir, name)
         if File.file?(path)
-          idx += 1 if idx
-          Chapter.new(book, idx, name, path)
+          number += 1 if number
+          Chapter.new(book, number, name, path)
         end
       end
 

--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -18,6 +18,22 @@ module ReVIEW
 
       attr_reader :number, :book
 
+      def self.mkchap(book, name, number = nil)
+        name += book.ext if File.extname(name).empty?
+        path = File.join(book.contentdir, name)
+        raise FileNotFound, "file not exist: #{path}" unless File.file?(path)
+        Chapter.new(book, number, name, path)
+      end
+
+      def self.mkchap_ifexist(book, name, idx = nil)
+        name += book.ext if File.extname(name).empty?
+        path = File.join(book.contentdir, name)
+        if File.file?(path)
+          idx += 1 if idx
+          Chapter.new(book, idx, name, path)
+        end
+      end
+
       def initialize(book, number, name, path, io = nil)
         @book = book
         @number = number

--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -29,7 +29,6 @@ module ReVIEW
         name += book.ext if File.extname(name).empty?
         path = File.join(book.contentdir, name)
         if File.file?(path)
-          number += 1 if number
           Chapter.new(book, number, name, path)
         end
       end

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -15,11 +15,11 @@ module ReVIEW
 
       def self.mkpart_from_namelistfile(book, path)
         chaps = []
-        File.read(path, mode: 'rt:BOM|utf-8').split.each_with_index do |name, idx|
+        File.read(path, mode: 'rt:BOM|utf-8').split.each_with_index do |name, number|
           if path =~ /PREDEF/
             chaps << Chapter.mkchap(book, name)
           else
-            chaps << Chapter.mkchap(book, name, idx + 1)
+            chaps << Chapter.mkchap(book, name, number + 1)
           end
         end
         Part.mkpart(chaps)

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -26,7 +26,7 @@ module ReVIEW
       end
 
       def self.mkpart_from_namelist(book, names)
-        Part.mkpart(names.map { |n| Chapter.mkchap_ifexist(book, n) }.compact)
+        Part.mkpart(names.map { |name| Chapter.mkchap_ifexist(book, name) }.compact)
       end
 
       def self.mkpart(chaps)

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -13,6 +13,26 @@ module ReVIEW
     class Part
       include Compilable
 
+      def self.mkpart_from_namelistfile(book, path)
+        chaps = []
+        File.read(path, mode: 'rt:BOM|utf-8').split.each_with_index do |name, idx|
+          if path =~ /PREDEF/
+            chaps << Chapter.mkchap(book, name)
+          else
+            chaps << Chapter.mkchap(book, name, idx + 1)
+          end
+        end
+        Part.mkpart(chaps)
+      end
+
+      def self.mkpart_from_namelist(book, names)
+        Part.mkpart(names.map { |n| Chapter.mkchap_ifexist(book, n) }.compact)
+      end
+
+      def self.mkpart(chaps)
+        chaps.empty? ? nil : Part.new(self, nil, chaps)
+      end
+
       # if Part is dummy, `number` is nil.
       #
       def initialize(book, number, chapters, name = '', io = nil)

--- a/test/test_book.rb
+++ b/test/test_book.rb
@@ -413,6 +413,51 @@ EOC
     end
   end
 
+  def test_parts_in_file
+    mktmpbookdir do |_dir, book, _files|
+      assert book.parts_in_file.empty?
+      assert !book.part(0)
+      assert !book.part(1)
+
+      tmp = []
+      book.each_part { tmp << true }
+      assert tmp.empty?
+    end
+
+    mktmpbookdir 'CHAPS' => "ch1.re\nch2.re\n\nch3.re\n",
+                 'PART' => "foo\nbar\n",
+                 'ch1.re' => "= ch1\n\n", 'ch2.re' => "= ch2\n\n",
+                 'ch3.re' => "= ch3\n\n" do |_dir, book, _files|
+      parts = book.parts_in_file
+      assert_equal 0, parts.size
+      assert !book.part(0)
+      assert_equal 'foo', book.part(1).name
+      assert_equal 'bar', book.part(2).name
+      assert !book.part(3)
+
+      tmp = []
+      book.each_part { |p| tmp << p.number }
+      assert_equal [1, 2], tmp
+    end
+
+    mktmpbookdir 'CHAPS' => "ch1.re\nch2.re\n\nch3.re\n",
+                 'PART' => "foo.re\nbar.re\n",
+                 'foo.re' => "= part1\n\n", 'bar.re' => "= part2\n\n",
+                 'ch1.re' => "= ch1\n\n", 'ch2.re' => "= ch2\n\n",
+                 'ch3.re' => "= ch3\n\n" do |_dir, book, _files|
+      parts = book.parts_in_file
+      assert_equal 2, parts.size
+      assert !book.part(0)
+      assert_equal 'foo', book.part(1).name
+      assert_equal 'bar', book.part(2).name
+      assert !book.part(3)
+
+      tmp = []
+      book.each_part { |p| tmp << p.number }
+      assert_equal [1, 2], tmp
+    end
+  end
+
   def test_chapters
     mktmpbookdir 'CHAPS' => "ch1\nch2\n\nch3" do |_dir, book, _files|
       chapters = book.chapters


### PR DESCRIPTION
`Chapter`や`Part`のコンストラクタを`Book::Base`から各クラスに移動させるものです。