### PR TITLE
move image_scale2width parameter to under pdfmaker section

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -75,7 +75,6 @@ module ReVIEW
         'structuredxml' => nil,
         'pt_to_mm_unit' => 0.3528, # DTP: 1pt = 0.3528mm, JIS: 1pt = 0.3514mm
         # for LaTeX
-        'image_scale2width' => true,
         'footnotetext' => nil,
         'texcommand' => 'uplatex',
         'texoptions' => '-interaction=nonstopmode -file-line-error -halt-on-error',
@@ -85,6 +84,7 @@ module ReVIEW
         'dvioptions' => '-d 5 -z 9',
         # for PDFMaker
         'pdfmaker' => {
+          'image_scale2width' => true,
           'makeindex' => nil, # Make index page
           'makeindex_command' => 'mendex', # works only when makeindex is true
           'makeindex_options' => '-f -r -I utf8',

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -491,7 +491,7 @@ module ReVIEW
     end
 
     def handle_metric(str)
-      if @book.config['image_scale2width'] && str =~ /\Ascale=([\d.]+)\Z/
+      if @book.config['pdfmaker']['image_scale2width'] && str =~ /\Ascale=([\d.]+)\Z/
         return "width=#{$1}\\maxwidth"
       end
       str

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2020 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -150,6 +150,12 @@ module ReVIEW
         else
           @config['texdocumentclass'] = @config['_texdocumentclass']
         end
+      end
+
+      # version 4.0 compatibility
+      if @config['image_scale2width']
+        warn 'image_scale2width parameter is moved to under pdfmaker section'
+        @config['pdfmaker']['image_scale2width'] = @config['image_scale2width']
       end
 
       begin

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -14,10 +14,10 @@ class LATEXBuidlerTest < Test::Unit::TestCase
       'secnolevel' => 2, # for IDGXMLBuilder, EPUBBuilder
       'toclevel' => 2,
       'stylesheet' => nil, # for EPUBBuilder
-      'image_scale2width' => nil,
       'texcommand' => 'uplatex',
-      'review_version' => '3'
+      'review_version' => '4'
     )
+    @config['pdfmaker']['image_scale2width'] = nil
     @book = Book::Base.new
     @book.config = @config
     @compiler = ReVIEW::Compiler.new(@builder)
@@ -904,7 +904,7 @@ EOS
       item
     end
 
-    @config['image_scale2width'] = true
+    @config['pdfmaker']['image_scale2width'] = true
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
     expected = <<-EOS
 \\begin{reviewimage}%%sampleimg
@@ -949,7 +949,7 @@ EOS
       item
     end
 
-    @config['image_scale2width'] = true
+    @config['pdfmaker']['image_scale2width'] = true
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
     expected = <<-EOS
 \\begin{reviewimage}%%sampleimg
@@ -1040,7 +1040,7 @@ EOS
       item
     end
 
-    @config['image_scale2width'] = true
+    @config['pdfmaker']['image_scale2width'] = true
     actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
     expected = <<-EOS
 \\begin{reviewimage}%%sampleimg

--- a/test/test_latexbuilder_v2.rb
+++ b/test/test_latexbuilder_v2.rb
@@ -14,10 +14,10 @@ class LATEXBuidlerV2Test < Test::Unit::TestCase
       'secnolevel' => 2, # for IDGXMLBuilder, EPUBBuilder
       'toclevel' => 2,
       'stylesheet' => nil, # for EPUBBuilder
-      'image_scale2width' => false,
       'texcommand' => 'uplatex',
       'review_version' => '2.0'
     )
+    @config['pdfmaker']['image_scale2width'] = nil
     @book = Book::Base.new
     @book.config = @config
     @compiler = ReVIEW::Compiler.new(@builder)
@@ -762,7 +762,7 @@ EOS
       item
     end
 
-    @config['image_scale2width'] = true
+    @config['pdfmaker']['image_scale2width'] = true
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2]{\n//}\n")
     expected = <<-EOS
 \\begin{reviewimage}%%sampleimg
@@ -799,7 +799,7 @@ EOS
       item
     end
 
-    @config['image_scale2width'] = true
+    @config['pdfmaker']['image_scale2width'] = true
     actual = compile_block("//image[sampleimg][sample photo][scale=1.2,html::class=sample,latex::ignore=params]{\n//}\n")
     expected = <<-EOS
 \\begin{reviewimage}%%sampleimg
@@ -869,7 +869,7 @@ EOS
       item
     end
 
-    @config['image_scale2width'] = true
+    @config['pdfmaker']['image_scale2width'] = true
     actual = compile_block("//indepimage[sampleimg][sample photo][scale=1.2]\n")
     expected = <<-EOS
 \\begin{reviewimage}%%sampleimg


### PR DESCRIPTION
#1462 の対応

古い直下image_scale2width パラメータがあればWARNを出しつつそれを採用するようにしています。