### PR TITLE
support footnote in description title

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -422,12 +422,10 @@ module ReVIEW
     def compile_dlist(f)
       @strategy.dl_begin
       while /\A\s*:/ =~ f.peek
-        if @strategy.class.to_s == 'ReVIEW::LATEXBuilder'
-          # defer compile_inline to handle footnotes
-          @strategy.dt(f.gets.sub(/\A\s*:/, '').strip)
-        else
-          @strategy.dt(text(f.gets.sub(/\A\s*:/, '').strip))
-        end
+        # defer compile_inline to handle footnotes
+        @strategy.doc_status[:dt] = true
+        @strategy.dt(text(f.gets.sub(/\A\s*:/, '').strip))
+        @strategy.doc_status[:dt] = nil
         desc = f.break(/\A(\S|\s*:|\s+\d+\.\s|\s+\*\s)/).map { |line| text(line.strip) }
         @strategy.dd(desc)
         f.skip_blank_lines

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -422,7 +422,12 @@ module ReVIEW
     def compile_dlist(f)
       @strategy.dl_begin
       while /\A\s*:/ =~ f.peek
-        @strategy.dt(text(f.gets.sub(/\A\s*:/, '').strip))
+        if @strategy.class.to_s == 'ReVIEW::LATEXBuilder'
+          # defer compile_inline to handle footnotes
+          @strategy.dt(f.gets.sub(/\A\s*:/, '').strip)
+        else
+          @strategy.dt(text(f.gets.sub(/\A\s*:/, '').strip))
+        end
         desc = f.break(/\A(\S|\s*:|\s+\d+\.\s|\s+\*\s)/).map { |line| text(line.strip) }
         @strategy.dd(desc)
         f.skip_blank_lines

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -299,10 +299,8 @@ module ReVIEW
     end
 
     def dt(str)
-      @doc_status[:caption] = true
-      str = compile_inline(str).gsub('[', '\lbrack{}').gsub(']', '\rbrack{}')
+      str = str.gsub('[', '\lbrack{}').gsub(']', '\rbrack{}')
       puts '\item[' + str + '] \mbox{} \\\\'
-      @doc_status[:caption] = nil
     end
 
     def dd(lines)
@@ -1028,7 +1026,7 @@ module ReVIEW
     def inline_fn(id)
       if @book.config['footnotetext']
         macro("footnotemark[#{@chapter.footnote(id).number}]", '')
-      elsif @doc_status[:caption] || @doc_status[:table] || @doc_status[:column]
+      elsif @doc_status[:caption] || @doc_status[:table] || @doc_status[:column] || @doc_status[:dt]
         @foottext[id] = @chapter.footnote(id).number
         macro('protect\\footnotemark', '')
       else

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -299,9 +299,10 @@ module ReVIEW
     end
 
     def dt(str)
-      str.sub!(/\[/) { '\lbrack{}' }
-      str.sub!(/\]/) { '\rbrack{}' }
+      @doc_status[:caption] = true
+      str = compile_inline(str).gsub('[', '\lbrack{}').gsub(']', '\rbrack{}')
       puts '\item[' + str + '] \mbox{} \\\\'
+      @doc_status[:caption] = nil
     end
 
     def dd(lines)

--- a/samples/syntax-book/ch01.re
+++ b/samples/syntax-book/ch01.re
@@ -104,7 +104,7 @@ olnumで一応番号が変更可能なことを期待していますが、Webブ
 === 用語リスト
 用語リスト（HTMLの@<i>{dl}、TeXの@<i>{description}）は@<i>{スペース}+@<tt>{:}+@<i>{スペース}で見出しを、説明は行頭にタブかスペースを入れて表現します。
 
- : Alpha@<b>{bold太字}@<i>{italicイタ}@<tt>{等幅code}
+ : Alpha@<b>{bold太字}@<i>{italicイタ}@<tt>{等幅code}@<fn>{foot1}
 	@<i>{DEC}の作っていた@<b>{RISC CPU}。@<i>{italicイタ}@<tt>{等幅code}
 	浮動小数点数演算が速い。
  : POWER
@@ -114,10 +114,12 @@ olnumで一応番号が変更可能なことを期待していますが、Webブ
 	Sunが作っているRISC CPU。
 	CPU数を増やすのが得意。
 
+//footnote[foot1][箇条書き見出しへの脚注。]
+
 //emlist{
 @<b>{bold太字}@<i>{italicイタ}
 
- : Alpha@<embed>{@}<b>{bold太字}@<embed>{@}<i>{italicイタ}@<embed>{@}<tt>{等幅code}
+ : Alpha@<embed>{@}<b>{bold太字}@<embed>{@}<i>{italicイタ}@<embed>{@}<tt>{等幅code}@<fn>{foot1}
         @<embed>{@}<i>{DEC}の作っていた@<embed>{@}<b>{RISC CPU}。@<embed>{@}<i>{italicイタ}@<embed>{@}<tt>{等幅code}
         浮動小数点数演算が速い。
  : POWER

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -778,6 +778,20 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_dt_inline
+    fn = Book::FootnoteIndex.parse(['//footnote[bar][bar]'])
+    @chapter.instance_eval { @footnote_index = fn }
+    actual = compile_block(" : foo@<fn>{bar}[]<>&@<m>$\\alpha[]$\n")
+
+    expected = <<-EOS
+<dl>
+<dt>foo<a id="fnb-bar" href="#fn-bar" class="noteref" epub:type="noteref">*1</a>[]&lt;&gt;&amp;<span class="equation">\\alpha[]</span></dt>
+<dd></dd>
+</dl>
+EOS
+    assert_equal expected, actual
+  end
+
   def test_list
     def @chapter.list(_id)
       Book::Index::Item.new('samplelist', 1)

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -226,6 +226,17 @@ EOS
     assert_equal %Q(<dl><dt>foo</dt><dd>foo.</dd></dl><p>para</p><dl><dt>foo</dt><dd>foo.</dd></dl><ol><li aid:pstyle="ol-item" olnum="1" num="1">bar</li></ol><dl><dt>foo</dt><dd>foo.</dd></dl><ul><li aid:pstyle="ul-item">bar</li></ul>), actual
   end
 
