### PR TITLE
//childによる箇条書き子要素のサポート

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -159,6 +159,7 @@ module ReVIEW
     defsingle :include, 1
     defsingle :olnum, 1
     defsingle :firstlinenum, 1
+    defsingle :child, 1
 
     definline :chapref
     definline :chap

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2019 Minero Aoki, Kenshi Muto, Masayoshi Takahashi,
+# Copyright (c) 2008-2020 Minero Aoki, Kenshi Muto, Masayoshi Takahashi,
 #                         KADO Masanori
 #               2002-2007 Minero Aoki
 #
@@ -92,7 +92,7 @@ module ReVIEW
     def result
       # default XHTML header/footer
       @title = strip_html(compile_inline(@chapter.title))
-      @body = @output.string
+      @body = solve_nest(@output.string)
       @language = @book.config['language']
       @stylesheets = @book.config['stylesheet']
       @next = @chapter.next_chapter
@@ -105,6 +105,20 @@ module ReVIEW
       end
 
       ReVIEW::Template.load(layoutfile).result(binding)
+    end
+
+    def solve_nest(s)
+      check_nest
+      s.gsub("</dd>\n</dl>\n\x01→dl←\x01", '').
+        gsub("\x01→/dl←\x01", "</dd>\n</dl>←END\x01").
+        gsub("</li>\n</ul>\n\x01→ul←\x01", '').
+        gsub("\x01→/ul←\x01", "</li>\n</ul>←END\x01").
+        gsub("</li>\n</ol>\n\x01→ol←\x01", '').
+        gsub("\x01→/ol←\x01", "</li>\n</ol>←END\x01").
+        gsub("</dl>←END\x01\n<dl>", '').
+        gsub("</ul>←END\x01\n<ul>", '').
+        gsub("</ol>←END\x01\n<ol>", '').
+        gsub("←END\x01", '')
     end
 
     def xmlns_ops_prefix

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2019 Minero Aoki, Kenshi Muto
+# Copyright (c) 2008-2020 Minero Aoki, Kenshi Muto
 #               2002-2007 Minero Aoki
 #
 # This program is free software.
@@ -89,7 +89,21 @@ module ReVIEW
         s += '</sect>' if @section > 0
         s += '</chapter>' if @chapter.number > 0
       end
-      @output.string + s + "</#{@rootelement}>\n"
+      solve_nest(@output.string) + s + "</#{@rootelement}>\n"
+    end
+
+    def solve_nest(s)
+      check_nest
+      s.gsub("</dd></dl>\x01→dl←\x01", '').
+        gsub("\x01→/dl←\x01", "</dd></dl>←END\x01").
+        gsub("</li></ul>\x01→ul←\x01", '').
+        gsub("\x01→/ul←\x01", "</li></ul>←END\x01").
+        gsub("</li></ol>\x01→ol←\x01", '').
+        gsub("\x01→/ol←\x01", "</li></ol>←END\x01").
+        gsub("</dl>←END\x01<dl>", '').
+        gsub("</ul>←END\x01<ul>", '').
+        gsub("</ol>←END\x01<ol>", '').
+        gsub("←END\x01", '')
     end
 
     def headline(level, label, caption)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -100,7 +100,21 @@ module ReVIEW
       if @chapter.is_a?(ReVIEW::Book::Part) && !@book.config.check_version('2', exception: false)
         puts '\end{reviewpart}'
       end
