### PR TITLE
add table_split_regexp parameter to specify splitter of //table

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -176,6 +176,9 @@ toc: true
 # @<w>命令で使用する単語ファイルのパス
 # words_file: words.csv
 
+# //table命令における列の区切り文字 (Rubyの正規表現)。''で囲むこと
+# table_split_regexp: '\t+'
+
 # review-vol向けのヒント情報
 # 1ページの行数文字数と1kbごとのページ数を用紙サイズで指定する(A5 or B5)
 # page_metric: A5

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -179,6 +179,14 @@ module ReVIEW
       table_end
     end
 
+    def table_split_regexp
+      begin
+        Regexp.new(@book.config['table_split_regexp'])
+      rescue RegexpError
+        error "invalid regular expression in 'table_split_regexp' parameter."
+      end
+    end
+
     def parse_table_rows(lines)
       sepidx = nil
       rows = []
@@ -187,7 +195,7 @@ module ReVIEW
           sepidx ||= idx
           next
         end
-        rows.push(line.strip.split(/\t+/).map { |s| s.sub(/\A\./, '') })
+        rows.push(line.strip.split(table_split_regexp).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
       error 'no rows in the table' if rows.empty?

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -66,6 +66,7 @@ module ReVIEW
         'colophon_order' => %w[aut csl trl dsr ill cov edt pbl contact prt],
         'externallink' => true,
         'join_lines_by_lang' => nil, # experimental. default should be nil
+        'table_split_regexp' => '\t+',
         # for IDGXML
         'tableopt' => nil,
         'listinfo' => nil,

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -516,11 +516,6 @@ module ReVIEW
     end
 
     def table_rows(sepidx, rows)
-      begin
-        table_split_regexp = Regexp.new(@book.config['table_split_regexp'])
-      rescue RegexpError
-        error "invalid regular expression in 'table_split_regexp' parameter."
-      end
       cellwidth = []
       if @tablewidth
         if @tsize.nil?

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -508,7 +508,7 @@ module ReVIEW
         else
           rows.push(line.gsub(/\t\.\t/, "\t\t").gsub(/\t\.\.\t/, "\t.\t").gsub(/\t\.\Z/, "\t").gsub(/\t\.\.\Z/, "\t.").gsub(/\A\./, ''))
         end
-        col2 = rows[rows.length - 1].split(/\t/).length
+        col2 = rows[rows.length - 1].split(table_split_regexp).length
         @col = col2 if col2 > @col
       end
       error 'no rows in the table' if rows.empty?
@@ -516,6 +516,11 @@ module ReVIEW
     end
 
     def table_rows(sepidx, rows)
+      begin
+        table_split_regexp = Regexp.new(@book.config['table_split_regexp'])
+      rescue RegexpError
+        error "invalid regular expression in 'table_split_regexp' parameter."
+      end
       cellwidth = []
       if @tablewidth
         if @tsize.nil?
@@ -542,7 +547,7 @@ module ReVIEW
             puts %Q(<tr type="header">#{rows.shift}</tr>)
           else
             i = 0
-            rows.shift.split("\t").each_with_index do |cell, x|
+            rows.shift.split(table_split_regexp).each_with_index do |cell, x|
               print %Q(<td xyh="#{x + 1},#{y + 1},#{sepidx}" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="#{sprintf('%.3f', cellwidth[i])}">#{cell.sub('DUMMYCELLSPLITTER', '')}</td>)
               i += 1
             end
@@ -557,7 +562,7 @@ module ReVIEW
       if tablewidth
         rows.each_with_index do |row, y|
           i = 0
-          row.split("\t").each_with_index do |cell, x|
+          row.split(table_split_regexp).each_with_index do |cell, x|
             print %Q(<td xyh="#{x + 1},#{y + 1 + sepidx},#{sepidx}" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="#{sprintf('%.3f', cellwidth[i])}">#{cell.sub('DUMMYCELLSPLITTER', '')}</td>)
             i += 1
           end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -2109,6 +2109,48 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_table_split_regexp
+    src = "//table{\n1\t2\t\t3  4,5\n------------\na b\tc  d,e\n//}\n"
+    expected = <<-EOS
+<div class="table">
+<table>
+<tr><th>1</th><th>2</th><th>3  4,5</th></tr>
+<tr><td>a b</td><td>c  d,e</td><td></td></tr>
+</table>
+</div>
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+
+    @config['table_split_regexp'] = '\s+'
+    actual = compile_block(src)
+    expected = <<-EOS
+<div class="table">
+<table>
+<tr><th>1</th><th>2</th><th>3</th><th>4,5</th></tr>
+<tr><td>a</td><td>b</td><td>c</td><td>d,e</td></tr>
+</table>
+</div>
+EOS
+    assert_equal expected, actual
+
+    @config['table_split_regexp'] = ','
+    actual = compile_block(src)
+    expected = <<-EOS
+<div class="table">
+<table>
+<tr><th>1\t2\t\t3  4</th><th>5</th></tr>
+<tr><td>a b\tc  d</td><td>e</td></tr>
+</table>
+</div>
+EOS
+    assert_equal expected, actual
+
+    @config['table_split_regexp'] = '['
+    e = assert_raises(ReVIEW::ApplicationError) { actual = compile_block(src) }
+    assert_equal ":5: error: invalid regular expression in 'table_split_regexp' parameter.", e.message
+  end
+
   def test_major_blocks
     actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
     expected = <<-EOS

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -146,6 +146,33 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(<table><caption>foo</caption><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table><table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table>), actual
   end
 
+  def test_table_split_regexp
+    src = "//table{\n1\t2\t\t3  4,5\n------------\na b\tc  d,e\n//}\n"
+    expected = <<-EOS.chomp
+<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="3"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">3  4,5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">a b</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">c  d,e</td></tbody></table>
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+
+    @config['table_split_regexp'] = '\s+'
+    actual = compile_block(src)
+    expected = <<-EOS.chomp
+<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="4"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">3</td><td xyh="4,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">4,5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">a</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">b</td><td xyh="3,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">c</td><td xyh="4,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">d,e</td></tbody></table>
+EOS
+    assert_equal expected, actual
+
+    @config['table_split_regexp'] = ','
+    actual = compile_block(src)
+    expected = <<-EOS.chomp
+<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="2"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">1\t2\t\t3  4</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">a b\tc  d</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">e</td></tbody></table>
+EOS
+    assert_equal expected, actual
+
+    @config['table_split_regexp'] = '['
+    e = assert_raises(ReVIEW::ApplicationError) { actual = compile_block(src) }
+    assert_equal ":5: error: invalid regular expression in 'table_split_regexp' parameter.", e.message
+  end
+
   def test_inline_br
     actual = compile_inline('@<br>{}')
     assert_equal "\n", actual

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -466,6 +466,45 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_table_split_regexp
+    src = "//table{\n1\t2\t\t3  4,5\n------------\na b\tc  d,e\n//}\n"
+    expected = <<-EOS
+◆→開始:表←◆
+★1☆\t★2☆\t★3  4,5☆
+a b\tc  d,e\t
+◆→終了:表←◆
+
+EOS
+    actual = compile_block(src)
+    assert_equal expected, actual
+
+    @config['table_split_regexp'] = '\s+'
+    actual = compile_block(src)
+    expected = <<-EOS
+◆→開始:表←◆
+★1☆\t★2☆\t★3☆\t★4,5☆
+a\tb\tc\td,e
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
+
+    @config['table_split_regexp'] = ','
+    actual = compile_block(src)
+    expected = <<-EOS
+◆→開始:表←◆
+★1\t2\t\t3  4☆\t★5☆
+a b\tc  d\te
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
+
+    @config['table_split_regexp'] = '['
+    e = assert_raises(ReVIEW::ApplicationError) { actual = compile_block(src) }
+    assert_equal ":5: error: invalid regular expression in 'table_split_regexp' parameter.", e.message
+  end
+
   def test_major_blocks
     actual = compile_block("//note{\nA\n\nB\n//}\n//note[caption]{\nA\n//}")
     expected = <<-EOS


### PR DESCRIPTION
#1420 の対処です。
正規表現でセル区切り文字を変えられるようにするパラメータ `table_split_regexp` を導入します。
