### PR TITLE
新しいjlreq.clsで偶数ページでのhiddenfolioが消えるのを修正

### DIFF
--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -66,7 +66,9 @@ cls]
   %% set hiddenfolio preset
   \expandafter\let\expandafter\@makehiddenfolio\csname @makehiddenfolio@#1\endcsname
   %% redefine to output \@makehiddenfolio for every page
+  %% TODO: would better to use \jlreqtrimmarkssetup
   \@bannertoken{\hskip-5mm\smash{\hiddenfolio@font\@makehiddenfolio}}%
+  \def\jlreq@trimmarks@banner@even@yoko@top@left{\hskip-5mm\smash{\hiddenfolio@font\@makehiddenfolio}}%
   \AddEverypageHook{\maketombowbox}%
 \fi}
 


### PR DESCRIPTION
#1395 のワークアラウンドです。

なお、
ちゃんとやるにはjlreqtrimmarkssetupを呼び出して適切に位置設定すべきですが、review-jsbookのやり方と全然違うので、互換性や実装方法などが難しい。
とりあえず現時点で手をつけられる状況にはないです。
