### PR TITLE
revert image_scale2width warning, part of #1464

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -154,12 +154,6 @@ module ReVIEW
         end
       end
 
-      # version 4.0 compatibility
-      if @config['image_scale2width']
-        warn 'image_scale2width parameter is moved to under pdfmaker section'
-        @config['pdfmaker']['image_scale2width'] = @config['image_scale2width']
-      end
-
       begin
         generate_pdf
       rescue ApplicationError => e


### PR DESCRIPTION
#1464 で`image_scale2width`が直下にあるかどうかを調べていたつもりだけれど、@configは単なるHashじゃなくてConfigureクラスオブジェクトで、聞かれたら直下にあるかのように答えるよう細工しているので意味がなかった。
