### PR TITLE
items of ChapterIndex should be Index::Item

### DIFF
--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -139,7 +139,6 @@ module ReVIEW
         chapter_items = chapters.map do |chap|
           Index::Item.new(chap.id, chap.number, chap)
         end
-        # TODO: contents += parts.find_all { |prt| prt.id.present? }
         part_items = parts.select{ |prt| prt.id.present? }.map{ |prt| Index::Item.new(prt.id, prt.number, prt) }
         @chapter_index = ChapterIndex.new(chapter_items + part_items)
       end

--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -136,19 +136,16 @@ module ReVIEW
 
       def chapter_index
         return @chapter_index if @chapter_index
-
-        contents = chapters
-        # TODO: contents += parts.find_all { |prt| prt.id.present? }
-        parts.each do |prt|
-          if prt.id.present?
-            contents << prt
-          end
+        chapter_items = chapters.map do |chap|
+          Index::Item.new(chap.id, chap.number, chap)
         end
-        @chapter_index = ChapterIndex.new(contents)
+        # TODO: contents += parts.find_all { |prt| prt.id.present? }
+        part_items = parts.select{ |prt| prt.id.present? }.map{ |prt| Index::Item.new(prt.id, prt.number, prt) }
+        @chapter_index = ChapterIndex.new(chapter_items + part_items)
       end
 
       def chapter(id)
-        chapter_index[id]
+        chapter_index[id].content
       end
 
       def next_chapter(chapter)

--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -88,8 +88,9 @@ module ReVIEW
       end
 
       def number(id)
-        chapter = @index.fetch(id)
+        chapter_item = @index.fetch(id)
         begin
+          chapter = chapter_item.content
           chapter.format_number
         rescue # part
           I18n.t('part', chapter.number)
@@ -97,9 +98,9 @@ module ReVIEW
       end
 
       def title(id)
-        @index.fetch(id).title
+        @index.fetch(id).content.title
       rescue # non-file part
-        @index.fetch(id).name
+        @index.fetch(id).content.name
       end
 
       def display_string(id)


### PR DESCRIPTION
現状のChapterIndexの中身はItemではなくChapterオブジェクトだったため、他のIndexと挙動を揃えるとエラーが発生してしまうのを修正するものです。