### PR TITLE
needs one more compile when makeindex is true

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -237,6 +237,7 @@ module ReVIEW
         call_hook('hook_beforemakeindex')
         if @config['pdfmaker']['makeindex'] && File.exist?("#{@mastertex}.idx")
           system_or_raise(*[makeindex_command, makeindex_options, @mastertex].flatten.compact)
+          system_or_raise(*[texcommand, texoptions, "#{@mastertex}.tex"].flatten.compact)
         end
         call_hook('hook_aftermakeindex')
 


### PR DESCRIPTION
#1418 の修正です。
コンパイル回数を増やし、makeindexが有効なときに索引を目次に含めるようにします。

llmkがフツーに使えるようになるなら、それを使うようにビルドを変えられるかなぁ。ただフックとかを入れづらそう。latexmkはPerl必須なので、抵抗がある…。

