### PR TITLE
fix rubocop warning (ERB.new)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -40,6 +40,9 @@ Lint/UnusedMethodArgument:
 Lint/UselessAssignment:
   Enabled: true
 
+Lint/ErbNewArguments:
+  Enabled: false
+
 #### Performance
 
 Performance/RegexpMatch:

--- a/lib/review/template.rb
+++ b/lib/review/template.rb
@@ -13,7 +13,7 @@ module ReVIEW
     def initialize(filename = nil, mode = nil)
       return unless filename
       content = File.read(filename)
-      @erb = ERB.new(content, trim_mode: mode)
+      @erb = ERB.new(content, nil, mode)
     end
 
     def result(bind_data = nil)

--- a/lib/review/template.rb
+++ b/lib/review/template.rb
@@ -13,7 +13,7 @@ module ReVIEW
     def initialize(filename = nil, mode = nil)
       return unless filename
       content = File.read(filename)
-      @erb = ERB.new(content, nil, mode)
+      @erb = ERB.new(content, trim_mode: mode)
     end
 
     def result(bind_data = nil)


### PR DESCRIPTION
rubocopで警告が出てたので確認したところ、

> Ruby 2.6.0 から位置引数での safe_level, trim_mode, eoutvar の指定は非推奨です。 Ruby 2.5 が EOL になったときに削除される予定です。 trim_mode と eoutvar の指定はキーワード引数に移行してください。

https://docs.ruby-lang.org/ja/latest/class/ERB.html

とのことだったようです。