### PR TITLE
Dockerfileの更新

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,29 @@
 #
 # cf. https://github.com/vvakame/docker-review/blob/master/Dockerfile
 
-FROM debian:sid
+FROM debian:buster
 MAINTAINER takahashim
 
-RUN apt-get update \
-	&& apt-get install -y --no-install-recommends git-core ruby locales zip \
-    && apt-get install -y --no-install-recommends texlive-lang-cjk texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra ghostscript \
-	&& rm -rf /var/lib/apt/lists/*
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      locales && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+RUN locale-gen en_US.UTF-8 && update-locale en_US.UTF-8
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+      texlive-lang-japanese texlive-fonts-recommended texlive-latex-extra lmodern fonts-lmodern cm-super tex-gyre fonts-texgyre texlive-pictures texlive-plain-generic \
+      ghostscript gsfonts \
+      zip ruby-zip \
+      ruby-nokogiri mecab ruby-mecab mecab-ipadic-utf8 poppler-data \
+      mecab-jumandic- mecab-jumandic-utf8- \
+      texlive-extra-utils poppler-utils && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+RUN kanji-config-updmap-sys ipaex
+
 RUN gem install review rake bundler --no-rdoc --no-ri
 
 VOLUME ["/work"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ MAINTAINER takahashim
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-      locales && \
+      locales git-core curl ca-certificates && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 RUN echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen


### PR DESCRIPTION
普通はvvakame/review使う、でいいとは思いますが、いちおうそれをベースにミニマム版を作りました。

- vvakame/reviewの手順や依存関係と同等に。Debianはv10のbuster
- nodeなどはRe:VIEW公式では使ってないので除去
- graphvizなどgraph系のツールも依存でひっぱりすぎるので除去。ただimgmathは使えるように依存を設定
- 書体はデフォルトのIPA利用
