### PR TITLE
fix syntax of dlist in testcases

### DIFF
--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -701,7 +701,7 @@ EOS
     assert_equal expected, actual
 
     @book.config['join_lines_by_lang'] = true
-    actual = compile_block(": foo\n  foo.\n  bar.\n")
+    actual = compile_block(" : foo\n  foo.\n  bar.\n")
     expected = <<-EOS
 <dl>
 <dt>foo</dt>
@@ -722,7 +722,7 @@ EOS
     assert_equal expected, actual
 
     @book.config['join_lines_by_lang'] = true
-    actual = compile_block(": foo[bar]\n    foo.\n    bar.\n")
+    actual = compile_block(" : foo[bar]\n    foo.\n    bar.\n")
     expected = <<-EOS
 <dl>
 <dt>foo[bar]</dt>
@@ -733,7 +733,7 @@ EOS
   end
 
   def test_dlist_with_comment
-    source = " : title\n  body\n\#@ comment\n\#@ comment\n: title2\n  body2\n"
+    source = " : title\n  body\n\#@ comment\n\#@ comment\n : title2\n  body2\n"
     actual = compile_block(source)
     expected = <<-EOS
 <dl>

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -319,7 +319,7 @@ EOS
     assert_equal expected, actual
 
     @book.config['join_lines_by_lang'] = true
-    actual = compile_block(": foo\n  foo.\n  bar.\n")
+    actual = compile_block(" : foo\n  foo.\n  bar.\n")
     expected = <<-EOS
 
 \\begin{description}
@@ -343,7 +343,7 @@ EOS
     assert_equal expected, actual
 
     @book.config['join_lines_by_lang'] = true
-    actual = compile_block(": foo[bar]\n    foo.\n    bar.\n")
+    actual = compile_block(" : foo[bar]\n    foo.\n    bar.\n")
     expected = <<-EOS
 
 \\begin{description}

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -136,7 +136,7 @@ EOS
     assert_equal expected, actual
 
     @book.config['join_lines_by_lang'] = true
-    actual = compile_block(": foo\n  foo.\n  bar.\n")
+    actual = compile_block(" : foo\n  foo.\n  bar.\n")
     expected = <<-EOS
 <dl>
 <dt>foo</dt>
@@ -157,7 +157,7 @@ EOS
     assert_equal expected, actual
 
     @book.config['join_lines_by_lang'] = true
-    actual = compile_block(": foo[bar]\n    foo.\n    bar.\n")
+    actual = compile_block(" : foo[bar]\n    foo.\n    bar.\n")
     expected = <<-EOS
 <dl>
 <dt>foo[bar]</dt>

--- a/test/test_md2inaobuilder.rb
+++ b/test/test_md2inaobuilder.rb
@@ -50,7 +50,7 @@ EOS
     assert_equal expected, actual
 
     @book.config['join_lines_by_lang'] = true
-    actual = compile_block(": foo\n  foo.\n  bar.\n")
+    actual = compile_block(" : foo\n  foo.\n  bar.\n")
     expected = <<-EOS
 <dl>
 <dt>foo</dt>


### PR DESCRIPTION
suppress warnings running in tests:

```console
WARN run_test: :0: Definition list starting with `:` is deprecated. It should start with ` : `.
```
