### PR TITLE
IDGXML: fix handling filter error message in maker

### DIFF
--- a/lib/review/idgxmlmaker.rb
+++ b/lib/review/idgxmlmaker.rb
@@ -121,10 +121,10 @@ module ReVIEW
         if s.success?
           File.write(xmlfile, o) # override
         else
-          warn("filter error for #{xmlfile}: #{e.message}")
+          warn("filter error for #{xmlfile}: #{e}")
         end
       rescue => e
-        warn("filter error for #{xmlfile}: #{e}")
+        warn("filter error for #{xmlfile}: #{e.message}")
       end
     end
 


### PR DESCRIPTION
IDGXMLMakerでフィルタにエラーがあったときにエラー表示する変数に誤りがありました