### PR TITLE
remove duplicated @non_parsed_commands definition

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -26,6 +26,14 @@ module ReVIEW
 
     attr_reader :strategy
 
+    def non_escaped_commands
+      if @strategy.highlight?
+        %i[list emlist listnum emlistnum cmd]
+      else
+        []
+      end
+    end
+
     def compile(chap)
       @chapter = chap
       do_compile
@@ -224,14 +232,6 @@ module ReVIEW
     def do_compile
       f = LineInput.new(StringIO.new(@chapter.content))
       @strategy.bind(self, @chapter, Location.new(@chapter.basename, f))
-
-      @non_parsed_commands = %i[embed texequation graph]
-      if @strategy.highlight?
-        @non_escaped_commands = %i[list emlist listnum emlistnum cmd]
-      else
-        @non_escaped_commands = []
-      end
-      @command_name_stack = []
 
       tagged_section_init
       while f.next?
@@ -554,7 +554,7 @@ module ReVIEW
 
     def in_non_escaped_command?
       current_command = @command_name_stack.last
-      current_command && @non_escaped_commands.include?(current_command)
+      current_command && non_escaped_commands.include?(current_command)
     end
 
     def text(str, block_mode = false)


### PR DESCRIPTION
#1499  の修正です

- `do_compile` で重複定義していた `@non_parsed_commands` を削除し、`initialize`側のみを有効に
- `do_compile` で定義していた `@non_escaped_commands`(ハイライト有効時にエスケープしないもの) は、highlight判定の前にbindされないとダメなので、`initialize`には置けない。highlight判定および非エスケープ対象タグシンボルの配列を返すメソッド `non_escaped_commands` を用意し、これを呼び出すように変更。これで、もし書き換えたいときには `do_compile` 全体ではなくこのメソッドだけをオーバライドすればよい