### PR TITLE
revival breakall tt

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -178,6 +178,8 @@
 
 % allow break line in tt
 % contributed by @zr_tex8r
+\g@addto@macro\pdfstringdefPreHook{%
+  \def\reviewbreakall#1{#1}}
 \newif\ifreview@ba@break
 \def\review@ba@end{\review@ba@end@}
 \DeclareRobustCommand{\reviewbreakall}[1]{%
@@ -222,15 +224,10 @@
   \review@ba@breaktrue
   \review@break@all@a
 }
-% These macros cause an error with hyperref...
-%\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily\reviewbreakall{#1}}}
-%\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily\reviewbreakall{#1}}}
-%\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape\reviewbreakall{#1}}}
-%\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily{#1}}}
-\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily{#1}}}
-\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape{#1}}}
-\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries{#1}}}
+\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries\reviewbreakall{#1}}}
 
 \DeclareRobustCommand{\reviewbou}[1]{\kenten{#1}}
 

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -268,6 +268,8 @@
 
 % allow break line in tt
 % contributed by @zr_tex8r
+\g@addto@macro\pdfstringdefPreHook{%
+  \def\reviewbreakall#1{#1}}
 \newif\ifreview@ba@break
 \def\review@ba@end{\review@ba@end@}
 \DeclareRobustCommand{\reviewbreakall}[1]{%
@@ -312,15 +314,10 @@
   \review@ba@breaktrue
   \review@break@all@a
 }
-% These macros cause an error with hyperref...
-%\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily\reviewbreakall{#1}}}
-%\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily\reviewbreakall{#1}}}
-%\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape\reviewbreakall{#1}}}
-%\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily{#1}}}
-\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily{#1}}}
-\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape{#1}}}
-\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries{#1}}}
+\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries\reviewbreakall{#1}}}
 
 \DeclareRobustCommand{\reviewbou}[1]{\kenten{#1}}
 


### PR DESCRIPTION
#1432  についていったん諦めていましたが、@munepi さんの解決方法

```
\g@addto@macro\pdfstringdefPreHook{%
  \def\reviewbreakall#1{#1}}
```

の追加でうまくいきそうです。