### PR TITLE
PDFMaker: revert tt,code,tti, and ttb temporary.

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -222,10 +222,15 @@
   \review@ba@breaktrue
   \review@break@all@a
 }
-\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries\reviewbreakall{#1}}}
+% These macros cause an error with hyperref...
+%\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily\reviewbreakall{#1}}}
+%\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily\reviewbreakall{#1}}}
+%\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape\reviewbreakall{#1}}}
+%\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily{#1}}}
+\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily{#1}}}
+\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape{#1}}}
+\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries{#1}}}
 
 \DeclareRobustCommand{\reviewbou}[1]{\kenten{#1}}
 

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2019/10/25]
+\ProvidesClass{review-base}[2019/12/16]
 % jlreq用基本設定
 \def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
   \hypersetup{

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -312,10 +312,15 @@
   \review@ba@breaktrue
   \review@break@all@a
 }
-\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries\reviewbreakall{#1}}}
+% These macros cause an error with hyperref...
+%\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily\reviewbreakall{#1}}}
+%\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily\reviewbreakall{#1}}}
+%\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape\reviewbreakall{#1}}}
+%\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily{#1}}}
+\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily{#1}}}
+\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape{#1}}}
+\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries{#1}}}
 
 \DeclareRobustCommand{\reviewbou}[1]{\kenten{#1}}
 

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2019/10/25]
+\ProvidesClass{review-base}[2019/12/16]
 \RequirePackage{ifthen}
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}


### PR DESCRIPTION
#1432 の対応
\reviewbreakall のhyperref対応が現状すぐにできるか不明なため、段落間分割をあきらめて書体変更のみを行うようにします。