### PR TITLE
PDFMaker: introduce pdfmaker/use_original_image_size parameter to disable an automatic image scaling

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -381,6 +381,9 @@ pdfmaker:
   # 画像のscale=X.Xという指定を画像拡大縮小率からページ最大幅の相対倍率に変換する
   # image_scale2width: true
   #
+  # 画像のデフォルトのサイズを、版面横幅合わせではなく、原寸をそのまま利用する
+  # use_original_image_size: null
+  #
   # PDFやIllustratorファイル(.ai)の画像のBoudingBoxの抽出に指定のボックスを採用する
   # cropbox(デフォルト), mediabox, artbox, trimbox, bleedboxから選択する。
   # Illustrator CC以降のIllustratorファイルに対してはmediaboxを指定する必要がある

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2019 Minero Aoki, Kenshi Muto
+# Copyright (c) 2009-2020 Minero Aoki, Kenshi Muto
 # Copyright (c) 2002-2007 Minero Aoki
 #
 # This program is free software.
@@ -115,7 +115,7 @@ module ReVIEW
     defblock :emlist, 0..2
     defblock :cmd, 0..1
     defblock :table, 0..2
-    defblock :imgtable, 0..2
+    defblock :imgtable, 0..3
     defblock :emtable, 0..1
     defblock :quote, 0
     defblock :image, 2..3, true

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2019 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
+# Copyright (c) 2012-2020 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -92,7 +92,8 @@ module ReVIEW
           'makeindex_dic' => nil,
           'makeindex_mecab' => true,
           'makeindex_mecab_opts' => '-Oyomi',
-          'use_cover_nombre' => true
+          'use_cover_nombre' => true,
+          'use_original_image_size' => nil
         },
         'imgmath_options' => {
           'format' => 'png',

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -1,6 +1,6 @@
 # Copyright (c) 2002-2007 Minero Aoki
 #               2008-2009 Minero Aoki, Kenshi Muto
-#               2010-2019 Minero Aoki, Kenshi Muto, TAKAHASHI Masayoshi
+#               2010-2020 Minero Aoki, Kenshi Muto, TAKAHASHI Masayoshi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -480,6 +480,14 @@ module ReVIEW
     end
 
     def image_header(id, caption)
+    end
+
+    def parse_metric(type, metric)
+      s = super(type, metric)
+      if @book.config['pdfmaker']['use_original_image_size'] && s.empty? && metric.nil?
+        return ' ' # pass empty to \reviewincludegraphics
+      end
+      s
     end
 
     def handle_metric(str)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -484,7 +484,7 @@ module ReVIEW
 
     def parse_metric(type, metric)
       s = super(type, metric)
-      if @book.config['pdfmaker']['use_original_image_size'] && s.empty? && metric.nil?
+      if @book.config['pdfmaker']['use_original_image_size'] && s.empty? && !metric.present?
         return ' ' # pass empty to \reviewincludegraphics
       end
       s

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -870,6 +870,9 @@ EOS
 \\end{reviewimage}
 EOS
     assert_equal expected, actual
+
+    actual = compile_block("//image[sampleimg][sample photo][]{\n//}\n")
+    assert_equal expected, actual
   end
 
   def test_image_with_metric
@@ -986,6 +989,9 @@ EOS
 \\reviewindepimagecaption{図: sample photo}
 \\end{reviewimage}
 EOS
+    assert_equal expected, actual
+
+    actual = compile_block("//indepimage[sampleimg][sample photo][]\n")
     assert_equal expected, actual
   end
 
@@ -1260,6 +1266,9 @@ EOS
 \\end{reviewimage}
 \\end{table}
 EOS
+    assert_equal expected, actual
+
+    actual = compile_block("//imgtable[sampleimg][test for imgtable][]{\n//}\n")
     assert_equal expected, actual
   end
 

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -14,7 +14,7 @@ class LATEXBuidlerTest < Test::Unit::TestCase
       'secnolevel' => 2, # for IDGXMLBuilder, EPUBBuilder
       'toclevel' => 2,
       'stylesheet' => nil, # for EPUBBuilder
-      'image_scale2width' => false,
+      'image_scale2width' => nil,
       'texcommand' => 'uplatex',
       'review_version' => '3'
     )
