### PR TITLE
webmaker,textmakerが数式画像を作り忘れているのを修正

### DIFF
--- a/lib/review/textmaker.rb
+++ b/lib/review/textmaker.rb
@@ -98,7 +98,7 @@ module ReVIEW
       end
 
       math_dir = "./#{@config['imagedir']}/_review_math_text"
-      if @config['imgmath'] && File.exist?(File.join(math_dir, '__IMGMATH_BODY__.tex'))
+      if @config['imgmath'] && File.exist?(File.join(math_dir, '__IMGMATH_BODY__.map'))
         make_math_images(math_dir)
       end
     end

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -118,7 +118,7 @@ module ReVIEW
       copy_backmatter(@path)
 
       math_dir = "./#{@config['imagedir']}/_review_math"
-      if @config['imgmath'] && File.exist?("#{math_dir}/__IMGMATH_BODY__.tex")
+      if @config['imgmath'] && File.exist?("#{math_dir}/__IMGMATH_BODY__.map")
         make_math_images(math_dir)
       end
 


### PR DESCRIPTION
#1489 で、数式の効率化をしたはいいが、判定ファイル名を変えたのをEPUBMakerしか修正反映していなかった。
textmaker, webmakerにも反映。
