### PR TITLE
PDFMaker: check idx isn't empty before calling makeindex

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -241,7 +241,7 @@ module ReVIEW
         end
 
         call_hook('hook_beforemakeindex')
-        if @config['pdfmaker']['makeindex'] && File.exist?("#{@mastertex}.idx")
+        if @config['pdfmaker']['makeindex'] && File.exist?("#{@mastertex}.idx") && !File.zero?("#{@mastertex}.idx")
           system_or_raise(*[makeindex_command, makeindex_options, @mastertex].flatten.compact)
           system_or_raise(*[texcommand, texoptions, "#{@mastertex}.tex"].flatten.compact)
         end

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -241,7 +241,7 @@ module ReVIEW
         end
 
         call_hook('hook_beforemakeindex')
-        if @config['pdfmaker']['makeindex'] && File.exist?("#{@mastertex}.idx") && !File.zero?("#{@mastertex}.idx")
+        if @config['pdfmaker']['makeindex'] && File.size?("#{@mastertex}.idx")
           system_or_raise(*[makeindex_command, makeindex_options, @mastertex].flatten.compact)
           system_or_raise(*[texcommand, texoptions, "#{@mastertex}.tex"].flatten.compact)
         end


### PR DESCRIPTION
索引作成を有効にした設定で実際に索引タームの登録がないと、makeindexに失敗してエラー終了してしまいます。
存在(`exist?`)チェックで見ていましたが、実際には0バイトファイルができてしまってやはり失敗していたので、`size?`で見るように変更します。
