### PR TITLE
表紙のノンブルをcoverに変更し、利便性のために偶数ページにしておく

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -394,4 +394,6 @@ pdfmaker:
   # makeindex_mecab_opts: "-Oyomi"
   # 奥付を作成するか。trueを指定するとデフォルトの奥付、ファイル名を指定するとそれがcolophon.htmlとしてコピーされる
   colophon: true
+  # 表紙挿入時に表紙のページ番号名を「cover」とし、偶数ページ扱いにして大扉前に白ページが入るのを防ぐ。デフォルトはtrue
+  # use_cover_nmbl: true
   # pdfmaker:階層を使うものはここまで

--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -395,5 +395,5 @@ pdfmaker:
   # 奥付を作成するか。trueを指定するとデフォルトの奥付、ファイル名を指定するとそれがcolophon.htmlとしてコピーされる
   colophon: true
   # 表紙挿入時に表紙のページ番号名を「cover」とし、偶数ページ扱いにして大扉前に白ページが入るのを防ぐ。デフォルトはtrue
-  # use_cover_nmbl: true
+  # use_cover_nombre: true
   # pdfmaker:階層を使うものはここまで

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -90,7 +90,7 @@ module ReVIEW
           'makeindex_dic' => nil,
           'makeindex_mecab' => true,
           'makeindex_mecab_opts' => '-Oyomi',
-          'use_cover_nmbl' => true
+          'use_cover_nombre' => true
         },
         'imgmath_options' => {
           'format' => 'png',

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -89,7 +89,8 @@ module ReVIEW
           'makeindex_sty' => nil,
           'makeindex_dic' => nil,
           'makeindex_mecab' => true,
-          'makeindex_mecab_opts' => '-Oyomi'
+          'makeindex_mecab_opts' => '-Oyomi',
+          'use_cover_nmbl' => true
         },
         'imgmath_options' => {
           'format' => 'png',

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -109,6 +109,9 @@
     \DeclareRobustCommand{\reviewincludegraphics}[2][]{%
       \includegraphics[##1]{##2}}
   }
+  \@ifundefined{covermatter}{% for 4.0.0 compatibility
+    \def\covermatter{}
+  }
 }
 
 \makeatother

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -59,8 +59,8 @@
 \def\review@coverimage{./<%= @config['imagedir'] %>/<%= @config['coverimage'] %>}
 \def\review@coverimageoption{<%= @coverimageoption%>}
 <%- end -%>
-<%- if @config['pdfmaker']['use_cover_nmbl'] -%>
-\def\review@usecovernmbl{true}
+<%- if @config['pdfmaker']['use_cover_nombre'] -%>
+\def\review@usecovernombre{true}
 <%- end -%>
 <%- if @config['titlepage'] -%>
 \def\review@titlepage{true}

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -59,6 +59,9 @@
 \def\review@coverimage{./<%= @config['imagedir'] %>/<%= @config['coverimage'] %>}
 \def\review@coverimageoption{<%= @coverimageoption%>}
 <%- end -%>
+<%- if @config['pdfmaker']['use_cover_nmbl'] -%>
+\def\review@usecovernmbl{true}
+<%- end -%>
 <%- if @config['titlepage'] -%>
 \def\review@titlepage{true}
 <%-   if @config['titlefile'] -%>

--- a/templates/latex/layout.tex.erb
+++ b/templates/latex/layout.tex.erb
@@ -18,6 +18,7 @@
 
 %% coverpage
 \ifdefined\reviewcoverpagecont
+\covermatter
 \reviewcoverpagecont
 \fi
 

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -309,8 +309,10 @@
 \if@reclscover
   \ifdefined\review@coverimage
     \def\reviewcoverpagecont{%
-      \renewcommand{\thepage}{cover}% set page name to 'cover'
-      \setcounter{page}{2}% force to even page, to avoid empty page
+      \ifdefined\review@usecovernmbl%
+        \renewcommand{\thepage}{cover}% set page name to 'cover'
+        \setcounter{page}{2}% force to even page, to avoid empty page
+      \fi
       \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
       \cleardoublepage
     }

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -306,13 +306,16 @@
 }
 
 % cover
+\newcommand*\covermatter{%
+  \ifdefined\review@usecovernmbl%
+    \pagenumbering{coverpagezero}
+    \setcounter{page}{0}% force to even page, to avoid empty page
+  \fi
+}
+
 \if@reclscover
   \ifdefined\review@coverimage
     \def\reviewcoverpagecont{%
-      \ifdefined\review@usecovernmbl%
-        \renewcommand{\thepage}{cover}% set page name to 'cover'
-        \setcounter{page}{2}% force to even page, to avoid empty page
-      \fi
       \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
       \cleardoublepage
     }

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -307,7 +307,7 @@
 
 % cover
 \newcommand*\covermatter{%
-  \ifdefined\review@usecovernmbl%
+  \ifdefined\review@usecovernombre%
     \pagenumbering{coverpagezero}
     \setcounter{page}{0}% force to even page, to avoid empty page
   \fi

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -307,15 +307,17 @@
 
 % cover
 \if@reclscover
-\ifdefined\review@coverimage
-  \def\reviewcoverpagecont{%
-    \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
-    \cleardoublepage
-  }
-\fi
-\ifdefined\review@coverfile
-  \def\reviewcoverpagecont{\review@coverfile}
-\fi
+  \ifdefined\review@coverimage
+    \def\reviewcoverpagecont{%
+      \renewcommand{\thepage}{cover}% set page name to 'cover'
+      \setcounter{page}{2}% force to even page, to avoid empty page
+      \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
+      \cleardoublepage
+    }
+  \fi
+  \ifdefined\review@coverfile
+    \def\reviewcoverpagecont{\review@coverfile}
+  \fi
 \fi
 
 % titlepage

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -336,5 +336,9 @@ cls]
   \AtBeginDocument{\@ifpackageloaded{pdfpages}{\recls@patch@pdfpages}{}}
 \fi
 