-      @output.string
+      solve_nest(@output.string)
+    end
+
+    def solve_nest(s)
+      check_nest
+      s.gsub("\\end{description}\n\n\x01→dl←\x01\n", "\n").
+        gsub("\x01→/dl←\x01", "\\end{description}←END\x01").
+        gsub("\\end{itemize}\n\n\x01→ul←\x01\n", "\n").
+        gsub("\x01→/ul←\x01", "\\end{itemize}←END\x01").
+        gsub("\\end{enumerate}\n\n\x01→ol←\x01\n", "\n").
+        gsub("\x01→/ol←\x01", "\\end{enumerate}←END\x01").
+        gsub("\\end{description}←END\x01\n\n\\begin{description}", '').
+        gsub("\\end{itemize}←END\x01\n\n\\begin{itemize}", '').
+        gsub("\\end{enumerate}←END\x01\n\n\\begin{enumerate}", '').
+        gsub("←END\x01", '')
     end
 
     HEADLINE = {

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2019 Kenshi Muto
+# Copyright (c) 2018-2020 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -74,7 +74,26 @@ module ReVIEW
     private :blank
 
     def result
-      @output.string
+      solve_nest(@output.string)
+    end
+
+    def solve_nest(s)
+      check_nest
+      lines = []
+      clevel = []
+      s.split("\n", -1).each do |l| # -1 means don't omit last "\n"
+        if l =~ /\A\x01→(dl|ul|ol)←\x01/
+          clevel.push($1)
+          lines.push("\x01→END←\x01")
+        elsif l =~ %r{\A\x01→/(dl|ul|ol)←\x01}
+          clevel.pop
+          lines.push("\x01→END←\x01")
+        else
+          lines.push("\t" * clevel.size + l)
+        end
+      end
+
+      lines.join("\n").gsub(/\n*\x01→END←\x01\n*/, "\n")
     end
 
     def headline(level, _label, caption)

--- a/lib/review/rstbuilder.rb
+++ b/lib/review/rstbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2019 Minero Aoki, Kenshi Muto
+# Copyright (c) 2008-2020 Minero Aoki, Kenshi Muto
 #               2002-2006 Minero Aoki
 #
 # This program is free software.
@@ -86,7 +86,7 @@ module ReVIEW
     private :blank
 
     def result
-      @output.string
+      solve_nest(@output.string)
     end
 
     def headline(level, label, caption)

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -973,4 +973,186 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_nest_error_close1
+    src = <<-EOS
+//child[ul]
+EOS
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
+    assert_equal ':2: error: //child[ul] miss close tag', e.message
+  end
+
+  def test_nest_error_close2
+    src = <<-EOS
+//child[ul]
+//child[ol]
+//child[dl]
+EOS
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
+    assert_equal ':4: error: //child[dl],//child[ol],//child[ul] miss close tag', e.message
+  end
+
+  def test_nest_error_close3
+    src = <<-EOS
+//child[ul]
+//child[ol]
+//child[dl]
+//child[/ol]
+EOS
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
+    assert_equal ":4: error: /ol is shown but previous 'dl' is not closed yet", e.message
+  end
+
+  def test_nest_ul
+    src = <<-EOS
+ * UL1
+
+//child[ul]
+
+ 1. UL1-OL1
+ 2. UL1-OL2
+
+ * UL1-UL1
+ * UL1-UL2
+
+ : UL1-DL1
+	UL1-DD1
+ : UL1-DL2
+	UL1-DD2
+
+//child[/ul]
+
+ * UL2
+
+//child[ul]
+
+UL2-PARA
+
+//child[/ul]
+EOS
+
+    expected = <<-EOS.chomp
+<ul><li aid:pstyle="ul-item">UL1<ol><li aid:pstyle="ol-item" olnum="1" num="1">UL1-OL1</li><li aid:pstyle="ol-item" olnum="2" num="2">UL1-OL2</li></ol><ul><li aid:pstyle="ul-item">UL1-UL1</li><li aid:pstyle="ul-item">UL1-UL2</li></ul><dl><dt>UL1-DL1</dt><dd>UL1-DD1</dd><dt>UL1-DL2</dt><dd>UL1-DD2</dd></dl></li><li aid:pstyle="ul-item">UL2<p>UL2-PARA</p></li></ul>
+EOS
+
+    actual = compile_block(src)
+    assert_equal expected, actual
+  end
+
+  def test_nest_ol
+    src = <<-EOS
+ 1. OL1
+
+//child[ol]
+
+ 1. OL1-OL1
+ 2. OL1-OL2
+
+ * OL1-UL1
+ * OL1-UL2
+
+ : OL1-DL1
+	OL1-DD1
+ : OL1-DL2
+	OL1-DD2
+
+//child[/ol]
+
+ 2. OL2
+
+//child[ol]
+
+OL2-PARA
+
+//child[/ol]
+EOS
+
+    expected = <<-EOS.chomp
+<ol><li aid:pstyle="ol-item" olnum="1" num="1">OL1<ol><li aid:pstyle="ol-item" olnum="1" num="1">OL1-OL1</li><li aid:pstyle="ol-item" olnum="2" num="2">OL1-OL2</li></ol><ul><li aid:pstyle="ul-item">OL1-UL1</li><li aid:pstyle="ul-item">OL1-UL2</li></ul><dl><dt>OL1-DL1</dt><dd>OL1-DD1</dd><dt>OL1-DL2</dt><dd>OL1-DD2</dd></dl></li><li aid:pstyle="ol-item" olnum="1" num="2">OL2<p>OL2-PARA</p></li></ol>
+EOS
+
+    actual = compile_block(src)
+    assert_equal expected, actual
+  end
+
+  def test_nest_dl
+    src = <<-EOS
+ : DL1
+
+//child[dl]
+
+ 1. DL1-OL1
+ 2. DL1-OL2
+
+ * DL1-UL1
+ * DL1-UL2
+
+ : DL1-DL1
+	DL1-DD1
+ : DL1-DL2
+	DL1-DD2
+
+//child[/dl]
+
+ : DL2
+	DD2
+
+//child[dl]
+
+ * DD2-UL1
+ * DD2-UL2
+
+DD2-PARA
+
+//child[/dl]
+EOS
+
+    expected = <<-EOS.chomp
+<dl><dt>DL1</dt><dd><ol><li aid:pstyle="ol-item" olnum="1" num="1">DL1-OL1</li><li aid:pstyle="ol-item" olnum="2" num="2">DL1-OL2</li></ol><ul><li aid:pstyle="ul-item">DL1-UL1</li><li aid:pstyle="ul-item">DL1-UL2</li></ul><dl><dt>DL1-DL1</dt><dd>DL1-DD1</dd><dt>DL1-DL2</dt><dd>DL1-DD2</dd></dl></dd><dt>DL2</dt><dd>DD2<ul><li aid:pstyle="ul-item">DD2-UL1</li><li aid:pstyle="ul-item">DD2-UL2</li></ul><p>DD2-PARA</p></dd></dl>
+EOS
+
+    actual = compile_block(src)
+    assert_equal expected, actual
+  end
+
+  def test_nest_multi
+    src = <<-EOS
+ 1. OL1
+
+//child[ol]
+
+ 1. OL1-OL1
+
+//child[ol]
+
+ * OL1-OL1-UL1
+
+OL1-OL1-PARA
+
+//child[/ol]
+
+ 2. OL1-OL2
+
+ * OL1-UL1
+
+//child[ul]
+
+ : OL1-UL1-DL1
+	OL1-UL1-DD1
+
+OL1-UL1-PARA
+
+//child[/ul]
+
+ * OL1-UL2
+
+//child[/ol]
+EOS
+    expected = <<-EOS.chomp
+<ol><li aid:pstyle="ol-item" olnum="1" num="1">OL1<ol><li aid:pstyle="ol-item" olnum="1" num="1">OL1-OL1<ul><li aid:pstyle="ul-item">OL1-OL1-UL1</li></ul><p>OL1-OL1-PARA</p></li><li aid:pstyle="ol-item" olnum="1" num="2">OL1-OL2</li></ol><ul><li aid:pstyle="ul-item">OL1-UL1<dl><dt>OL1-UL1-DL1</dt><dd>OL1-UL1-DD1</dd></dl><p>OL1-UL1-PARA</p></li><li aid:pstyle="ul-item">OL1-UL2</li></ul></li></ol>
+EOS
+
+    actual = compile_block(src)
+    assert_equal expected, actual
+  end
 end


### PR DESCRIPTION
#1492 の対応です。

*箇条書きの中で//child[ul]〜//child[/ul]
1.箇条書きの中で//child[ol]〜//child[/ol]
:箇条書きの中で//child[dl]〜//child[/dl]
を入れることで、囲み範囲を箇条書きの子要素とします。
入れ子は対応するかぎりいくつでも可能です(表現系はともかくとして)。

対応が壊れている(開いてない、閉じてない、ミスマッチ)場合はエラーとします。