### PR TITLE
章を選択してビルド実行できるようにする

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -397,6 +397,7 @@ module ReVIEW
       end
 
       if @buildonly && !@buildonly.include?(id)
+        warn "skip #{id}.re"
         return
       end
 

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2019 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2020 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -73,6 +73,7 @@ module ReVIEW
     def parse_opts(args)
       cmd_config = {}
       opts = OptionParser.new
+      @buildonly = nil
 
       opts.banner = 'Usage: review-epubmaker [options] configfile [export_filename]'
       opts.version = ReVIEW::VERSION
@@ -81,6 +82,7 @@ module ReVIEW
         exit 0
       end
       opts.on('--[no-]debug', 'Keep temporary files.') { |debug| cmd_config['debug'] = debug }
+      opts.on('-y', '--only file1,file2,...', 'Build only specified files.') { |v| @buildonly = v.split(/\s*,\s*/).map { |m| m.strip.sub(/\.re\Z/, '') } }
 
       opts.parse!(args)
       if args.size < 1 || args.size > 2
@@ -392,6 +394,10 @@ module ReVIEW
           @bodycount += 1
           id = sprintf('chap%02d', @bodycount)
         end
+      end
+
+      if @buildonly && !@buildonly.include?(id)
+        return
       end
 
       htmlfile = "#{id}.#{@config['htmlext']}"

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -175,6 +175,7 @@ module ReVIEW
           @config['use_part'] = true
           if part.file?
             if @buildonly && !@buildonly.include?(part.name)
+              warn "skip #{part.name}.re"
               input_files['CHAPS'] << %Q(\\part{}\n)
             else
               output_chaps(part.name)
@@ -189,6 +190,7 @@ module ReVIEW
           filename = File.basename(chap.path, '.*')
           entry = "\\input{#{filename}.tex}\n"
           if @buildonly && !@buildonly.include?(filename)
+            warn "skip #{filename}.re"
             entry = "\\chapter{}\n"
           else
             output_chaps(filename)

--- a/lib/review/textmaker.rb
+++ b/lib/review/textmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019 Kenshi Muto
+# Copyright (c) 2018-2020 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -45,10 +45,12 @@ module ReVIEW
     def parse_opts(args)
       cmd_config = {}
       opts = OptionParser.new
+      @buildonly = nil
 
       opts.banner = 'Usage: review-textmaker [-n] configfile'
       opts.version = ReVIEW::VERSION
       opts.on('-n', 'No decoration.') { @plaintext = true }
+      opts.on('-y', '--only file1,file2,...', 'Build only specified files.') { |v| @buildonly = v.split(/\s*,\s*/).map { |m| m.strip.sub(/\.re\Z/, '') } }
       opts.on('--help', 'Prints this message and quit.') do
         puts opts.help
         exit 0
@@ -154,6 +156,10 @@ module ReVIEW
         filename = Pathname.new(chap.path).relative_path_from(base_path).to_s
       end
       id = File.basename(filename).sub(/\.re\Z/, '')
+      if @buildonly && !@buildonly.include?(id)
+        warn "skip #{id}.re"
+        return
+      end
 
       textfile = "#{id}.txt"
 

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2018 Masayoshi Takahashi, Masanori Kado, Kenshi Muto
+# Copyright (c) 2016-2020 Masayoshi Takahashi, Masanori Kado, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -50,6 +50,7 @@ module ReVIEW
     def parse_opts(args)
       cmd_config = {}
       opts = OptionParser.new
+      @buildonly = nil
 
       opts.banner = 'Usage: review-webmaker [option] configfile'
       opts.version = ReVIEW::VERSION
@@ -58,6 +59,7 @@ module ReVIEW
         exit 0
       end
       opts.on('--ignore-errors', 'Ignore review-compile errors.') { cmd_config['ignore-errors'] = true }
+      opts.on('-y', '--only file1,file2,...', 'Build only specified files.') { |v| @buildonly = v.split(/\s*,\s*/).map { |m| m.strip.sub(/\.re\Z/, '') } }
 
       opts.parse!(args)
       if args.size != 1
@@ -185,6 +187,11 @@ module ReVIEW
         filename = Pathname.new(chap.path).relative_path_from(base_path).to_s
       end
       id = File.basename(filename).sub(/\.re\Z/, '')
+
+      if @buildonly && !@buildonly.include?(id)
+        warn "skip #{id}.re"
+        return
+      end
 
       htmlfile = "#{id}.#{@config['htmlext']}"
 

