### PR TITLE
Webブラウザ上での初期レイアウト作成

### DIFF
--- a/lib/review/init-web/finish.html
+++ b/lib/review/init-web/finish.html
@@ -1,0 +1,10 @@
+<html>
+<head>
+<meta charset="UTF-8" />
+<title>Re:VIEWレイアウトデザイナ</title>
+</head>
+<body>
+<p>プロジェクトフォルダを作成しました。このウィンドウを閉じてください。</p>
+</body>
+</html>
+

--- a/lib/review/init-web/index.html
+++ b/lib/review/init-web/index.html
@@ -1,0 +1,90 @@
+<html>
+<head>
+<meta charset="UTF-8" />
+<title>Re:VIEWレイアウトデザイナ</title>
+<script src="https://code.createjs.com/1.0.0/easeljs.min.js" charset="UTF-8"></script>
+<script src="review-layout-design.js" charset="UTF-8"></script>
+</head>
+<body onload="init();">
+<form method="post" name="reviewform" action="/finish">
+クラス
+<select id="cls" name="cls" onchange="change_cls();">
+<option value="review-jsbook" selected>review-jsbook (jsbook派生)</option>
+<option value="review-jlreq">review-jlreq (jlreq派生)</option>
+</select>
+
+<br />
+
+紙のサイズ
+<select id="papersize" name="papersize" onchange="change_paper();">
+<option value="a5" selected>A5 (148mm×210mm)</option>
+<option value="b5">B5 (182mm×257mm)</option>
+<option value="a4">A4 (210mm×297mm)</option>
+</select>
+
+<input type="button" id="reset" name="reset" value="初期値に戻す" onclick="reset_all();">
+&nbsp;
+
+<hr/>
+
+基本文字サイズ <input type="number" id="fontsize" name="fontsize" style="width: 5em;" min="0" max="100" step="any" onchange="change_fontsize();"> pt &nbsp;
+行送り <input type="number" id="baselineskip" name="baselineskip" style="width: 5em;" min="0" max="100" step="any" onchange="change_baselineskip();"> pt
+&nbsp;
+(<span id="fontsize_q"></span>)
+<hr/>
+
+<input type="number" id="line_length" name="line_length" min="1" max="400" step="1" style="width: 3em;" onchange="change_line_length();"> 文字 ×
+<input type="number" id="number_of_lines" name="number_of_lines" min="1" max="400" step="1" style="width: 3em;" onchange="change_number_of_lines();"> 行
+
+<hr/>
+
+ノド <input type="number" id="gutter" name="gutter" style="width: 4em;" min="0" max="1000" step="any" onchange="change_gutter();"> mm &nbsp;
+小口 <input type="number" id="edge" name="edge" style="width: 4em;" min="0" max="1000" step="any" disabled> mm
+<br/>
+
+天 <input type="number" id="head_space" name="head_space" style="width: 5em;" min="0" max="1000" step="any" onchange="change_head_space();"> mm
+&nbsp;
+地 <input type="number" id="bottom_space" name="bottom_space" style="width: 5em;" min="0" max="1000" step="any" disabled> mm
+&nbsp;
+(版面 <span id="hanmen"></span>)
+<hr />
+
+ヘッダ下/本文上間隔 <input type="number" id="headsep" name="headsep" style="width: 4em;" min="-1000" max="1000" step="any" onchange="change_headsep();"> mm &nbsp;
+/本文下/フッタ下間隔 <input type="number" id="footskip" name="footskip" style="width: 4em;" min="-1000" max="1000" step="any" onchange="change_footskip();"> mm &nbsp;
+<hr />
+
+<input type="button" id="showdetails" name="showdatails" value="詳細設定を表示" onclick="show_details();">
+<input type="button" id="fordoujin" name="fordoujin" value="技術同人誌印刷の準標準設定" onclick="set_doujin();"><br />
+<div id="details">
+<input type="checkbox" id="ebook" name="ebook" checked="true"> 電子版の設定ファイル (config-ebook.yml) も作成<br />
+<input type="checkbox" id="openany" name="openany">章や目次が左右どちらのページからも始まることを許可する<br/>
+<input type="checkbox" id="fleqno" name="fleqno">数式を左寄せにする<br/>
+最初のページのページ番号 <input type="number" id="startpage" name="startpage" style="width: 3em;" value="1" min="1" max="999"><br/>
+<input type="checkbox" id="serial_pagination" name="serial_pagination">最初からページ番号にアラビア数字を使う<br/>
+<input type="checkbox" id="hiddenfolio" name="hiddenfolio">ノドへの隠しノンブルの設置 (日光企画等)<br/>
+トンボ付きの紙サイズ
+<select id="tombopaper" name="tombopaper" onchange="change_tombopaper();">
+<option value="auto">自動</option>
+<option value="b5">B5</option>
+<option value="a4">A4</option>
+<option value="b4">B4</option>
+<option value="a3">A3</option>
+</select>
+<br />
+塗り足し幅 <input type="number" id="bleed_margin" name="bleed_margin" style="width: 3em;" value="3" min="1" max="8"> mm<br/>
+</div>
+
+<div id="result" style="display: none;">
+print: <input type="text" id="result_print" name="result_print" value="" size="128"><br/>
+ebook: <input type="text" id="result_ebook" name="result_ebook" value="" size="128">
+</div>
+
+<hr />
+<input type="button" value="作成" onclick="update_result();">
+</form>
+<hr/>
+
+<canvas id="mainCanvas"></canvas>
+<br />
+</body>
+</html>

--- a/lib/review/init-web/index.html
+++ b/lib/review/init-web/index.html
@@ -1,90 +1,190 @@
-<html>
+<!DOCTYPE html>
+<html lang="ja">
 <head>
