### PR TITLE
エラーチェックおよびデフォルト値設定

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -15,10 +15,10 @@ module ReVIEW
     def self.values
       conf = Configure[
         # These parameters can be overridden by YAML file.
-        'bookname' => 'example', # it defines epub file name also
+        'bookname' => 'book', # it defines epub file name also
         'booktitle' => 'Re:VIEW Sample Book',
         'title' => nil,
-        'aut' => nil, # author
+        'aut' => ['anonymous'], # author
         'prt' => nil, # printer(publisher)
         'asn' => nil, # associated name
         'ant' => nil, # bibliographic antecedent
@@ -32,7 +32,7 @@ module ReVIEW
         'rights' => nil, # Copyright messages
         'description' => nil, # Description
         'urnid' => "urn:uid:#{SecureRandom.uuid}", # Identifier
-        'stylesheet' => 'stylesheet.css', # stylesheet file
+        'stylesheet' => ['style.css'], # stylesheet file
         'coverfile' => nil, # content file of body of cover page
         'mytoc' => nil, # whether make own table of contents or not
         'params' => '', # specify review2html parameters
@@ -78,6 +78,7 @@ module ReVIEW
         'texcommand' => 'uplatex',
         'texoptions' => '-interaction=nonstopmode -file-line-error -halt-on-error',
         '_texdocumentclass' => ['review-jsbook', ''],
+        'texstyle' => ['reviewmacro'],
         'dvicommand' => 'dvipdfmx',
         'dvioptions' => '-d 5 -z 9',
         # for PDFMaker

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -32,7 +32,7 @@ module ReVIEW
         'rights' => nil, # Copyright messages
         'description' => nil, # Description
         'urnid' => "urn:uid:#{SecureRandom.uuid}", # Identifier
-        'stylesheet' => ['style.css'], # stylesheet file
+        'stylesheet' => [], # stylesheet file
         'coverfile' => nil, # content file of body of cover page
         'mytoc' => nil, # whether make own table of contents or not
         'params' => '', # specify review2html parameters

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -500,6 +500,9 @@ module ReVIEW
     def copy_stylesheet(basetmpdir)
       return if @config['stylesheet'].empty?
       @config['stylesheet'].each do |sfile|
+        unless File.exist?(sfile)
+          error "#{sfile} is not found."
+        end
         FileUtils.cp(sfile, basetmpdir)
         @producer.contents.push(Content.new('file' => sfile))
       end

--- a/lib/review/yamlloader.rb
+++ b/lib/review/yamlloader.rb
@@ -18,6 +18,9 @@ module ReVIEW
       while file_queue.present?
         current_file = file_queue.shift
         current_yaml = YAML.load_file(current_file)
+        if current_yaml.class == FalseClass
+          raise "#{File.basename(current_file)} is malformed."
+        end
         yaml = current_yaml.deep_merge(yaml)
 
         if yaml.key?('inherit')

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -1,13 +1,14 @@
 \documentclass[dvipdfmx]{review-jsbook}
 \makeatletter
-\def\review@reviewversion{3.0.0.preview3}
+\def\review@reviewversion{3.2.0}
 \def\review@texcompiler{uplatex}
 \def\review@documentclass{review-jsbook}
 
 \def\review@booktitlename{Re:VIEW Sample Book}
 
+\def\review@autnames{anonymous}
 
-\def\review@titlepageauthors{}
+\def\review@titlepageauthors{anonymous　著}
 \def\review@date{2011{-}01{-}01}
 
 \def\review@bookname{sample}
@@ -37,7 +38,8 @@
 \def\review@titlepage{true}
 
 \def\review@pubhistories{2011年1月1日　発行}
-\def\review@colophonnames{}
+\def\review@colophonnames{著　者 & anonymous \\
+}
 
 \def\reviewprefacefiles{}
 \def\reviewchapterfiles{}
@@ -56,6 +58,7 @@
 
 \makeatother
 
+\usepackage{reviewmacro}
 
 %% backward compatibility (defined in config.erb)
 \reviewbackcompatibilityhook

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -1,13 +1,14 @@
 \documentclass[dvipdfmx]{review-jsbook}
 \makeatletter
-\def\review@reviewversion{3.0.0.preview3}
+\def\review@reviewversion{3.2.0}
 \def\review@texcompiler{uplatex}
 \def\review@documentclass{review-jsbook}
 
 \def\review@booktitlename{Re:VIEW Sample Book}
 
+\def\review@autnames{anonymous}
 
-\def\review@titlepageauthors{}
+\def\review@titlepageauthors{anonymous　著}
 \def\review@date{2011{-}01{-}01}
 
 \def\review@bookname{sample}
@@ -48,7 +49,8 @@ some ad content
 \null}
 
 \def\review@pubhistories{2011年1月1日　発行}
-\def\review@colophonnames{}
+\def\review@colophonnames{著　者 & anonymous \\
+}
 
 \def\reviewprefacefiles{}
 \def\reviewchapterfiles{}
@@ -67,6 +69,7 @@ some ad content
 
 \makeatother
 
+\usepackage{reviewmacro}
 
 %% backward compatibility (defined in config.erb)
 \reviewbackcompatibilityhook

--- a/test/test_yamlloader.rb
+++ b/test/test_yamlloader.rb
@@ -184,4 +184,17 @@ EOB
                    yaml)
     end
   end
+
+  def test_empty_file
+    Dir.mktmpdir do |dir|
+      yaml_file = File.join(dir, 'test.yml')
+      File.open(yaml_file, 'w') do |f|
+        f.write <<EOB
+#
+EOB
+      end
+      e = assert_raise(RuntimeError) { @loader.load_file(yaml_file) }
+      assert_match('test.yml is malformed.', e.message)
+    end
+  end
 end


### PR DESCRIPTION
いくつかのイレギュラーパターンについて、ランタイム例外エラーを出す前に対処するようにしました。

- YAMLファイル異常は基本的にYAML.load時点の例外捕捉で対処できるのですが、「空」(YAMLエントリがないを含む)だったときにはYAML.loadでは捕捉できず、`deep_merge` の時点でFalseClassだったとしてランタイムエラーになります。FalseClassだった場合にはerrorメソッド経由でエラー終了させるようにしました。
- CSSをコピーしようとするときにファイルが存在しないとランタイムエラーになります。ファイルが存在しなかったときにはエラー終了させるようにしました。

デフォルト値の変更
- aut抜け：TeXコンパイル時にnilのエラーが発生するので、autのデフォルトを`["anonymous"]`としました。
- booknameのデフォルト: 通常のreview-initで作るconfig.ymlに合わせてexample→bookとしました。
- texstyleのデフォルト: 空だったのを`["reviewmacro"]`としました。
- ~stylesheetのデフォルト: 通常のreview-initで作るconfig.ymlに合わせてstylesheet.css→`["style.css"]` としました。~
- stylesheetのデフォルト: 上記はわかりづらいのでデフォルトは`[]`にしました。