--- a/samples/sample-book/src/lib/tasks/review.rake
+++ b/samples/sample-book/src/lib/tasks/review.rake
@@ -34,6 +34,7 @@ PDF_OPTIONS = ENV['REVIEW_PDF_OPTIONS'] || ''
 EPUB_OPTIONS = ENV['REVIEW_EPUB_OPTIONS'] || ''
 WEB_OPTIONS = ENV['REVIEW_WEB_OPTIONS'] || ''
 IDGXML_OPTIONS = ENV['REVIEW_IDGXML_OPTIONS'] || ''
+TEXT_OPTIONS = ENV['REVIEW_TEXT_OPTIONS'] || ''
 
 def build(mode, chapter)
   sh("review-compile --target=#{mode} --footnotetext --stylesheet=style.css #{chapter} > tmp")
@@ -79,12 +80,12 @@ task web: WEBROOT
 
 desc 'generate text file (without decoration)'
 task plaintext: TEXTROOT do
-  sh "review-textmaker -n #{CONFIG_FILE}"
+  sh "review-textmaker #{TEXT_OPTIONS} -n #{CONFIG_FILE}"
 end
 
 desc 'generate (decorated) text file'
 task text: TOPROOT do
-  sh "review-textmaker #{CONFIG_FILE}"
+  sh "review-textmaker #{TEXT_OPTIONS} #{CONFIG_FILE}"
 end
 
 desc 'generate IDGXML file'

--- a/samples/sample-book/src/lib/tasks/review.rake
+++ b/samples/sample-book/src/lib/tasks/review.rake
@@ -1,4 +1,4 @@
-# Copyright (c) 2006-2019 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
+# Copyright (c) 2006-2020 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,9 @@ WEBROOT = ENV['REVIEW_WEBROOT'] || 'webroot'
 TEXTROOT = BOOK + '-text'
 TOPROOT = BOOK + '-text'
 IDGXMLROOT = BOOK + '-idgxml'
+PDF_OPTIONS = ENV['REVIEW_PDF_OPTIONS'] || ''
+EPUB_OPTIONS = ENV['REVIEW_EPUB_OPTIONS'] || ''
+WEB_OPTIONS = ENV['REVIEW_WEB_OPTIONS'] || ''
 IDGXML_OPTIONS = ENV['REVIEW_IDGXML_OPTIONS'] || ''
 
 def build(mode, chapter)
@@ -100,17 +103,17 @@ SRC_PDF = FileList['layouts/*.erb', 'sty/**/*.sty']
 
 file BOOK_PDF => SRC + SRC_PDF do
   FileUtils.rm_rf([BOOK_PDF, BOOK, BOOK + '-pdf'])
-  sh "review-pdfmaker #{CONFIG_FILE}"
+  sh "review-pdfmaker #{PDF_OPTIONS} #{CONFIG_FILE}"
 end
 
 file BOOK_EPUB => SRC + SRC_EPUB do
   FileUtils.rm_rf([BOOK_EPUB, BOOK, BOOK + '-epub'])
-  sh "review-epubmaker #{CONFIG_FILE}"
+  sh "review-epubmaker #{EPUB_OPTIONS} #{CONFIG_FILE}"
 end
 
 file WEBROOT => SRC do
   FileUtils.rm_rf([WEBROOT])
-  sh "review-webmaker #{CONFIG_FILE}"
+  sh "review-webmaker #{WEB_OPTIONS} #{CONFIG_FILE}"
 end
 
 file TEXTROOT => SRC do

--- a/samples/syntax-book/lib/tasks/review.rake
+++ b/samples/syntax-book/lib/tasks/review.rake
@@ -34,6 +34,7 @@ PDF_OPTIONS = ENV['REVIEW_PDF_OPTIONS'] || ''
 EPUB_OPTIONS = ENV['REVIEW_EPUB_OPTIONS'] || ''
 WEB_OPTIONS = ENV['REVIEW_WEB_OPTIONS'] || ''
 IDGXML_OPTIONS = ENV['REVIEW_IDGXML_OPTIONS'] || ''
+TEXT_OPTIONS = ENV['REVIEW_TEXT_OPTIONS'] || ''
 
 def build(mode, chapter)
   sh("review-compile --target=#{mode} --footnotetext --stylesheet=style.css #{chapter} > tmp")
@@ -79,12 +80,12 @@ task web: WEBROOT
 
 desc 'generate text file (without decoration)'
 task plaintext: TEXTROOT do
-  sh "review-textmaker -n #{CONFIG_FILE}"
+  sh "review-textmaker #{TEXT_OPTIONS} -n #{CONFIG_FILE}"
 end
 
 desc 'generate (decorated) text file'
 task text: TOPROOT do
-  sh "review-textmaker #{CONFIG_FILE}"
+  sh "review-textmaker #{TEXT_OPTIONS} #{CONFIG_FILE}"
 end
 
 desc 'generate IDGXML file'

