### PR TITLE
enable to build without mecab

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -60,7 +60,7 @@ module ReVIEW
         require 'nkf'
         @index_mecab = MeCab::Tagger.new(@book.config['pdfmaker']['makeindex_mecab_opts'])
       rescue LoadError
-        error 'not found MeCab'
+        warn 'not found MeCab'
       end
     end
 


### PR DESCRIPTION
mebabがいないときに`rake test`でコケるようです。

```
INFO review-pdfmaker: compiling pre01.tex
WARN review-pdfmaker: compile error in pre01.tex (ReVIEW::ApplicationError)
WARN review-pdfmaker: pre01.re:0: error: not found MeCab
INFO review-pdfmaker: compiling ch01.tex
WARN review-pdfmaker: compile error in ch01.tex (ReVIEW::ApplicationError)
WARN review-pdfmaker: ch01.re:0: error: not found MeCab
INFO review-pdfmaker: compiling part2.tex
WARN review-pdfmaker: compile error in part2.tex (ReVIEW::ApplicationError)
WARN review-pdfmaker: part2.re:0: error: not found MeCab
INFO review-pdfmaker: compiling ch02.tex
WARN review-pdfmaker: compile error in ch02.tex (ReVIEW::ApplicationError)
WARN review-pdfmaker: ch02.re:0: error: not found MeCab
INFO review-pdfmaker: compiling ch03.tex
WARN review-pdfmaker: compile error in ch03.tex (ReVIEW::ApplicationError)
WARN review-pdfmaker: ch03.re:0: error: not found MeCab
INFO review-pdfmaker: compiling appA.tex
WARN review-pdfmaker: compile error in appA.tex (ReVIEW::ApplicationError)
WARN review-pdfmaker: appA.re:0: error: not found MeCab
INFO review-pdfmaker: compiling bib.tex
WARN review-pdfmaker: compile error in bib.tex (ReVIEW::ApplicationError)
WARN review-pdfmaker: bib.re:0: error: not found MeCab
ERROR review-pdfmaker: compile error, No PDF file output.
F
```