+%% 表紙のノンブル
+\def\coverpagezero#1{\expandafter\@coverpagezero\csname c@#1\endcsname}
+\def\@coverpagezero#1{cover}
+
 \listfiles
 \endinput

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -399,7 +399,7 @@
 
 % cover
 \newcommand*\covermatter{%
-  \ifdefined\review@usecovernmbl%
+  \ifdefined\review@usecovernombre%
     \pagenumbering{coverpagezero}
     \setcounter{page}{0}% force to even page, to avoid empty page
   \fi

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -398,13 +398,16 @@
 }
 
 % cover
+\newcommand*\covermatter{%
+  \ifdefined\review@usecovernmbl%
+    \pagenumbering{coverpagezero}
+    \setcounter{page}{0}% force to even page, to avoid empty page
+  \fi
+}
+
 \if@reclscover
   \ifdefined\review@coverimage
     \def\reviewcoverpagecont{%
-      \ifdefined\review@usecovernmbl%
-        \renewcommand{\thepage}{cover}% set page name to 'cover'
-        \setcounter{page}{2}% force to even page, to avoid empty page
-      \fi
       \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
       \cleardoublepage
     }

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -401,8 +401,10 @@
 \if@reclscover
   \ifdefined\review@coverimage
     \def\reviewcoverpagecont{%
-      \renewcommand{\thepage}{cover}% set page name to 'cover'
-      \setcounter{page}{2}% force to even page, to avoid empty page
+      \ifdefined\review@usecovernmbl%
+        \renewcommand{\thepage}{cover}% set page name to 'cover'
+        \setcounter{page}{2}% force to even page, to avoid empty page
+      \fi
       \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
       \cleardoublepage
     }

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -401,6 +401,8 @@
 \if@reclscover
   \ifdefined\review@coverimage
     \def\reviewcoverpagecont{%
+      \renewcommand{\thepage}{cover}% set page name to 'cover'
+      \setcounter{page}{2}% force to even page, to avoid empty page
       \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
       \cleardoublepage
     }

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -486,5 +486,9 @@
       %% \setcounter{page}\@ne
     \fi}
 
+%% 表紙のノンブル
+\def\coverpagezero#1{\expandafter\@coverpagezero\csname c@#1\endcsname}
+\def\@coverpagezero#1{cover}
+
 \listfiles
 \endinput

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -55,6 +55,9 @@
     \DeclareRobustCommand{\reviewincludegraphics}[2][]{%
       \includegraphics[##1]{##2}}
   }
+  \@ifundefined{covermatter}{% for 4.0.0 compatibility
+    \def\covermatter{}
+  }
 }
 
 \makeatother

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -73,6 +73,7 @@
 
 %% coverpage
 \ifdefined\reviewcoverpagecont
+\covermatter
 \reviewcoverpagecont
 \fi
 

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -35,7 +35,7 @@
 \def\review@tablename{表}
 \def\review@appendixname{付録}
 
-\def\review@usecovernmbl{true}
+\def\review@usecovernombre{true}
 \def\review@titlepage{true}
 
 \def\review@pubhistories{2011年1月1日　発行}

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -35,6 +35,7 @@
 \def\review@tablename{表}
 \def\review@appendixname{付録}
 
+\def\review@usecovernmbl{true}
 \def\review@titlepage{true}
 
 \def\review@pubhistories{2011年1月1日　発行}

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -35,6 +35,7 @@
 \def\review@tablename{表}
 \def\review@appendixname{付録}
 
+\def\review@usecovernmbl{true}
 \def\review@titlepage{true}
 \def\reviewprofilepagecont{\thispagestyle{empty}\chapter*{Profile}
 some profile

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -66,6 +66,9 @@ some ad content
     \DeclareRobustCommand{\reviewincludegraphics}[2][]{%
       \includegraphics[##1]{##2}}
   }
+  \@ifundefined{covermatter}{% for 4.0.0 compatibility
+    \def\covermatter{}
+  }
 }
 
 \makeatother

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -35,7 +35,7 @@
 \def\review@tablename{表}
 \def\review@appendixname{付録}
 
-\def\review@usecovernmbl{true}
+\def\review@usecovernombre{true}
 \def\review@titlepage{true}
 \def\reviewprofilepagecont{\thispagestyle{empty}\chapter*{Profile}
 some profile

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -84,6 +84,7 @@ some ad content
 
 %% coverpage
 \ifdefined\reviewcoverpagecont
+\covermatter
 \reviewcoverpagecont
 \fi
 


### PR DESCRIPTION
デフォルトの状態だとノンブル文字列は

```
表紙 1
白 2
大扉 i
 …
```

になるのですが、これを

```
表紙 cover
大扉 i
 …
```

となるようにします。大扉は奇数でなければならない都合で、表紙は偶数(p.2)としています。

後方互換性を壊すことにはなります。
表紙込みで入稿するというやり方をしている場合だと問題になるかも。クラスパラメータで持ったほうがよい？