--- a/samples/syntax-book/lib/tasks/review.rake
+++ b/samples/syntax-book/lib/tasks/review.rake
@@ -1,4 +1,4 @@
-# Copyright (c) 2006-2019 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
+# Copyright (c) 2006-2020 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -30,6 +30,9 @@ WEBROOT = ENV['REVIEW_WEBROOT'] || 'webroot'
 TEXTROOT = BOOK + '-text'
 TOPROOT = BOOK + '-text'
 IDGXMLROOT = BOOK + '-idgxml'
+PDF_OPTIONS = ENV['REVIEW_PDF_OPTIONS'] || ''
+EPUB_OPTIONS = ENV['REVIEW_EPUB_OPTIONS'] || ''
+WEB_OPTIONS = ENV['REVIEW_WEB_OPTIONS'] || ''
 IDGXML_OPTIONS = ENV['REVIEW_IDGXML_OPTIONS'] || ''
 
 def build(mode, chapter)
@@ -100,17 +103,17 @@ SRC_PDF = FileList['layouts/*.erb', 'sty/**/*.sty']
 
 file BOOK_PDF => SRC + SRC_PDF do
   FileUtils.rm_rf([BOOK_PDF, BOOK, BOOK + '-pdf'])
-  sh "review-pdfmaker #{CONFIG_FILE}"
+  sh "review-pdfmaker #{PDF_OPTIONS} #{CONFIG_FILE}"
 end
 
 file BOOK_EPUB => SRC + SRC_EPUB do
   FileUtils.rm_rf([BOOK_EPUB, BOOK, BOOK + '-epub'])
-  sh "review-epubmaker #{CONFIG_FILE}"
+  sh "review-epubmaker #{EPUB_OPTIONS} #{CONFIG_FILE}"
 end
 
 file WEBROOT => SRC do
   FileUtils.rm_rf([WEBROOT])
-  sh "review-webmaker #{CONFIG_FILE}"
+  sh "review-webmaker #{WEB_OPTIONS} #{CONFIG_FILE}"
 end
 
 file TEXTROOT => SRC do

--- a/test/test_pdfmaker_cmd.rb
+++ b/test/test_pdfmaker_cmd.rb
@@ -20,7 +20,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
     ENV['RUBYLIB'] = @old_rubylib
   end
 
-  def common_buildpdf(bookdir, templatedir, configfile, targetpdffile)
+  def common_buildpdf(bookdir, templatedir, configfile, targetpdffile, option = nil)
     if /mswin|mingw|cygwin/ !~ RUBY_PLATFORM
       config = prepare_samplebook(@tmpdir1, bookdir, templatedir, configfile)
       builddir = File.join(@tmpdir1, config['bookname'] + '-pdf')
@@ -28,7 +28,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
 
       ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name'])
       Dir.chdir(@tmpdir1) do
-        _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_PDFMAKER} #{configfile}")
+        _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_PDFMAKER} #{option} #{configfile}")
         if !e.empty? && !s.success?
           STDERR.puts e
         end
@@ -86,6 +86,16 @@ class PDFMakerCmdTest < Test::Unit::TestCase
       return true
     end
     common_buildpdf('syntax-book', 'review-jsbook', 'config-print.yml', 'syntax-book.pdf')
+  end
+
+  def test_pdfmaker_cmd_syntax_jsbook_print_buildonly
+    begin
+      `uplatex -v`
+    rescue
+      $stderr.puts 'skip test_pdfmaker_cmd_syntax_jsbook_print_buildonly'
+      return true
+    end
+    common_buildpdf('syntax-book', 'review-jsbook', 'config-print.yml', 'syntax-book.pdf', '-y ch01')
   end
 
   def test_pdfmaker_cmd_syntax_jsbook_ebook


### PR DESCRIPTION
idgxmlmakerでは`-y ch1,ch3,..` のようにして実際に生成するXMLファイルを選択できるようになっていますが、ある特定の章だけをビルドしたいという需要はそれなりにあるので、同様にEPUBMaker、WEBMaker、PDFMaker、TEXTMakerにも-yオプションを導入します。

-y(または--only)オプションは,区切りで、〜.reまたは〜 の箇所を指定し、指定ファイルだけをビルドします。大扉や目次、奥付などのreによらない自動生成物はそのまま生成されます。

rakeを使うときには`REVIEW_PDF_OPTIONS`, `REVIEW_EPUB_OPTIONS`, `REVIEW_WEB_OPTIONS`、 `REVIEW_TEXT_OPTIONS` という環境変数からコマンドラインオプションを取るようにして、
```
REVIEW_PDF_OPTIONS="-y ch01" rake pdf
```
のような呼び出しができます。