### PR TITLE
PDFMaker: review-jsbookでのtableの設置設定をhtpからHにする

### DIFF
--- a/templates/latex/review-jsbook/review-style.sty
+++ b/templates/latex/review-jsbook/review-style.sty
@@ -43,4 +43,4 @@
 \hypersetup{hidelinks}
 
 \floatplacement{figure}{H}
-\floatplacement{table}{htp}
+\floatplacement{table}{H}


### PR DESCRIPTION
#1385 の対応

後方互換性は若干失われますが、てくぶスタイルではもともとHを使っているし、影響範囲はかなり限定と思います。
