### PR TITLE
PDFMaker: set xkanjiskip zero in list environments.

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -27,19 +27,19 @@
 
 % コードリスト装飾のデフォルト
 \newenvironment{reviewemlist}{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=black!10,colframe=black!10,boxrule=0mm,arc=0mm]\begin{alltt}}%
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=black!10,colframe=black!10,boxrule=0mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\begin{alltt}}%
  {\end{alltt}\end{tcolorbox}}
 
 \newenvironment{reviewlist}{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=white,colframe=black,boxrule=0.15mm,arc=0mm]\begin{alltt}}%
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=white,colframe=black,boxrule=0.15mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\begin{alltt}}%
  {\end{alltt}\end{tcolorbox}}
 
 \newenvironment{reviewsource}{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=white,colframe=black,boxrule=0.15mm,arc=0mm]\begin{alltt}}%
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=white,colframe=black,boxrule=0.15mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\begin{alltt}}%
  {\end{alltt}\end{tcolorbox}}
 
 \newenvironment{reviewcmd}{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=black!99,coltext=white,colframe=black!99,boxrule=0mm,arc=0mm]\begin{alltt}}%
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=black!99,coltext=white,colframe=black!99,boxrule=0mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\begin{alltt}}%
  {\end{alltt}\end{tcolorbox}}
 
 % 図

--- a/templates/latex/review-jlreq/review-style.sty
+++ b/templates/latex/review-jlreq/review-style.sty
@@ -33,3 +33,6 @@
 % 図表フロートの配置
 \floatplacement{figure}{H}
 \floatplacement{table}{H}
+
+% リスト内和欧空き幅 (\z@は0で、空きなしを意味する。互換性で空きを入れたいときは以下の行をコメントアウトする)
+\def\reviewlistxkanjiskip{\z@}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -132,23 +132,23 @@
 \newenvironment{reviewlistblock}{\needspace{2\Cvs}}{}
 
 \newenvironment{reviewemlist}{%
-  \medskip\small\begin{shaded}\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
+  \medskip\small\begin{shaded}\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
   \end{alltt}\end{shaded}}
 
 \newenvironment{reviewlist}{%
-  \begin{shaded}\small\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
+  \begin{shaded}\small\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
   \end{alltt}\end{shaded}\par\vspace*{0.5zw}}
 
 \newenvironment{reviewsource}{%
-  \begin{shaded}\small\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
+  \begin{shaded}\small\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
   \end{alltt}\end{shaded}\par\vspace*{0.5zw}}
 
 \newenvironment{reviewcmd}{%
-  \color{white}\medskip\small\begin{shadedb}\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
+  \color{white}\medskip\small\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\begin{shadedb}\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
   \end{alltt}\end{shadedb}}
 
 \newenvironment{reviewbox}{%
-  \medskip\small\begin{framed}\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
+  \medskip\small\begin{framed}\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\setlength{\baselineskip}{1.3zw}\begin{alltt}}{%
   \end{alltt}\end{framed}}
 
 \newenvironment{reviewtable}[1]{%

--- a/templates/latex/review-jsbook/review-style.sty
+++ b/templates/latex/review-jsbook/review-style.sty
@@ -44,3 +44,6 @@
 
 \floatplacement{figure}{H}
 \floatplacement{table}{H}
+
+% space between English/Japanese characters in list environments (\z@ means 0, no space. You can comment out below line for backward compatibility.)
+\def\reviewlistxkanjiskip{\z@}


### PR DESCRIPTION
後方互換性を壊すんですが、
コードリスト内の和欧アキが1/4アキままなのは普通は意図しないはずなので、アキ0(`\z@`)にするのをデフォルトにしたいと思います。
設定はマクロ化しておいたので、review-style.styでreviewlistxkanjiskipの設定をコメントアウトすればデフォルトのアキに戻ります(必要なら別のskip値にすることも)。