-<meta charset="UTF-8" />
-<title>Re:VIEWレイアウトデザイナ</title>
-<script src="https://code.createjs.com/1.0.0/easeljs.min.js" charset="UTF-8"></script>
-<script src="review-layout-design.js" charset="UTF-8"></script>
+  <meta charset="UTF-8" />
+  <title>Re:VIEWレイアウトデザイナ</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no" />
+  <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous" />
+  <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.14.7/umd/popper.min.js" integrity="sha384-UO2eT0CpHqdSJQ6hJty5KVphtPhzWj9WO1clHTMGa3JDZwrnQq4sF86dIHNDz0W1" crossorigin="anonymous"></script>
+  <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/js/bootstrap.min.js" integrity="sha384-JjSmVgyd0p3pXB1rRibZUAYoIIy6OrQ6VrjIEaFf/nJGzIxFDsf4x0xIM+B07jRM" crossorigin="anonymous"></script>
+  <script src="https://code.createjs.com/1.0.0/easeljs.min.js" charset="UTF-8"></script>
+  <script src="review-layout-design.js" charset="UTF-8"></script>
 </head>
 <body onload="init();">
+<div class="container">
 <form method="post" name="reviewform" action="/finish">
-クラス
-<select id="cls" name="cls" onchange="change_cls();">
-<option value="review-jsbook" selected>review-jsbook (jsbook派生)</option>
-<option value="review-jlreq">review-jlreq (jlreq派生)</option>
-</select>
-
-<br />
-
-紙のサイズ
-<select id="papersize" name="papersize" onchange="change_paper();">
-<option value="a5" selected>A5 (148mm×210mm)</option>
-<option value="b5">B5 (182mm×257mm)</option>
-<option value="a4">A4 (210mm×297mm)</option>
-</select>
-
-<input type="button" id="reset" name="reset" value="初期値に戻す" onclick="reset_all();">
-&nbsp;
-
-<hr/>
-
-基本文字サイズ <input type="number" id="fontsize" name="fontsize" style="width: 5em;" min="0" max="100" step="any" onchange="change_fontsize();"> pt &nbsp;
-行送り <input type="number" id="baselineskip" name="baselineskip" style="width: 5em;" min="0" max="100" step="any" onchange="change_baselineskip();"> pt
-&nbsp;
-(<span id="fontsize_q"></span>)
-<hr/>
-
-<input type="number" id="line_length" name="line_length" min="1" max="400" step="1" style="width: 3em;" onchange="change_line_length();"> 文字 ×
-<input type="number" id="number_of_lines" name="number_of_lines" min="1" max="400" step="1" style="width: 3em;" onchange="change_number_of_lines();"> 行
-
-<hr/>
-
-ノド <input type="number" id="gutter" name="gutter" style="width: 4em;" min="0" max="1000" step="any" onchange="change_gutter();"> mm &nbsp;
-小口 <input type="number" id="edge" name="edge" style="width: 4em;" min="0" max="1000" step="any" disabled> mm
-<br/>
-
-天 <input type="number" id="head_space" name="head_space" style="width: 5em;" min="0" max="1000" step="any" onchange="change_head_space();"> mm
-&nbsp;
-地 <input type="number" id="bottom_space" name="bottom_space" style="width: 5em;" min="0" max="1000" step="any" disabled> mm
-&nbsp;
-(版面 <span id="hanmen"></span>)
+<div class="form-group row">
+  <div class="col-auto">
+    <label for="cls" data-toggle="tooltip" data-placement="bottom" title="文書基本テンプレート。jsbookはよく使われているクラス。jlreqは紙面をカスタマイズしやすい新しいクラス">クラス</label>
+    <select id="cls" name="cls" class="btn btn-outline-dark" onchange="change_cls();">
+      <option value="review-jsbook" selected="true">review-jsbook (jsbook派生)</option>
+      <option value="review-jlreq">review-jlreq (jlreq派生)</option>
+    </select>
+  </div>
+  <div class="col-auto">
+    <label for="papersize" data-toggle="tooltip" data-placement="bottom" title="仕上がりサイズ。他のサイズ指定はsty/README.md参照">紙のサイズ</label>
+    <select id="papersize" name="papersize" class="btn btn-outline-dark" onchange="change_paper();">
+      <option value="a5" selected="true">A5 (148mm×210mm)</option>
+      <option value="b5">B5 (182mm×257mm)</option>
+      <option value="a4">A4 (210mm×297mm)</option>
+    </select>
+  </div>
+  <div class="col-auto">
+    <input type="button" id="reset" name="reset" class="btn btn-danger" value="初期値に戻す" onclick="reset_all();" data-toggle="tooltip" data-placement="bottom" title="クラスおよび紙に基づく初期値に復帰" />
+  </div>
+</div>
 <hr />
 
-ヘッダ下/本文上間隔 <input type="number" id="headsep" name="headsep" style="width: 4em;" min="-1000" max="1000" step="any" onchange="change_headsep();"> mm &nbsp;
-/本文下/フッタ下間隔 <input type="number" id="footskip" name="footskip" style="width: 4em;" min="-1000" max="1000" step="any" onchange="change_footskip();"> mm &nbsp;
-<hr />
+<div class="form-group row">
+  <div class="col-auto" style="padding-right: 0;">
+    <label for="fontsize" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="基本の文字の大きさ。review-jsbookでは8,9,10,11,12,14,17,20,21,25,30,36,43のみ">文字サイズ</label>
+  </div>
+  <div class="col-auto">
+    <input type="number" id="fontsize" name="fontsize" class="form-control" style="width: 4em;" min="0" max="100" step="any" onchange="change_fontsize();" />
+  </div>
+  <label for="fontsize" class="col-form-label">pt　</label>
+  <label for="baselineskip" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="行のベースライン間の幅">行送り</label>
+  <div class="col-auto">
+    <input type="number" id="baselineskip" name="baselineskip" class="form-control" style="width: 4em;" min="0" max="100" step="any" onchange="change_baselineskip();" />
+  </div>
+  <label for="baselineskip" class="col-form-label">pt</label>
+  <div class="col-auto">
+    <label class="col-form-label">(<span id="fontsize_q" data-toggle="tooltip" data-placement="bottom" title="1Q=1H=0.25mm。1pt=0.35146mm(英米ポイント)"></span>)</label>
+  </div>
+</div>
 
