### PR TITLE
compile PDF in test phase exactly

### DIFF
--- a/samples/sample-book/src/config-ebook.yml
+++ b/samples/sample-book/src/config-ebook.yml
@@ -1,0 +1,4 @@
+# call me by 'REVIEW_CONFIG_FILE=config-ebook.yml rake pdf'
+inherit: ["config.yml"]
+pdfmaker:
+  texdocumentclass: ["review-jsbook", "media=ebook,paper=a5"]

--- a/samples/sample-book/src/config-jlreq-ebook.yml
+++ b/samples/sample-book/src/config-jlreq-ebook.yml
@@ -1,0 +1,4 @@
+# call me by 'REVIEW_TEMPLATE=review-jlreq REVIEW_CONFIG_FILE=config-jlreq-ebook.yml rake pdf'
+inherit: ["config.yml"]
+pdfmaker:
+  texdocumentclass: ["review-jlreq", "media=ebook,paper=a5"]

--- a/samples/sample-book/src/config.yml
+++ b/samples/sample-book/src/config.yml
@@ -1,5 +1,5 @@
 ## config.yml for sample book
-review_version: 3.0
+review_version: 4.0
 bookname: book
 language: ja
 booktitle: Re:VIEWサンプル書籍

--- a/samples/syntax-book/ch02.re
+++ b/samples/syntax-book/ch02.re
@@ -324,6 +324,7 @@ a_{m1} & \cdots & a_{mn}
 網カケ@<ami>{amiアミ}    @<balloon>{ふきだし説明}
 //}
 
+=== 見出し内 @<b>{BOLD},@<i>{ITALIC},@<tt>{TT},@<strong>{STRONG},@<em>{EM},@<u>{UNDERLINE},@<code>{CODE},@<ttb>{TTB},@<tti>{TTI}
 
 ==={crossref} 参照
 #@# FIXME:任意ラベルを使うと、EPUBチェックエラーになることがある？

--- a/samples/syntax-book/config-print.yml
+++ b/samples/syntax-book/config-print.yml
@@ -1,0 +1,3 @@
+# call me by 'REVIEW_CONFIG_FILE=config-print.yml rake pdf'
+inherit: ["config.yml"]
+texdocumentclass: ["review-jsbook", "media=print,paper=b5"]

--- a/samples/syntax-book/config.yml
+++ b/samples/syntax-book/config.yml
@@ -1,4 +1,4 @@
-review_version: 3.0
+review_version: 4.0
 bookname: syntax-book
 language: ja
 booktitle: {name: "Re:VIEW文法使用例", file-as: "リビューブンポウシヨウレイ"}

--- a/test/test_epubmaker_cmd.rb
+++ b/test/test_epubmaker_cmd.rb
@@ -21,18 +21,25 @@ class EPUBMakerCmdTest < Test::Unit::TestCase
     ENV['RUBYLIB'] = @old_rubylib
   end
 
-  def test_epubmaker_cmd
+  def common_buildepub(bookdir, configfile, targetepubfile)
     if /mswin|mingw|cygwin/ !~ RUBY_PLATFORM
-      config = prepare_samplebook(@tmpdir1)
+      config = prepare_samplebook(@tmpdir1, bookdir, nil, configfile)
       builddir = File.join(@tmpdir1, config['bookname'] + '-epub')
       assert !File.exist?(builddir)
 
       ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']) + RbConfig::CONFIG['EXEEXT']
       Dir.chdir(@tmpdir1) do
-        system("#{ruby_cmd} -S #{REVIEW_EPUBMAKER} config.yml 1>/dev/null 2>/dev/null")
+        system("#{ruby_cmd} -S #{REVIEW_EPUBMAKER} #{configfile} 1>/dev/null 2>/dev/null")
       end
-
-      assert File.exist?(builddir)
+      assert File.exist?(File.join(@tmpdir1, targetepubfile))
     end
+  end
+
+  def test_epubmaker_cmd_samplebook
+    common_buildepub('sample-book/src', 'config.yml', 'book.epub')
+  end
+
+  def test_epubmaker_cmd_syntaxbook
+    common_buildepub('syntax-book', 'config.yml', 'syntax-book.epub')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,13 +10,16 @@ def assets_dir
   File.join(File.dirname(__FILE__), 'assets')
 end
 
-def prepare_samplebook(srcdir)
-  samplebook_dir = File.expand_path('../samples/sample-book/src/', File.dirname(__FILE__))
+def prepare_samplebook(srcdir, bookdir, latextemplatedir, configfile)
+  samplebook_dir = File.expand_path("../samples/#{bookdir}/", File.dirname(__FILE__))
   FileUtils.cp_r(Dir.glob(File.join(samplebook_dir, '*')), srcdir)
-  # copy from review-jsbook
-  template_dir = File.expand_path('../templates/latex/review-jsbook/', File.dirname(__FILE__))
-  FileUtils.cp(Dir.glob(File.join(template_dir, '*')), File.join(srcdir, 'sty'))
-  YAML.safe_load(File.open(File.join(srcdir, 'config.yml')), [Date])
+  if latextemplatedir
+    # copy from review-jsbook or review-jlreq
+    template_dir = File.expand_path("../templates/latex/#{latextemplatedir}/", File.dirname(__FILE__))
+    FileUtils.cp(Dir.glob(File.join(template_dir, '*')), File.join(srcdir, 'sty'))
+  end
+  loader = ReVIEW::YAMLLoader.new
+  loader.load_file(File.open(File.join(srcdir, configfile)))
 end
 
 def compile_inline(text)


### PR DESCRIPTION
コンパイラがある環境では、rake test時にいろいろな設定でのPDFビルドを実際に行い、確かにビルドできることを確認するようにします。

また、見出しに等幅などのいくつかの命令を追加し、よりエラーを発見しやすいようにします。

で、実際 #1432 で手元でコケますね…
