### PR TITLE
introduce table_splitter to choose predefined splitter regexp

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -181,8 +181,8 @@ toc: true
 # @<w>命令で使用する単語ファイルのパス
 # words_file: words.csv
 
-# //table命令における列の区切り文字 (Rubyの正規表現)。''で囲むこと
-# table_split_regexp: '\t+'
+# //table命令における列の区切り文字。tabs (1文字以上のタブ文字区切り。デフォルト), singletab (1文字のタブ文字区切り), spaces (1文字以上のスペースまたはタブ文字の区切り), verticalbar ("0個以上の空白 | 0個以上の空白"の区切り)
+# table_splitter: tabs
 
 # review-vol向けのヒント情報
 # 1ページの行数文字数と1kbごとのページ数を用紙サイズで指定する(A5 or B5)

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -180,10 +180,17 @@ module ReVIEW
     end
 
     def table_split_regexp
-      begin
-        Regexp.new(@book.config['table_split_regexp'])
-      rescue RegexpError
-        error "invalid regular expression in 'table_split_regexp' parameter."
+      case @book.config['table_splitter']
+      when 'tabs'
+        Regexp.new('\t+')
+      when 'singletab'
+        Regexp.new('\t')
+      when 'spaces'
+        Regexp.new('\s+')
+      when 'verticalbar'
+        Regexp.new('\s*\\' + escape('|') + '\s*')
+      else
+        error "Unknown value for 'table_splitter', shold be: tabs, singletab, spaces, verticalbar"
       end
     end
 

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -66,7 +66,7 @@ module ReVIEW
         'colophon_order' => %w[aut csl trl dsr ill cov edt pbl contact prt],
         'externallink' => true,
         'join_lines_by_lang' => nil, # experimental. default should be nil
-        'table_split_regexp' => '\t+',
+        'table_splitter' => 'tabs',
         # for IDGXML
         'tableopt' => nil,
         'listinfo' => nil,

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -2109,46 +2109,54 @@ EOS
     assert_equal expected, actual
   end
 
-  def test_table_split_regexp
-    src = "//table{\n1\t2\t\t3  4,5\n------------\na b\tc  d,e\n//}\n"
+  def test_table_splitter
+    src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS
 <div class="table">
 <table>
-<tr><th>1</th><th>2</th><th>3  4,5</th></tr>
-<tr><td>a b</td><td>c  d,e</td><td></td></tr>
+<tr><th>1</th><th>2</th><th>3  4| 5</th></tr>
+<tr><td>a b</td><td>c  d   |e</td><td></td></tr>
 </table>
 </div>
 EOS
     actual = compile_block(src)
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = '\s+'
+    @config['table_splitter'] = 'singletab'
     actual = compile_block(src)
     expected = <<-EOS
 <div class="table">
 <table>
-<tr><th>1</th><th>2</th><th>3</th><th>4,5</th></tr>
-<tr><td>a</td><td>b</td><td>c</td><td>d,e</td></tr>
+<tr><th>1</th><th>2</th><th></th><th>3  4| 5</th></tr>
+<tr><td>a b</td><td>c  d   |e</td><td></td><td></td></tr>
 </table>
 </div>
 EOS
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = ','
+    @config['table_splitter'] = 'spaces'
     actual = compile_block(src)
     expected = <<-EOS
 <div class="table">
 <table>
-<tr><th>1\t2\t\t3  4</th><th>5</th></tr>
-<tr><td>a b\tc  d</td><td>e</td></tr>
+<tr><th>1</th><th>2</th><th>3</th><th>4|</th><th>5</th></tr>
+<tr><td>a</td><td>b</td><td>c</td><td>d</td><td>|e</td></tr>
 </table>
 </div>
 EOS
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = '['
-    e = assert_raises(ReVIEW::ApplicationError) { actual = compile_block(src) }
-    assert_equal ":5: error: invalid regular expression in 'table_split_regexp' parameter.", e.message
+    @config['table_splitter'] = 'verticalbar'
+    actual = compile_block(src)
+    expected = <<-EOS
+<div class="table">
+<table>
+<tr><th>1	2		3  4</th><th>5</th></tr>
+<tr><td>a b	c  d</td><td>e</td></tr>
+</table>
+</div>
+EOS
+    assert_equal expected, actual
   end
 
   def test_major_blocks

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -146,31 +146,34 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(<table><caption>foo</caption><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table><table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table>), actual
   end
 
-  def test_table_split_regexp
-    src = "//table{\n1\t2\t\t3  4,5\n------------\na b\tc  d,e\n//}\n"
+  def test_table_splitter
+    src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS.chomp
-<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="3"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">3  4,5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">a b</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">c  d,e</td></tbody></table>
+<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="3"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">3  4| 5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">a b</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">c  d   |e</td></tbody></table>
 EOS
     actual = compile_block(src)
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = '\s+'
+    @config['table_splitter'] = 'singletab'
     actual = compile_block(src)
     expected = <<-EOS.chomp
-<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="4"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">3</td><td xyh="4,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">4,5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">a</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">b</td><td xyh="3,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">c</td><td xyh="4,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">d,e</td></tbody></table>
+<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="4"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086"></td><td xyh="4,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">3  4| 5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">a b</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">c  d   |e</td></tbody></table>
 EOS
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = ','
+    @config['table_splitter'] = 'spaces'
     actual = compile_block(src)
     expected = <<-EOS.chomp