-<input type="button" id="showdetails" name="showdatails" value="詳細設定を表示" onclick="show_details();">
-<input type="button" id="fordoujin" name="fordoujin" value="技術同人誌印刷の準標準設定" onclick="set_doujin();"><br />
+<div class="form-group row">
+  <div class="col-auto">
+    <input type="number" id="line_length" name="line_length" class="form-control" min="1" max="400" step="1" style="width: 4em;" onchange="change_line_length();" />
+  </div>
+  <label for="line_length" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="和文字での1行あたりの文字数">文字 ×</label>
+  <div class="col-auto">
+    <input type="number" id="number_of_lines" name="number_of_lines" class="form-control" min="1" max="400" step="1" style="width: 4em;" onchange="change_number_of_lines();" />
+  </div>
+  <label for="number_of_lines" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="ページあたりの行の数">行</label>
+  <div class="col-auto">
+    <label class="col-form-label">(版面 <span id="hanmen" data-toggle="tooltip" data-placement="bottom" title="主となるコンテンツの入る領域。下画面の方眼の箇所"></span>)</label>
+  </div>
+</div>
+
+<hr/>
+
+<div class="form-group row">
+  <div class="col-auto" style="padding-right: 0;">
+    <label for="gutter" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="ページ内側から版面までの余白">ノド</label>
+  </div>
+  <div class="col-auto">
+    <input type="number" id="gutter" name="gutter" class="form-control" style="width: 5em;" min="0" max="1000" step="any" onchange="change_gutter();" />
+  </div>
+  <label for="gutter" class="col-form-label">mm　</label>
+  <label for="edge" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="ページ外側から版面までの余白。ノドと版面横幅から導出">小口</label>
+  <div class="col-auto">
+    <input type="number" id="edge" name="edge" class="form-control" style="width: 5em;" min="0" max="1000" step="any" readonly="true" />
+  </div>
+  <label for="edge" class="col-form-label">mm　</label>
+
+  <label for="head_space" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="ページ上側から版面までの余白">天　</label>
+  <div class="col-auto">
+  <input type="number" id="head_space" name="head_space" class="form-control" style="width: 5em;" min="0" max="1000" step="any" onchange="change_head_space();" />
+  </div>
+  <label for="head_space" class="col-form-label">mm　</label>
+  <label for="bottom_space" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="ページ下側から版面までの余白。天と版面縦幅から導出">地　</label>
+  <div class="col-auto">
+    <input type="number" id="bottom_space" name="bottom_space" class="form-control" style="width: 5em;" min="0" max="1000" step="any" readonly="true" />
+  </div>
+  <label for="bottom_space" class="col-form-label">mm</label>
+</div>
+
+<div class="form-group row">
+  <div class="col-auto" style="padding-right: 0;">
+    <label for="headsep" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="ヘッダ領域下部と版面上との間隔">ヘッダ下/本文上間隔</label>
+  </div>
+  <div class="col-auto">
+    <input type="number" id="headsep" name="headsep" class="form-control" style="width: 4em;" min="-1000" max="1000" step="any" onchange="change_headsep();" />
+  </div>
+  <label for="headsep" class="col-form-label">mm　</label>
+  <label for="footskip" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="フッタ領域下部と版面下との間隔">本文下/フッタ下間隔</label>
+  <div class="col-auto">
+    <input type="number" id="footskip" name="footskip" class="form-control" style="width: 4em;" min="-1000" max="1000" step="any" onchange="change_footskip();" />
+  </div>
+  <label for="footskip" class="col-form-label">mm</label>
+</div>
+<hr/>
+
+<div class="form-group row">
+  <div class="col-auto">
+    <input type="button" id="showdetails" name="showdatails" class="btn btn-secondary"  value="詳細設定を表示" onclick="show_details();" data-toggle="tooltip" data-placement="bottom" title="版面設計以外の設定" />
+  </div>
+  <div class="col-auto">
+    <input type="button" id="fordoujin" name="fordoujin" class="btn btn-secondary"  value="技術系同人誌印刷の設定" onclick="set_doujin();" data-toggle="tooltip" data-placement="bottom" title="技術系同人誌の印刷所でよく使われる設定をマーク" />
+  </div>
+</div>
+
 <div id="details">