@@ -859,6 +859,17 @@ EOS
 \\end{reviewimage}
 EOS
     assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[ ]{./images/chap1-sampleimg.png}
+\\reviewimagecaption{sample photo}
+\\label{image:chap1:sampleimg}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_metric
@@ -876,6 +887,10 @@ EOS
 \\label{image:chap1:sampleimg}
 \\end{reviewimage}
 EOS
+    assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
     assert_equal expected, actual
   end
 
@@ -896,6 +911,10 @@ EOS
 \\end{reviewimage}
 EOS
     assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
+    assert_equal expected, actual
   end
 
   def test_image_with_metric2
@@ -913,6 +932,10 @@ EOS
 \\label{image:chap1:sampleimg}
 \\end{reviewimage}
 EOS
+    assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
     assert_equal expected, actual
   end
 
@@ -933,6 +956,10 @@ EOS
 \\end{reviewimage}
 EOS
     assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
+    assert_equal expected, actual
   end
 
   def test_indepimage
@@ -946,6 +973,16 @@ EOS
     expected = <<-EOS
 \\begin{reviewimage}%%sampleimg
 \\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\reviewindepimagecaption{図: sample photo}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//indepimage[sampleimg][sample photo]\n")
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[ ]{./images/chap1-sampleimg.png}
 \\reviewindepimagecaption{図: sample photo}
 \\end{reviewimage}
 EOS
@@ -984,6 +1021,10 @@ EOS
 \\end{reviewimage}
 EOS
     assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric_width
@@ -1002,6 +1043,10 @@ EOS
 \\end{reviewimage}
 EOS
     assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric2
@@ -1019,6 +1064,10 @@ EOS
 \\end{reviewimage}
 EOS
     assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block(%Q(//indepimage[sampleimg][sample photo][scale=1.2, html::class="sample",latex::ignore=params]\n))
+    assert_equal expected, actual
   end
 
   def test_indepimage_without_caption_but_with_metric
@@ -1035,6 +1084,10 @@ EOS
 \\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}
 \\end{reviewimage}
 EOS
+    assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//indepimage[sampleimg][][scale=1.2]\n")
     assert_equal expected, actual
   end
 
@@ -1193,6 +1246,44 @@ EOS
 \\end{reviewimage}
 \\end{table}
 EOS
+    assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//imgtable[sampleimg][test for imgtable]{\n//}\n")
+
+    expected = <<-EOS
+\\begin{table}[h]%%sampleimg
+\\reviewimgtablecaption{test for imgtable}
+\\label{table:chap1:sampleimg}
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[ ]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+\\end{table}
+EOS
+    assert_equal expected, actual
+  end
+
+  def test_imgtable_with_metrics
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('sampleimg', 1, 'sample img')
+      item.instance_eval { @path = './images/chap1-sampleimg.png' }
+      item
+    end
+
+    actual = compile_block("//imgtable[sampleimg][test for imgtable][scale=1.2]{\n//}\n")
+    expected = <<-EOS
+\\begin{table}[h]%%sampleimg
+\\reviewimgtablecaption{test for imgtable}
+\\label{table:chap1:sampleimg}
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[scale=1.2]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+\\end{table}
+EOS
+    assert_equal expected, actual
+
+    @book.config['pdfmaker']['use_original_image_size'] = true
+    actual = compile_block("//imgtable[sampleimg][test for imgtable][scale=1.2]{\n//}\n")
     assert_equal expected, actual
   end
 


### PR DESCRIPTION
#1461 の対応

`pdfmaker/use_original_image_size` がtrueのとき、かつmetricsに何も指定がないときに、reviewincludegraphicsには空白文字1つが渡るようになる。デフォルトはnil。

(完全に空だとimageメソッド内などで`present?`判定でfalseになってしまうので、TeX側には意味はないがRubyロジック側には意味がある文字として空白文字を採用した。ロジック側を直すのは副作用がいろいろありそうなので…)