+  def test_dt_inline
+    fn = Book::FootnoteIndex.parse(['//footnote[bar][bar]'])
+    @chapter.instance_eval { @footnote_index = fn }
+    actual = compile_block(" : foo@<fn>{bar}[]<>&@<m>$\\alpha[]$\n")
+
+    expected = <<-EOS.chomp
+<dl><dt>foo<footnote>bar</footnote>[]&lt;&gt;&amp;<replace idref="texinline-1"><pre>\\alpha[]</pre></replace></dt><dd></dd></dl>
+EOS
+    assert_equal expected, actual
+  end
+
   def test_paragraph
     actual = compile_block("foo\nbar\n")
     assert_equal '<p>foobar</p>', actual

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -388,6 +388,24 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_dt_footnote
+    fn = Book::FootnoteIndex.parse(['//footnote[bar][bar]'])
+    @chapter.instance_eval { @footnote_index = fn }
+    @builder.dt('foo@<fn>{bar}')
+    expected = <<-EOS
+\\item[foo\\protect\\footnotemark{}] \\mbox{} \\\\
+EOS
+    assert_equal expected, @builder.result
+  end
+
+  def test_dt_math
+    @builder.dt('foo[@<m>{[]}][]@<m>$\alpha$')
+    expected = <<-EOS
+\\item[foo\\lbrack{}$\\lbrack{}\\rbrack{}$\\rbrack{}\\lbrack{}\\rbrack{}$\\alpha$] \\mbox{} \\\\
+EOS
+    assert_equal expected, @builder.result
+  end
+
   def test_cmd
     actual = compile_block("//cmd{\nfoo\nbar\n\nbuz\n//}\n")
     expected = <<-EOS

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -388,22 +388,19 @@ EOS
     assert_equal expected, actual
   end
 
-  def test_dt_footnote
+  def test_dt_inline
     fn = Book::FootnoteIndex.parse(['//footnote[bar][bar]'])
     @chapter.instance_eval { @footnote_index = fn }
-    @builder.dt('foo@<fn>{bar}')
-    expected = <<-EOS
-\\item[foo\\protect\\footnotemark{}] \\mbox{} \\\\
-EOS
-    assert_equal expected, @builder.result
-  end
+    actual = compile_block(" : foo@<fn>{bar}[]<>&@<m>$\\alpha[]$\n")
 
-  def test_dt_math
-    @builder.dt('foo[@<m>{[]}][]@<m>$\alpha$')
     expected = <<-EOS
-\\item[foo\\lbrack{}$\\lbrack{}\\rbrack{}$\\rbrack{}\\lbrack{}\\rbrack{}$\\alpha$] \\mbox{} \\\\
+
+\\begin{description}
+\\item[foo\\protect\\footnotemark{}\\lbrack{}\\rbrack{}\\textless{}\\textgreater{}\\&$\\alpha\\lbrack{}\\rbrack{}$] \\mbox{} \\\\
+
+\\end{description}
 EOS
-    assert_equal expected, @builder.result
+    assert_equal expected, actual
   end
 
   def test_cmd

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -174,6 +174,19 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_dt_inline
+    fn = Book::FootnoteIndex.parse(['//footnote[bar][bar]'])
+    @chapter.instance_eval { @footnote_index = fn }
+    actual = compile_block(" : foo@<fn>{bar}[]<>&@<m>$\\alpha[]$\n")
+
+    expected = <<-EOS
+★foo【注1】[]<>&◆→TeX式ここから←◆\\alpha[]◆→TeX式ここまで←◆☆
+	
+
+EOS
+    assert_equal expected, actual
+  end
+
   def test_paragraph
     actual = compile_block("foo\nbar\n")
     assert_equal %Q(foobar\n), actual


### PR DESCRIPTION
#1476 の対処

`: foo@<fn>{bar}`をPDFMakerで入れると、`\item[foo\footnote{bar}]` に展開されてしまい、脚注内容が消えてしまう。

そのため、

- コンパイラでLATEXBuilderのときのみ、dtのtext囲みをしない(`compile_inline`を遅らせる)。コンパイラにビルダ固有判定が入るのは業腹だが、LATEXBuilder固有なのに全ビルダのdtに手を入れるというのも本末転倒という判断です。
- LATEXBuilderのdt内では、captionモードにしてから`compile_inline`を実施する。こうすることで、dt内のfootnoteはfootnotemarkになります。
- `[`と`]`のlbrackとrbrackへの置き換えがなぜかこれまではsubで1回しか実行していなかったので、gsubにして全部に適用するように。数式内で`[]`が使われた場合…を考えたんですが、箇条書き見出しでリテラルにそう表示する以外にはフツーはなさそうなので、かまわず同じように置換するようにしました。本当にまじめにやろうとするとパーサが必要そうです。