### PR TITLE
PDFMaker: strip some inline markups in PDF bookmark

### DIFF
--- a/samples/syntax-book/ch02.re
+++ b/samples/syntax-book/ch02.re
@@ -316,7 +316,7 @@ a_{m1} & \cdots & a_{mn}
 網カケ@<ami>{amiアミ}    @<balloon>{ふきだし説明}
 //}
 
-=== 見出し内 @<b>{BOLD},@<i>{ITALIC},@<tt>{TT},@<strong>{STRONG},@<em>{EM},@<code>{CODE},@<ttb>{TTB},@<tti>{TTI},@<u>{UNDERLINE},@<ami>{AMI},@<bou>{BOU},@<kw}{KW},@<bou>{BOU}
+=== 見出し内 @<b>{BOLD},@<i>{ITALIC},@<tt>{TT},@<strong>{STRONG},@<em>{EM},@<code>{CODE},@<ttb>{TTB},@<tti>{TTI},@<ami>{AMI},@<bou>{BOU},@<kw>{KW},@<u>{UNDERLINE}
 
 ==={crossref} 参照
 #@# FIXME:任意ラベルを使うと、EPUBチェックエラーになることがある？

--- a/samples/syntax-book/ch02.re
+++ b/samples/syntax-book/ch02.re
@@ -316,8 +316,7 @@ a_{m1} & \cdots & a_{mn}
 網カケ@<ami>{amiアミ}    @<balloon>{ふきだし説明}
 //}
 
-=== 見出し内 @<b>{BOLD},@<i>{ITALIC},@<tt>{TT},@<strong>{STRONG},@<em>{EM},@<code>{CODE},@<ttb>{TTB},@<tti>{TTI}
-#@# @<u>はmedia=ebookにおいてはダメ
+=== 見出し内 @<b>{BOLD},@<i>{ITALIC},@<tt>{TT},@<strong>{STRONG},@<em>{EM},@<code>{CODE},@<ttb>{TTB},@<tti>{TTI},@<u>{UNDERLINE},@<ami>{AMI},@<bou>{BOU},@<kw}{KW},@<bou>{BOU}
 
 ==={crossref} 参照
 #@# FIXME:任意ラベルを使うと、EPUBチェックエラーになることがある？

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2019/12/16]
+\ProvidesClass{review-base}[2020/01/02]
 % jlreq用基本設定
 \def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
   \hypersetup{
@@ -178,8 +178,14 @@
 
 % allow break line in tt
 % contributed by @zr_tex8r
-\g@addto@macro\pdfstringdefPreHook{%
-  \def\reviewbreakall#1{#1}}
+\g@addto@macro\pdfstringdefPreHook{% for PDF bookmarks
+  \def\reviewami#1{#1}
+  \def\reviewbreakall#1{#1}
+  \def\reviewballoon#1{#1}
+  \def\reviewbou#1{#1}
+  \def\reviewstrike#1{#1}
+  \def\reviewunderline#1{#1}
+}
 \newif\ifreview@ba@break
 \def\review@ba@end{\review@ba@end@}
 \DeclareRobustCommand{\reviewbreakall}[1]{%

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -183,6 +183,7 @@
   \def\reviewbreakall#1{#1}
   \def\reviewballoon#1{#1}
   \def\reviewbou#1{#1}
+  \def\reviewkw#1{#1}
   \def\reviewstrike#1{#1}
   \def\reviewunderline#1{#1}
 }

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -273,6 +273,7 @@
   \def\reviewbreakall#1{#1}
   \def\reviewballoon#1{#1}
   \def\reviewbou#1{#1}
+  \def\reviewkw#1{#1}
   \def\reviewstrike#1{#1}
   \def\reviewunderline#1{#1}
 }

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2019/12/16]
+\ProvidesClass{review-base}[2020/01/02]
 \RequirePackage{ifthen}
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}
@@ -268,8 +268,14 @@
 
 % allow break line in tt
 % contributed by @zr_tex8r
-\g@addto@macro\pdfstringdefPreHook{%
-  \def\reviewbreakall#1{#1}}
+\g@addto@macro\pdfstringdefPreHook{% for PDF bookmarks
+  \def\reviewami#1{#1}
+  \def\reviewbreakall#1{#1}
+  \def\reviewballoon#1{#1}
+  \def\reviewbou#1{#1}
+  \def\reviewstrike#1{#1}
+  \def\reviewunderline#1{#1}
+}
 \newif\ifreview@ba@break
 \def\review@ba@end{\review@ba@end@}
 \DeclareRobustCommand{\reviewbreakall}[1]{%


### PR DESCRIPTION
#1432 のヒントをもとに、さらに見出しで使われるとPDFしおりが変になるかビルド失敗するインラインマークアップについて、引数ママの文字になるようにしました。

reviewami, reviewballoon, reviewbou, reviewstrike, reviewunderline。