-<input type="checkbox" id="ebook" name="ebook" checked="true"> 電子版の設定ファイル (config-ebook.yml) も作成<br />
-<input type="checkbox" id="openany" name="openany">章や目次が左右どちらのページからも始まることを許可する<br/>
-<input type="checkbox" id="fleqno" name="fleqno">数式を左寄せにする<br/>
-最初のページのページ番号 <input type="number" id="startpage" name="startpage" style="width: 3em;" value="1" min="1" max="999"><br/>
-<input type="checkbox" id="serial_pagination" name="serial_pagination">最初からページ番号にアラビア数字を使う<br/>
-<input type="checkbox" id="hiddenfolio" name="hiddenfolio">ノドへの隠しノンブルの設置 (日光企画等)<br/>
-トンボ付きの紙サイズ
-<select id="tombopaper" name="tombopaper" onchange="change_tombopaper();">
-<option value="auto">自動</option>
-<option value="b5">B5</option>
-<option value="a4">A4</option>
-<option value="b4">B4</option>
-<option value="a3">A3</option>
-</select>
-<br />
-塗り足し幅 <input type="number" id="bleed_margin" name="bleed_margin" style="width: 3em;" value="3" min="1" max="8"> mm<br/>
+  <div class="form-group form-check">
+    <input type="checkbox" id="ebook" name="ebook" class="form-check-input" checked="true" />
+    <label for="ebook" class="form-check-label" data-toggle="tooltip" data-placement="bottom" title="表紙あり・トンボなしの電子配布版のための設定ファイルを準備">電子版の設定ファイル (config-ebook.yml) も作成</label>
+  </div>
+
+  <div class="form-group form-check">
+    <input type="checkbox" id="openany" name="openany" class="form-check-input" />
+    <label for="openany" data-toggle="tooltip" data-placement="bottom" title="標準では章や目次は常に奇数(右)ページ開始">章や目次が左右どちらのページからも始まることを許可する</label>
+  </div>
+  <div class="form-group form-check">
+    <input type="checkbox" id="fleqno" name="fleqno" class="form-check-input" />
+    <label for="fleqno" class="form-check-label" data-toggle="tooltip" data-placement="bottom" title="標準では式は左右中央揃え">数式を左寄せにする</label>
+  </div>
+  <div class="form-group row">
+    <div class="col-auto">
+      <label for="startpage" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="通常は1(本文から数えたい場合)または3(表紙から数えたい場合)">冒頭ページ番号</label>
+    </div>
+    <div class="col-auto">
+      <input type="number" id="startpage" name="startpage" class="form-control" style="width: 4em;" value="1" min="1" max="999" />
+    </div>
+  </div>
+  <div class="form-group form-check">
+    <input type="checkbox" id="serial_pagination" name="serial_pagination" class="form-check-input" />
+    <label for="serial_pagination" class="form-check-label" data-toggle="tooltip" data-placement="bottom" title="標準では前付け(PREDEF)部分はローマ数字">最初からページ番号にアラビア数字を使う</label>
+  </div>
+  <div class="form-group form-check">
+    <input type="checkbox" id="hiddenfolio" name="hiddenfolio" class="form-check-input" />
+    <label for="hiddenfolio" class="form-check-label" data-toggle="tooltip" data-placement="bottom" title="ノドのきわにページ番号を埋め込む。印刷所によっては隠しノンブルは不要">ノドへの隠しノンブルの設置 (日光企画等)</label>
+  </div>
+  <div class="form-group row">
+    <div class="col-auto">
+      <label for="tombopaper" class="form-check-label" data-toggle="tooltip" data-placement="bottom" title="「自動」の場合は仕上がりのひとまわり大きな紙が選ばれる">トンボ付きの紙サイズ</label>
+    </div>
+    <div class="col-auto">
+      <select id="tombopaper" name="tombopaper" class="btn btn-outline-dark" onchange="change_tombopaper();">
+        <option value="auto">自動</option>
+        <option value="b5">B5</option>
+        <option value="a4">A4</option>
+        <option value="b4">B4</option>
+        <option value="a3">A3</option>
+      </select>
+    </div>
+  </div>
+  <div class="form-group row">
+    <div class="col-auto">
+      <label for="bleed_margin" class="col-form-label" data-toggle="tooltip" data-placement="bottom" title="通常は3。印刷所によって異なることがある">塗り足し幅(mm)</label>
+    </div>
+    <div class="col-auto">
+      <input type="number" id="bleed_margin" name="bleed_margin" style="width: 4em;" value="3" min="1" max="8" class="form-control" />
+    </div>
+  </div>
 </div>
 
 <div id="result" style="display: none;">
-print: <input type="text" id="result_print" name="result_print" value="" size="128"><br/>
-ebook: <input type="text" id="result_ebook" name="result_ebook" value="" size="128">
+  print: <input type="text" id="result_print" name="result_print" value="" size="80" /><br/>
+  ebook: <input type="text" id="result_ebook" name="result_ebook" value="" size="80" />
 </div>
 
-<hr />
-<input type="button" value="作成" onclick="update_result();">
+<hr/>
+<input type="button" class="btn btn-success" value="作成" onclick="update_result();" data-toggle="tooltip" data-placement="bottom" title="入力に基づいて設定ファイルを作成"/>
 </form>
 <hr/>
-
 <canvas id="mainCanvas"></canvas>
-<br />
+</div>
 </body>
 </html>

