### PR TITLE
rename parameter from table_splitter to table_rows_splitter

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -182,7 +182,7 @@ toc: true
 # words_file: words.csv
 
 # //table命令における列の区切り文字。tabs (1文字以上のタブ文字区切り。デフォルト), singletab (1文字のタブ文字区切り), spaces (1文字以上のスペースまたはタブ文字の区切り), verticalbar ("0個以上の空白 | 0個以上の空白"の区切り)
-# table_splitter: tabs
+# table_rows_splitter: tabs
 
 # review-vol向けのヒント情報
 # 1ページの行数文字数と1kbごとのページ数を用紙サイズで指定する(A5 or B5)

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -179,8 +179,8 @@ module ReVIEW
       table_end
     end
 
-    def table_split_regexp
-      case @book.config['table_splitter']
+    def table_rows_split_regexp
+      case @book.config['table_rows_splitter']
       when 'tabs'
         Regexp.new('\t+')
       when 'singletab'
@@ -190,7 +190,7 @@ module ReVIEW
       when 'verticalbar'
         Regexp.new('\s*\\' + escape('|') + '\s*')
       else
-        error "Unknown value for 'table_splitter', shold be: tabs, singletab, spaces, verticalbar"
+        error "Unknown value for 'table_rows_splitter', shold be: tabs, singletab, spaces, verticalbar"
       end
     end
 
@@ -202,7 +202,7 @@ module ReVIEW
           sepidx ||= idx
           next
         end
