### PR TITLE
use eregon/use-ruby-action instead of actions/setup-ruby

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -9,12 +9,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '2.6.x', '2.5.x', '2.4.x' ]
+        ruby: [2.4, 2.5, 2.6, 2.7]
         os: [ubuntu-latest, macOS-latest]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Ruby
-      uses: actions/setup-ruby@v1
+      uses: eregon/use-ruby-action@master
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: fix ImageMagick policy.xml on Linux


### PR DESCRIPTION
#1444 の代わりに https://github.com/eregon/use-ruby-action を使って2.7に対応するものです。