### PR TITLE
PDFMaker: LuaLaTeX利用時にはPDFメタ情報をhypersetupで定義する

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,15 +1,22 @@
 % jlreq用基本設定
-\newcommand*\PDFDocumentInformation[1]{%
-  \AtBeginShipoutFirst{\special{pdf:docinfo <<#1>>}}}
-\@onlypreamble\PDFDocumentInformation
-
-\PDFDocumentInformation{
-  /Title    (\review@booktitlename)
-  /Author   (\review@autnames)
-  % /Subject  ()
-  % /Keywords (,,)
-  /Creator  (Re:VIEW \review@reviewversion, with LaTeX)
-}
+\def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
+  \hypersetup{
+    pdftitle={\review@booktitlename},
+    pdfauthor={\review@autnames},
+    pdfcreator={Re:VIEW \review@reviewversion, with LaTeX}
+  }
+\else
+  \newcommand*\PDFDocumentInformation[1]{%
+    \AtBeginShipoutFirst{\special{pdf:docinfo <<#1>>}}}
+  \@onlypreamble\PDFDocumentInformation
+  \PDFDocumentInformation{
+    /Title    (\review@booktitlename)
+    /Author   (\review@autnames)
+    % /Subject  ()
+    % /Keywords (,,)
+    /Creator  (Re:VIEW \review@reviewversion, with LaTeX)
+  }
+\fi
 
 \RequirePackage{pxrubrica}
 \@ifpackagelater{pxrubrica}{2017/04/20}{% true


### PR DESCRIPTION
#1392 の修正。

specialマクロで定義すると異常なPDFを作ってしまうため、LuaLaTeXの場合はhyperrefの機能によるメタ情報記述を使うようにする。

副作用として、hyperrefはprintモードではdraftオプションが付記されるためメタ情報も記述されない。ebookモードのときのみメタ情報が付くことになる。(upLaTeXの場合は従来どおりどちらでもメタ情報が入る)