-        rows.push(line.strip.split(table_split_regexp).map { |s| s.sub(/\A\./, '') })
+        rows.push(line.strip.split(table_rows_split_regexp).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
       error 'no rows in the table' if rows.empty?

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -66,7 +66,7 @@ module ReVIEW
         'colophon_order' => %w[aut csl trl dsr ill cov edt pbl contact prt],
         'externallink' => true,
         'join_lines_by_lang' => nil, # experimental. default should be nil
-        'table_splitter' => 'tabs',
+        'table_rows_splitter' => 'tabs',
         # for IDGXML
         'tableopt' => nil,
         'listinfo' => nil,

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -499,7 +499,7 @@ module ReVIEW
         else
           rows.push(line.gsub(/\t\.\t/, "\t\t").gsub(/\t\.\.\t/, "\t.\t").gsub(/\t\.\Z/, "\t").gsub(/\t\.\.\Z/, "\t.").gsub(/\A\./, ''))
         end
-        col2 = rows[rows.length - 1].split(table_split_regexp).length
+        col2 = rows[rows.length - 1].split(table_rows_split_regexp).length
         @col = col2 if col2 > @col
       end
       error 'no rows in the table' if rows.empty?
@@ -533,7 +533,7 @@ module ReVIEW
             puts %Q(<tr type="header">#{rows.shift}</tr>)
           else
             i = 0
-            rows.shift.split(table_split_regexp).each_with_index do |cell, x|
+            rows.shift.split(table_rows_split_regexp).each_with_index do |cell, x|
               print %Q(<td xyh="#{x + 1},#{y + 1},#{sepidx}" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="#{sprintf('%.3f', cellwidth[i])}">#{cell.sub('DUMMYCELLSPLITTER', '')}</td>)
               i += 1
             end
@@ -548,7 +548,7 @@ module ReVIEW
       if tablewidth
         rows.each_with_index do |row, y|
           i = 0
-          row.split(table_split_regexp).each_with_index do |cell, x|
+          row.split(table_rows_split_regexp).each_with_index do |cell, x|
             print %Q(<td xyh="#{x + 1},#{y + 1 + sepidx},#{sepidx}" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="#{sprintf('%.3f', cellwidth[i])}">#{cell.sub('DUMMYCELLSPLITTER', '')}</td>)
             i += 1
           end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -2109,7 +2109,7 @@ EOS
     assert_equal expected, actual
   end
 
-  def test_table_splitter
+  def test_table_rows_splitter
     src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS
 <div class="table">
@@ -2122,7 +2122,7 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'singletab'
+    @config['table_rows_splitter'] = 'singletab'
     actual = compile_block(src)
     expected = <<-EOS
 <div class="table">
@@ -2134,7 +2134,7 @@ EOS
 EOS
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'spaces'
+    @config['table_rows_splitter'] = 'spaces'
     actual = compile_block(src)
     expected = <<-EOS
 <div class="table">
@@ -2146,7 +2146,7 @@ EOS
 EOS
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'verticalbar'
+    @config['table_rows_splitter'] = 'verticalbar'
     actual = compile_block(src)
     expected = <<-EOS
 <div class="table">

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -146,7 +146,7 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(<table><caption>foo</caption><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table><table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="1" aid:tcols="1"><td xyh="1,1,0" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="28.345">A</td></tbody></table>), actual
   end
 
-  def test_table_splitter
+  def test_table_rows_splitter
     src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS.chomp
 <table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="3"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">3  4| 5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">a b</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">c  d   |e</td></tbody></table>
@@ -154,21 +154,21 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'singletab'
+    @config['table_rows_splitter'] = 'singletab'
     actual = compile_block(src)
     expected = <<-EOS.chomp
 <table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="4"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086"></td><td xyh="4,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">3  4| 5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">a b</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">c  d   |e</td></tbody></table>
 EOS
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'spaces'
+    @config['table_rows_splitter'] = 'spaces'
     actual = compile_block(src)
     expected = <<-EOS.chomp
 <table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="5"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">3</td><td xyh="4,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">4|</td><td xyh="5,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">a</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">b</td><td xyh="3,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">c</td><td xyh="4,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">d</td><td xyh="5,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="5.669">|e</td></tbody></table>
 EOS
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'verticalbar'
+    @config['table_rows_splitter'] = 'verticalbar'
     actual = compile_block(src)
     expected = <<-EOS.chomp
 <table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="2"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">1	2		3  4</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">a b	c  d</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">e</td></tbody></table>

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1194,7 +1194,7 @@ EOS
     assert_equal expected, actual
   end
 
-  def test_table_splitter
+  def test_table_rows_splitter
     src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS
 \\begin{reviewtable}{|l|l|l|}
@@ -1206,7 +1206,7 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'singletab'
+    @config['table_rows_splitter'] = 'singletab'
     actual = compile_block(src)
     expected = <<-EOS
 \\begin{reviewtable}{|l|l|l|l|}
@@ -1217,7 +1217,7 @@ a b & c  d   \\textbar{}e &  &  \\\\  \\hline
 EOS
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'spaces'
+    @config['table_rows_splitter'] = 'spaces'
     actual = compile_block(src)
     expected = <<-EOS
 \\begin{reviewtable}{|l|l|l|l|l|}
@@ -1228,7 +1228,7 @@ a & b & c & d & \\textbar{}e \\\\  \\hline
 EOS
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'verticalbar'
+    @config['table_rows_splitter'] = 'verticalbar'
     actual = compile_block(src)
     expected = <<-EOS
 \\begin{reviewtable}{|l|l|}

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -466,7 +466,7 @@ EOS
     assert_equal expected, actual
   end
 
-  def test_table_splitter
+  def test_table_rows_splitter
     src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS
 ◆→開始:表←◆
@@ -478,7 +478,7 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'singletab'
+    @config['table_rows_splitter'] = 'singletab'
     actual = compile_block(src)
     expected = <<-EOS
 ◆→開始:表←◆
@@ -489,7 +489,7 @@ a b	c  d   |e
 EOS
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'spaces'
+    @config['table_rows_splitter'] = 'spaces'
     actual = compile_block(src)
     expected = <<-EOS
 ◆→開始:表←◆
@@ -500,7 +500,7 @@ a	b	c	d	|e
 EOS
     assert_equal expected, actual
 
-    @config['table_splitter'] = 'verticalbar'
+    @config['table_rows_splitter'] = 'verticalbar'
     actual = compile_block(src)
     expected = <<-EOS
 ◆→開始:表←◆


### PR DESCRIPTION
まだリリースしてないし、@takahashim さんアドバイスに基づいてパラメータ名を変更します。
