### PR TITLE
use ifdefined-else for backward compatibility check

### DIFF
--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -102,16 +102,16 @@
 <%- end -%>
 
 \def\reviewbackcompatibilityhook{
-  \@ifundefined{reviewimagecaption}{% for 3.0.0 compatibility
+  \ifdefined\reviewimagecaption\else% for 3.0.0 compatibility
     \newcommand{\reviewimagecaption}[1]{\caption{##1}}
-  }
-  \@ifundefined{reviewincludegraphics}{% for 3.2.0 compatibility
+  \fi
+  \ifdefined\reviewincludegraphics\else% for 3.2.0 compatibility
     \DeclareRobustCommand{\reviewincludegraphics}[2][]{%
       \includegraphics[##1]{##2}}
-  }
-  \@ifundefined{covermatter}{% for 4.0.0 compatibility
+  \fi
+  \ifdefined\covermatter\else% for 4.0.0 compatibility
     \def\covermatter{}
-  }
+  \fi
 }
 
 \makeatother

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -48,16 +48,16 @@
 \def\reviewpostdeffiles{}
 
 \def\reviewbackcompatibilityhook{
-  \@ifundefined{reviewimagecaption}{% for 3.0.0 compatibility
+  \ifdefined\reviewimagecaption\else% for 3.0.0 compatibility
     \newcommand{\reviewimagecaption}[1]{\caption{##1}}
-  }
-  \@ifundefined{reviewincludegraphics}{% for 3.2.0 compatibility
+  \fi
+  \ifdefined\reviewincludegraphics\else% for 3.2.0 compatibility
     \DeclareRobustCommand{\reviewincludegraphics}[2][]{%
       \includegraphics[##1]{##2}}
-  }
-  \@ifundefined{covermatter}{% for 4.0.0 compatibility
+  \fi
+  \ifdefined\covermatter\else% for 4.0.0 compatibility
     \def\covermatter{}
-  }
+  \fi
 }
 
 \makeatother

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -59,16 +59,16 @@ some ad content
 \def\reviewpostdeffiles{}
 
 \def\reviewbackcompatibilityhook{
-  \@ifundefined{reviewimagecaption}{% for 3.0.0 compatibility
+  \ifdefined\reviewimagecaption\else% for 3.0.0 compatibility
     \newcommand{\reviewimagecaption}[1]{\caption{##1}}
-  }
-  \@ifundefined{reviewincludegraphics}{% for 3.2.0 compatibility
+  \fi
+  \ifdefined\reviewincludegraphics\else% for 3.2.0 compatibility
     \DeclareRobustCommand{\reviewincludegraphics}[2][]{%
       \includegraphics[##1]{##2}}
-  }
-  \@ifundefined{covermatter}{% for 4.0.0 compatibility
+  \fi
+  \ifdefined\covermatter\else% for 4.0.0 compatibility
     \def\covermatter{}
-  }
+  \fi
 }
 
 \makeatother


### PR DESCRIPTION
#1414 の対応

`@ifundefined` の代わりに `\ifdefined\マクロ\else` でテストするようにします。
