### PR TITLE
fix rubocop settings

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,9 @@ Performance/StringReplacement:
 Performance/RangeInclude:
   Enabled: true
 
+Performance/DeletePrefix:
+  Enabled: false
+
 #### Style
 
 Style/AccessModifierDeclarations:


### PR DESCRIPTION
`rubocop-performance 1.6.1` で警告が出るので抑制します。