--- a/lib/review/init-web/review-layout-design.js
+++ b/lib/review/init-web/review-layout-design.js
@@ -628,8 +628,8 @@ function makelines(container) {
 function update_result() {
   var ra = ["media=print"];
   ra.push("paper=" + document.getElementById("papersize").value);
-  ra.push("fontsize=" + p.fontsize + "pt");
-  ra.push("baselineskip=" + p.baselineskip + "pt");
+  if (p.fontsize != p.o_fontsize) ra.push("fontsize=" + p.fontsize + "pt");
+  if (p.baselineskip != p.o_baselineskip) ra.push("baselineskip=" + p.baselineskip + "pt");
   ra.push("line_length=" + p.line_length + "zw");
   ra.push("number_of_lines=" + p.number_of_lines);
   if (p.head_space != p.o_head_space) ra.push("head_space=" + dp2(pttomm(p.head_space)) + "mm");

--- a/lib/review/init-web/review-layout-design.js
+++ b/lib/review/init-web/review-layout-design.js
@@ -1,0 +1,690 @@
+/*
+# Copyright (c) 2019 Kenshi Muto
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+# For details of the GNU LGPL, see the file "COPYING".
+*/
+
+// パラメータオブジェクト
+var p = new Object;
+
+// 初期実行
+function init() {
+  document.getElementById("details").style.display = "none";
+  p.cls = "review-jsbook";
+  p.scale = 1;
+  update_paper_info("a5");
+
+  reset_all();
+}
+
+// パラメータ初期化
+function init_val() {
+  p.textwidth = p.o_textwidth;
+  p.textheight = p.o_textheight;
+  p.head_space = p.o_head_space;
+  p.topmargin = p.o_topmargin;
+  p.headheight = p.o_headheight;
+  p.headsep = p.o_headsep;
+  p.footskip = p.o_footskip;
+  p.footheight = p.headheight; // もう存在しないものだけど高さは必要
+  p.oddsidemargin = p.o_oddsidemargin;
+  p.evensidemargin = p.o_evensidemargin;
+  p.gutter = p.o_gutter;
+
+  p.fontsize = p.o_fontsize;
+  p.baselineskip = p.o_baselineskip;
+
+  p.line_length = null;
+  p.number_of_lines = null;
+
+  p.edge = p.paperwidth - p.textwidth - p.gutter;
+  p.bottom_space = p.paperheight - p.textheight - p.head_space;
+
+  p.ebookyaml = true;
+
+  update_fontsize();
+  write_values();
+}
+
+// クラス変更
+function change_cls() {
+  var v = document.getElementById("cls").value;
+  if (v == "review-jsbook" || v == "review-jlreq") {
+    p.cls = v;
+    change_paper();
+    init_val();
+    base_draw();
+  }
+  return true;
+}
+
+// 初期化
+function reset_all() {
+  init_val();
+  base_draw();
+  return true;
+}
+
+// 詳細表示切り替え
+function show_details() {
+  if (document.getElementById("details").style.display == "none") {
+    document.getElementById("details").style.display = "block";
+    document.getElementById("showdetails").value = "詳細設定を隠す";
+    
+  } else {
+    document.getElementById("details").style.display = "none";
+    document.getElementById("showdetails").value = "詳細設定を表示";
+  }
+  return true;
+}
+
+// 同人誌基本設定
+function set_doujin() {
+  if (document.getElementById("details").style.display == "none") {
+    show_details();
+  }
+  document.getElementById("ebook").checked = true;
+  document.getElementById("serial_pagination").checked = true;
+  document.getElementById("hiddenfolio").checked = true;
+  
+  return true;
+}
+
+// 文字サイズ変更
+function change_fontsize() {
+  var v = Number(document.getElementById("fontsize").value);
+  if (v == NaN || v < 0.1 || v >= 100) {
+    write_values();
+    return true;
+  }
+  if (v > p.baselineskip) {
+    var baselineskip = dp2(v * ((p.cls == "review-jlreq") ? 1.7 : 1.6));
+    p.baselineskip = baselineskip;
+  }
+
+  if (p.cls == "review-jsbook") {
+    var v2 = round_fontsize_jsbook(v);
+    if (v != v2) {
+      // alert(v + " は、jsbook で許容するpt値 " + v2 + " に丸められます");
+      v = v2;
+    }
+  }
+
+  p.fontsize = v;
+  update_fontsize();
+  write_values();
+  base_draw();
+  return true;
+}
+
+// jsbookのQ数丸め
+function round_fontsize_jsbook(v) {
+  if (v < 8.5) {
+    return 8;
+  } else if (v < 9.5) {
+    return 9;
+  } else if (v < 10.5) {
+    return 10;
+  } else if (v < 11.5) {
+    return 11;
+  } else if (v < 12.5) {
+    return 12;
+  } else if (v < 15.5) {
+    return 14;
+  } else if (v < 18.5) {
+    return 17;
+  } else if (v < 20.5) {
+    return 20;
+  } else if (v < 23.5) {
+    return 21;
+  } else if (v < 27.5) {
+    return 25;
+  } else if (v < 33) {
+    return 30;
+  } else if (v < 39.5) {
+    return 36;
+  } else {
+    return 43;
+  }
+}
+
+// 行送りの変更
+function change_baselineskip() {
+  var v = Number(document.getElementById("baselineskip").value);
+  if (v == NaN || v < p.fontsize || v >= 100) {
+    write_values();
+    return true;
+  }
+  p.baselineskip = v;
+  update_fontsize();
+  write_values();
+  base_draw();
+  return true;
+}
+
+// 文字数の変更
+function change_line_length() {
+  var v = Number(document.getElementById("line_length").value);
+  if (v == NaN || v < 1 || v >= 400) {
+    write_values();
+    return true;
+  }
+  p.line_length = Math.floor(v);
+  update_wl();
+  // 小口を変える
+  update_sidemargin();
+  write_values();
+  base_draw();
+  return true;
+}
+
+// 行数の変更
+function change_number_of_lines() {
+  var v = Number(document.getElementById("number_of_lines").value);
+  if (v == NaN || v < 1 || v >= 400) {
+    write_values();
+    return true;
+  }
+
+  p.number_of_lines = Math.floor(v);
+  update_wl();
+  // 地を変える
+  write_values();
+  base_draw();
+  return true;
+}
+
+// ノドの変更
+function change_gutter() {
+  var v = Number(document.getElementById("gutter").value);
+  if (v == NaN) {
+    write_values();
+    return true;
+  }
+
+  v = mmtopt(v);
+  var edge = p.paperwidth - v - p.textwidth;
+  if (v < 0 || v > mmtopt(p.paperwidth) || edge < 0) {
+    write_values(); // はみだし
+    return true;
+  }
+
+  p.gutter = v;
+  p.edge = edge;
+  update_sidemargin();
+  write_values();
+  base_draw();
+  return true;
+}
+
+// 天変更
+function change_head_space() {
+  var v = Number(document.getElementById("head_space").value);
+  if (v == NaN) {
+    write_values();
+    return true;
+  }
+
+  v = mmtopt(v);
+  var bottom_space = p.paperheight - v - p.textheight;
+  if (v < 0 || v > mmtopt(p.paperheight) || bottom_space < 0) {
+    write_values();
+    return true;
+  }
+
+  p.head_space = v;
+  p.bottom_space = bottom_space;
+  update_head();
+  write_values();
+  base_draw();
+  return true;
+}
+
+// ヘッダ下/本文上アキ変更
+function change_headsep() {
+  var v = Number(document.getElementById("headsep").value);
+  if (v == NaN) {
+    write_values();
+    return true;
+  }
+
+  v = mmtopt(v);
+  if (v < -1 * mmtopt(p.paperheight) || v > p.head_space) {
+    write_values();
+    return true;
+  }
+
+  p.headsep = v;
+  update_head();
+  base_draw();
+  return true;
+}
+
+// 本文下/フッタ下変更
+function change_footskip() {
+  var v = Number(document.getElementById("footskip").value);
+  if (v == NaN) {
+    write_values();
+    return true;
+  }
+
+  v = mmtopt(v);
+  if (v < 0 || v > p.edge) {
+    write_values();
+    return true;
+  }
+
+  p.footskip = v;
+  base_draw();
+  return true;
+}
+
+// 紙変更
+function change_paper() {
+  var paper = document.getElementById("papersize").value;
+  update_paper_info(paper);
+  p.textwidth = p.o_textwidth;
+  p.textheight = p.o_textheight;
+  p.topmargin = p.o_topmargin;
+  p.head_space = p.o_head_space;
+  p.gutter = p.o_gutter;
+
+  update_fontsize();
+  p.edge = p.paperwidth - p.textwidth - p.gutter;
+  update_sidemargin();
+  p.bottom_space = p.paperheight - p.head_space - p.textheight;
+  write_values();
+  change_tombopaper();
+  base_draw();
+}
+
+// トンボ紙変更
+function change_tombopaper() {
+  var f = document.getElementById("tombopaper");
+  var papersize = document.getElementById("papersize").value;
+  if (f.value != "auto") {
+    if (papersize == "b5" && f.value == "b5") {
+      f.value = "auto";
+    } else if (papersize == "a4" && (f.value == "b5" || f.value == "a4")) {
+      f.value = "auto";
+    }
+  }
+  return true;
+}
+
+// フォームへの値書き込み
+function write_values() {
+  document.getElementById("fontsize").value = p.fontsize;
+  document.getElementById("baselineskip").value = p.baselineskip;
+  document.getElementById("line_length").value = p.line_length;
+  document.getElementById("number_of_lines").value = p.number_of_lines;
+  document.getElementById("gutter").value = pttomm(p.gutter);
+  document.getElementById("edge").value = pttomm(p.edge);
+  document.getElementById("head_space").value = pttomm(p.head_space);
+  document.getElementById("bottom_space").value = pttomm(p.bottom_space);
+  document.getElementById("headsep").value = pttomm(p.headsep);
+  document.getElementById("footskip").value = pttomm(p.footskip);
+  update_qh();
+  update_hanmen();
+}
+
+// 紙情報の初期情報
+function update_paper_info(paper) {
+  switch(p.cls + "-" + paper) {
+    case "review-jsbook-a5":
+      p.o_fontsize = 10;
+      p.o_baselineskip = 16;
+      p.papersize = "a5";
+      p.paperwidth = mmtopt(148);
+      p.paperheight = mmtopt(210);
+      p.o_textwidth = 314.39209;
+      p.o_textheight = 460.86066;
+      p.o_headsep = 14.31091;
+      p.o_headheight = 20.0;
+      p.o_topmargin = -16.10184;
+      p.o_oddsidemargin = -18.91565;
+      p.o_evensidemargin = -18.91565;
+      p.o_footskip = 0;
+      break;
+
+    case "review-jlreq-a5":
+      p.o_fontsize = 10;
+      p.o_baselineskip = 17;
+      p.papersize = "a5";
+      p.paperwidth = mmtopt(148);
+      p.paperheight = mmtopt(210);
+      p.o_textwidth = 310.0;
+      p.o_textheight = 435.0;
+      p.o_headsep = 18.79999;
+      p.o_headheight = 10.0;
+      p.o_topmargin = -21.01604;
+      p.o_oddsidemargin = -16.7196;
+      p.o_evensidemargin = -16.7196;
+      p.o_footskip = 30;
+      break;
+
+    case "review-jsbook-b5":
+      p.o_fontsize = 10;
+      p.o_baselineskip = 16;
+      p.papersize = "b5";
+      p.paperwidth = mmtopt(182);
+      p.paperheight = mmtopt(257);
+      p.o_textwidth = 369.87305;
+      p.o_textheight = 572.86066;
+      p.o_headsep = 14.31091;
+      p.o_headheight = 20.0;
+      p.o_topmargin = -5.23787;
+      p.o_oddsidemargin = -16.78009;
+      p.o_evensidemargin = 20.20721;
+      p.o_footskip = 0;
+      break;
+
+    case "review-jlreq-b5":
+      p.o_fontsize = 10;
+      p.o_baselineskip = 17;
+      p.papersize = "b5";
+      p.paperwidth = mmtopt(182);
+      p.paperheight = mmtopt(257);
+      p.o_textwidth = 380.0;
+      p.o_textheight = 537.0;
+      p.o_headsep = 18.79999;
+      p.o_headheight = 10.0;
+      p.o_topmargin = -5.15207;
+      p.o_oddsidemargin = -3.34991;
+      p.o_evensidemargin = -3.34991;
+      p.o_footskip = 30;
+      break;
+
+    case "review-jsbook-a4":
+      p.o_fontsize = 10;
+      p.o_baselineskip = 16;
+      p.papersize = "a4";
+      p.paperwidth = mmtopt(210);
+      p.paperheight = mmtopt(297);
+      p.o_textwidth = 369.87305;
+      p.o_textheight = 572.86066;
+      p.o_headsep = 14.31091;
+      p.o_headheight = 20.0;
+      p.o_topmargin = -5.23787;
+      p.o_oddsidemargin = -18.55695;
+      p.o_evensidemargin = 101.6518;
+      p.o_footskip = 0;
+      break;
+
+    case "review-jlreq-a4":
+      p.o_fontsize = 10;
+      p.o_baselineskip = 17;
+      p.papersize = "a4";
+      p.paperwidth = mmtopt(210);
+      p.paperheight = mmtopt(297);
+      p.o_textwidth = 440.0;
+      p.o_textheight = 622.0;
+      p.o_headsep = 18.79999;
+      p.o_headheight = 10.0;
+      p.o_topmargin = 9.25345;
+      p.o_oddsidemargin = 6.48395;
+      p.o_evensidemargin = 6.48395;
+      p.o_footskip = 30;
+      break;
+  }
+
+  p.o_head_space = inchpt() + p.o_topmargin + p.o_headheight + p.o_headsep;
+  p.o_gutter = inchpt() + p.o_oddsidemargin;
+}
+
+// 文字サイズに伴う行・列更新
+function update_fontsize() {
+  p.jfontsize = p.fontsize;
+  if (p.cls == "review-jsbook") p.jfontsize = p.fontsize * 0.9246895759999999; // http://akahana-1.hatenablog.jp/entry/2017/12/06/234615
+
+  p.line_length = Math.floor(nearlyRound(p.textwidth / p.jfontsize)); // .99→繰り上げにする
+  p.number_of_lines = Math.floor(nearlyRound((p.textheight + p.headsep) / p.baselineskip));
+}
+
+// 小口、地の追従更新
+function update_wl() {
+  p.textwidth = p.jfontsize * p.line_length;
+  p.textheight = p.baselineskip * p.number_of_lines;
+  p.edge = p.paperwidth - p.textwidth - p.gutter;
+  p.bottom_space = p.paperheight - p.textheight - p.head_space;
+  return true;
+}
+
+// 文字サイズのQ/H表示
+function update_qh() {
+  document.getElementById("fontsize_q").innerText = dp2(pttoq(p.fontsize)) + "Q, " + dp2(pttoq(p.baselineskip)) + "H";
+}
+
+// 版面表示
+function update_hanmen() {
+  document.getElementById("hanmen").innerText = dp2(pttomm(p.textwidth)) + "mm×" + dp2(pttomm(p.textheight)) + "mm";
+}
+
+// oddside,evensideを変える
+function update_sidemargin() {
+  p.oddsidemargin = p.gutter - inchpt();
+  p.evensidemargin = p.paperwidth - 2 * inchpt() - p.oddsidemargin - p.textwidth;
+}
+
+// topmarginを変える
+function update_head() {
+  p.topmargin = p.head_space - inchpt() - p.headheight - p.headsep;
+}
+
+// 描画
+function base_draw() {
+  canvas = document.getElementById("mainCanvas");
+  stage = new createjs.Stage(canvas);
+  stage.scaleX = p.scale;
+  stage.scaleY = p.scale;
+
+  canvas.width = p.paperwidth * 2 + 10;
+  canvas.height = p.paperheight + 10;
+
+  p.paper_left = new createjs.Shape();
+  p.paper_left.graphics.beginStroke("black").beginFill("#fffff0").drawRect(0, 0, p.paperwidth, p.paperheight);
+  stage.addChild(p.paper_left);
+  p.paper_right = new createjs.Shape();
+  p.paper_right.graphics.beginStroke("black").beginFill("#fffff0").drawRect(p.paperwidth, 0, p.paperwidth, p.paperheight);
+  stage.addChild(p.paper_right);
+
+  p.paper_left_text = new createjs.Text("左ページ(偶数)", "sans serif", "black");
+  p.paper_left_text.x = 10;
+  p.paper_left_text.y = 10;
+  p.paper_left_text.textAlign = "left";
+  p.paper_left_text.textBaseline = "top";
+  stage.addChild(p.paper_left_text);
+  p.paper_right_text = new createjs.Text("右ページ(奇数)", "sans serif", "black");
+  p.paper_right_text.x = p.paperwidth * 2 - 10;
+  p.paper_right_text.y = 10;
+  p.paper_right_text.textAlign = "right";
+  p.paper_right_text.textBaseline = "top";
+  stage.addChild(p.paper_right_text);
+
+  // ヘッダ領域
+  p.head_left = new createjs.Container();
+  p.head_left.x = inchpt() + p.evensidemargin;
+  p.head_left.y = inchpt() + p.topmargin;
+  stage.addChild(p.head_left);
+
+  p.head_left_box = new createjs.Shape();
+  p.head_left_box.alpha = 0.8;
+  p.head_left_box.graphics.beginStroke("black").beginFill("#c0c0c0").drawRect(0, 0, p.textwidth, p.headheight);
+  p.head_left.addChild(p.head_left_box);
+  p.head_left_text = new createjs.Text("ヘッダ領域", "sans serif", "black");
+  p.head_left_text.x = p.textwidth / 2;
+  p.head_left_text.y = p.headheight / 2;
+  p.head_left_text.textAlign = "center";
+  p.head_left_text.textBaseline = "middle";
+  p.head_left.addChild(p.head_left_text);
+
+  p.head_right = new createjs.Container();
+  p.head_right.x = p.paperwidth + inchpt() + p.oddsidemargin;
+  p.head_right.y = inchpt() + p.topmargin;
+  stage.addChild(p.head_right);
+
+  p.head_right_box = new createjs.Shape();
+  p.head_right_box.alpha = 0.8;
+  p.head_right_box.graphics.beginStroke("black").beginFill("#c0c0c0").drawRect(0, 0, p.textwidth, p.headheight);
+  p.head_right.addChild(p.head_right_box);
+  p.head_right_text = new createjs.Text("ヘッダ領域", "sans serif", "black");
+  p.head_right_text.x = p.textwidth / 2;
+  p.head_right_text.y = p.headheight / 2;
+  p.head_right_text.textAlign = "center";
+  p.head_right_text.textBaseline = "middle";
+  p.head_right.addChild(p.head_right_text);
+
+  // 本文
+  var border_col = "black";
+  var border_width = 1;
+  if ((p.textwidth + p.gutter) > p.paperwidth || (p.textheight + p.head_space) > p.paperheight) {
+    border_col = "red";
+    border_width = 2;
+  }
+
+  p.body_left = new createjs.Container();
+  p.body_left.x = inchpt() + p.evensidemargin;
+  p.body_left.y = inchpt() + p.topmargin + p.headheight + p.headsep;
+  stage.addChild(p.body_left);
+
+  p.body_left_box = new createjs.Shape();
+  p.body_left_box.alpha = 0.8;
+  p.body_left_box.graphics.beginStroke(border_col).setStrokeStyle(border_width).beginFill("#e0ffe0").drawRect(0, 0, p.textwidth, p.textheight);
+  p.body_left.addChild(p.body_left_box);
+  makelines(p.body_left);
+
+  p.body_right = new createjs.Container();
+  p.body_right.x = p.paperwidth + inchpt() + p.oddsidemargin;
+  p.body_right.y = inchpt() + p.topmargin + p.headheight + p.headsep;
+  stage.addChild(p.body_right);
+
+  p.body_right_box = new createjs.Shape();
+  p.body_right_box.alpha = 0.8;
+  p.body_right_box.graphics.beginStroke(border_col).setStrokeStyle(border_width).beginFill("#e0ffe0").drawRect(0, 0, p.textwidth, p.textheight);
+  p.body_right.addChild(p.body_right_box);
+  makelines(p.body_right);
+
+  // フッタ
+  p.foot_left = new createjs.Container();
+  p.foot_left.x = inchpt() + p.evensidemargin;
+  p.foot_left.y = inchpt() + p.topmargin + p.headheight + p.headsep + p.textheight + p.footskip - p.footheight;
+  stage.addChild(p.foot_left);
+
+  p.foot_left_box = new createjs.Shape();
+  p.foot_left_box.alpha = 0.5;
+  p.foot_left_box.graphics.beginStroke("black").beginFill("#c0c0c0").drawRect(0, 0, p.textwidth, p.footheight);
+  p.foot_left.addChild(p.foot_left_box);
+  p.foot_left_text = new createjs.Text("フッタ領域", "sans serif", "black");
+  p.foot_left_text.x = p.textwidth / 2;
+  p.foot_left_text.y = p.footheight / 2;
+  p.foot_left_text.textAlign = "center";
+  p.foot_left_text.textBaseline = "middle";
+  p.foot_left.addChild(p.foot_left_text);
+
+  p.foot_right = new createjs.Container();
+  p.foot_right.x = p.paperwidth + inchpt() + p.oddsidemargin;
+  p.foot_right.y = inchpt() + p.topmargin + p.headheight + p.headsep + p.textheight + p.footskip - p.footheight;
+  stage.addChild(p.foot_right);
+
+  p.foot_right_box = new createjs.Shape();
+  p.foot_right_box.alpha = 0.5;
+  p.foot_right_box.graphics.beginStroke("black").beginFill("#c0c0c0").drawRect(0, 0, p.textwidth, p.footheight);
+  p.foot_right.addChild(p.foot_right_box);
+  p.foot_right_text = new createjs.Text("フッタ領域", "sans serif", "black");
+  p.foot_right_text.x = p.textwidth / 2;
+  p.foot_right_text.y = p.footheight / 2;
+  p.foot_right_text.textAlign = "center";
+  p.foot_right_text.textBaseline = "middle";
+  p.foot_right.addChild(p.foot_right_text);
+
+  stage.update();
+}
+
+// 行文字配置
+function makelines(container) {
+  for (var y = 0; y < p.number_of_lines; y++) {
+    for (var x = 0; x < p.line_length; x++) {
+      var ch = new createjs.Shape();
+      ch.alpha = 0.2;
+      var fcolor = "#ffffff";
+      if ((x + 1) % 10 == 0) fcolor = "#000000";
+      ch.graphics.beginStroke("#0000ff").beginFill(fcolor).drawRect(x * p.jfontsize, y * p.baselineskip, p.jfontsize - 1, p.jfontsize - 1);
+      container.addChild(ch);
+    }
+  }
+  var s = new createjs.Text("本文領域：" + p.line_length + "文字×" + p.number_of_lines + "行", "sans serif", "black");
+  s.x = p.textwidth / 2;
+  s.y = p.textheight / 2;
+  s.textAlign = "center";
+  s.textBaseline = "middle";
+  container.addChild(s);
+}
+
+// texdocumentclass出力
+function update_result() {
+  var ra = ["media=print"];
+  ra.push("paper=" + document.getElementById("papersize").value);
+  ra.push("fontsize=" + p.fontsize + "pt");
+  ra.push("baselineskip=" + p.baselineskip + "pt");
+  ra.push("line_length=" + p.line_length + "zw");
+  ra.push("number_of_lines=" + p.number_of_lines);
+  if (p.head_space != p.o_head_space) ra.push("head_space=" + dp2(pttomm(p.head_space)) + "mm");
+  if (p.gutter != p.o_gutter) ra.push("gutter=" + dp2(pttomm(p.gutter)) + "mm");
+  if (p.headsep != p.o_headsep) ra.push("headheight=" + dp2(pttomm(p.headheight)) + "mm");
+  if (p.headsep != p.o_headsep) ra.push("headsep=" + dp2(pttomm(p.headsep)) + "mm");
+  if (p.footskip != p.o_footskip) ra.push("footskip=" + dp2(pttomm(p.footskip)) + "mm");
+  if (document.getElementById("openany").checked) ra.push("openany");
+  if (document.getElementById("fleqno").checked) ra.push("fleqno");
+  if (document.getElementById("startpage").value != "1") ra.push("startpage=" + document.getElementById("startpage").value);
+  if (document.getElementById("serial_pagination").checked) ra.push("serial_pagination=true");
+  if (document.getElementById("hiddenfolio").checked) ra.push("hiddenfolio=nikko-pc");
+  if (document.getElementById("tombopaper").value != "auto") ra.push("tombopaper=" + document.getElementById("tombopaper").value);
+  if (document.getElementById("bleed_margin").value != "3") ra.push("bleed_margin=" + document.getElementById("bleed_margin").value + "mm");
+  var result = ra.join(",");
+  document.getElementById("result_print").value = result;
+  if (document.getElementById("ebook").checked) {
+    document.getElementById("result_ebook").value = result.replace("media=print", "media=ebook");
+  } else {
+    document.getElementById("result_ebook").value = "";
+  }
+  document.reviewform.submit();
+}
+
+// インチ→pt
+function inchpt() {
+  return 72.2712035135135;
+}
+
+// mm→pt
+function mmtopt(mm) {
+  return mm * 2.8453229729729728;
+}
+
+// Q→pt
+function qtopt(q) {
+  return q * 0.25 * 2.8453229729729728;
+}
+
+// pt→mm
+function pttomm(pt) {
+  return pt * 0.3514598096921122;
+}
+
+// pt→Q
+function pttoq(pt) {
+  return pt * 0.3514598096921122 * 4;
+}
+
+// 99→1、.98→0にする
+function nearlyRound(n) {
+  var r = (((n + 0.01) * 10) >> 0) / 10;
+  return (r > n) ? r : n;
+}
+
+// 小数点2桁化
+function dp2(v) {
+  return Math.round(v * 100) / 100;
+}

--- a/lib/review/init-web/review-layout-design.js
+++ b/lib/review/init-web/review-layout-design.js
@@ -12,6 +12,7 @@ var p = new Object;
 
 // 初期実行
 function init() {
+  $('[data-toggle="tooltip"]').tooltip();
   document.getElementById("details").style.display = "none";
   p.cls = "review-jsbook";
   p.scale = 1;

--- a/lib/review/init.rb
+++ b/lib/review/init.rb
@@ -332,7 +332,7 @@ EOS
         @web_result.each do |s|
           if s !~ /\A[a-z0-9=_,\.-]*\Z/i
             @web_result = nil
-            return
+            break
           end
         end
       end


### PR DESCRIPTION
review-initに`-w`(および変更用に`--bind`と`--port`)を付けることで、ブラウザ上でのレイアウトを可能にします(CreateJSを使っています)。

見た目を今風にしたりReactあたりを使ったツールチップとかもできるといいんですが、あまりそのあたりのセンスが自分にはないので、得意な方からのパッチを待ちたいと思います。
