### PR TITLE
introduce setxkanjiskip Closes: #1416

### DIFF
--- a/samples/syntax-book/config-jlreq-lualatex.yml
+++ b/samples/syntax-book/config-jlreq-lualatex.yml
@@ -1,0 +1,4 @@
+# call me by 'REVIEW_TEMPLATE=review-jlreq REVIEW_CONFIG_FILE=config-jlreq-lualatex.yml rake pdf'
+inherit: ["config-jlreq.yml"]
+texcommand: "lualatex"
+dvicommand: null

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -28,19 +28,19 @@
 
 % コードリスト装飾のデフォルト
 \newenvironment{reviewemlist}{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=black!10,colframe=black!10,boxrule=0mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\begin{alltt}}%
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=black!10,colframe=black!10,boxrule=0mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\setxkanjiskip{\reviewlistxkanjiskip}\fi\begin{alltt}}%
  {\end{alltt}\end{tcolorbox}}
 
 \newenvironment{reviewlist}{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=white,colframe=black,boxrule=0.15mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\begin{alltt}}%
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=white,colframe=black,boxrule=0.15mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\setxkanjiskip{\reviewlistxkanjiskip}\fi\begin{alltt}}%
  {\end{alltt}\end{tcolorbox}}
 
 \newenvironment{reviewsource}{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=white,colframe=black,boxrule=0.15mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\begin{alltt}}%
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=white,colframe=black,boxrule=0.15mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\setxkanjiskip{\reviewlistxkanjiskip}\fi\begin{alltt}}%
  {\end{alltt}\end{tcolorbox}}
 
 \newenvironment{reviewcmd}{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=black!99,coltext=white,colframe=black!99,boxrule=0mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\xkanjiskip=\reviewlistxkanjiskip\fi\begin{alltt}}%
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,colback=black!99,coltext=white,colframe=black!99,boxrule=0mm,arc=0mm]\ifdefined\reviewlistxkanjiskip\setxkanjiskip{\reviewlistxkanjiskip}\fi\begin{alltt}}%
  {\end{alltt}\end{tcolorbox}}
 
 % 図

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -20,7 +20,7 @@
 % THE SOFTWARE.
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{review-jlreq}[2019/09/22 Re:VIEW pLaTeX class modified for jlreq.
+\ProvidesClass{review-jlreq}[2019/11/11 Re:VIEW pLaTeX class modified for jlreq.
 cls]
 
 %% hook at end of reviewmacro
@@ -339,6 +339,15 @@ cls]
 %% 表紙のノンブル
 \def\coverpagezero#1{\expandafter\@coverpagezero\csname c@#1\endcsname}
 \def\@coverpagezero#1{cover}
+
+%% xkanjiskip抽象化
+\newcommand*\setxkanjiskip[1]{%
+  \def\recls@tmp{lualatex}\ifx\recls@tmp\recls@engine
+    \ltjsetparameter{xkanjiskip={#1}}
+  \else
+    \xkanjiskip=#1\relax
+  \fi
+}
 
 \listfiles
 \endinput


### PR DESCRIPTION
#1416 の修正。

`\setxkanjiskip{値}`で抽象化します。とりあえず把握している範囲として、lualatexとそれ以外、としています。