-<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="2"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">1\t2\t\t3  4</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">a b\tc  d</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">e</td></tbody></table>
+<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="5"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">3</td><td xyh="4,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">4|</td><td xyh="5,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">a</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">b</td><td xyh="3,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">c</td><td xyh="4,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">d</td><td xyh="5,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">|e</td></tbody></table>
 EOS
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = '['
-    e = assert_raises(ReVIEW::ApplicationError) { actual = compile_block(src) }
-    assert_equal ":5: error: invalid regular expression in 'table_split_regexp' parameter.", e.message
+    @config['table_splitter'] = 'verticalbar'
+    actual = compile_block(src)
+    expected = <<-EOS.chomp
+<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="2"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">1	2		3  4</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">a b	c  d</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">e</td></tbody></table>
+EOS
+    assert_equal expected, actual
   end
 
   def test_inline_br

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1194,43 +1194,50 @@ EOS
     assert_equal expected, actual
   end
 
-  def test_table_split_regexp
-    src = "//table{\n1\t2\t\t3  4,5\n------------\na b\tc  d,e\n//}\n"
+  def test_table_splitter
+    src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS
 \\begin{reviewtable}{|l|l|l|}
 \\hline
-\\reviewth{1} & \\reviewth{2} & \\reviewth{3  4,5} \\\\  \\hline
-a b & c  d,e &  \\\\  \\\hline
+\\reviewth{1} & \\reviewth{2} & \\reviewth{3  4\\textbar{} 5} \\\\  \\hline
+a b & c  d   \\textbar{}e &  \\\\  \\hline
 \\end{reviewtable}
 EOS
     actual = compile_block(src)
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = '\s+'
+    @config['table_splitter'] = 'singletab'
     actual = compile_block(src)
     expected = <<-EOS
 \\begin{reviewtable}{|l|l|l|l|}
 \\hline
-\\reviewth{1} & \\reviewth{2} & \\reviewth{3} & \\reviewth{4,5} \\\\  \\hline
-a & b & c & d,e \\\\  \\hline
+\\reviewth{1} & \\reviewth{2} & \\reviewth{} & \\reviewth{3  4\\textbar{} 5} \\\\  \\hline
+a b & c  d   \\textbar{}e &  &  \\\\  \\hline
 \\end{reviewtable}
 EOS
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = ','
+    @config['table_splitter'] = 'spaces'
+    actual = compile_block(src)
+    expected = <<-EOS
+\\begin{reviewtable}{|l|l|l|l|l|}
+\\hline
+\\reviewth{1} & \\reviewth{2} & \\reviewth{3} & \\reviewth{4\\textbar{}} & \\reviewth{5} \\\\  \\hline
+a & b & c & d & \\textbar{}e \\\\  \\hline
+\\end{reviewtable}
+EOS
+    assert_equal expected, actual
+
+    @config['table_splitter'] = 'verticalbar'
     actual = compile_block(src)
     expected = <<-EOS
 \\begin{reviewtable}{|l|l|}
 \\hline
-\\reviewth{1\t2\t\t3  4} & \\reviewth{5} \\\\  \\hline
-a b\tc  d & e \\\\  \\hline
+\\reviewth{1	2		3  4} & \\reviewth{5} \\\\  \\hline
+a b	c  d & e \\\\  \\hline
 \\end{reviewtable}
 EOS
     assert_equal expected, actual
-
-    @config['table_split_regexp'] = '['
-    e = assert_raises(ReVIEW::ApplicationError) { actual = compile_block(src) }
-    assert_equal ":5: error: invalid regular expression in 'table_split_regexp' parameter.", e.message
   end
 
   def test_bib

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -466,43 +466,50 @@ EOS
     assert_equal expected, actual
   end
 
-  def test_table_split_regexp
-    src = "//table{\n1\t2\t\t3  4,5\n------------\na b\tc  d,e\n//}\n"
+  def test_table_splitter
+    src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS
 ◆→開始:表←◆
-★1☆\t★2☆\t★3  4,5☆
-a b\tc  d,e\t
+★1☆	★2☆	★3  4| 5☆
+a b	c  d   |e	
 ◆→終了:表←◆
 
 EOS
     actual = compile_block(src)
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = '\s+'
+    @config['table_splitter'] = 'singletab'
     actual = compile_block(src)
     expected = <<-EOS
 ◆→開始:表←◆
-★1☆\t★2☆\t★3☆\t★4,5☆
-a\tb\tc\td,e
+★1☆	★2☆	★☆	★3  4| 5☆
+a b	c  d   |e		
 ◆→終了:表←◆
 
 EOS
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = ','
+    @config['table_splitter'] = 'spaces'
     actual = compile_block(src)
     expected = <<-EOS
 ◆→開始:表←◆
-★1\t2\t\t3  4☆\t★5☆
-a b\tc  d\te
+★1☆	★2☆	★3☆	★4|☆	★5☆
+a	b	c	d	|e
 ◆→終了:表←◆
 
 EOS
     assert_equal expected, actual
 
-    @config['table_split_regexp'] = '['
-    e = assert_raises(ReVIEW::ApplicationError) { actual = compile_block(src) }
-    assert_equal ":5: error: invalid regular expression in 'table_split_regexp' parameter.", e.message
+    @config['table_splitter'] = 'verticalbar'
+    actual = compile_block(src)
+    expected = <<-EOS
+◆→開始:表←◆
+★1	2		3  4☆	★5☆
+a b	c  d	e
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
   end
 
   def test_major_blocks


### PR DESCRIPTION
@takahashim 

`table_splitter_regexp`を廃棄し、定義済み名のみをとる`table_splitter`を導入します。パターンはこの4つあればよかろうという判断です。

- tabs : デフォルト。\t+に展開
- singletab: \tに展開。「tab」だとtabsと区別しづらいので…
- spaces: \s+に展開
- verticalbar: \s*\|\s*に展開
