### PR TITLE
aut値が空のときにPDFMakerがエラーになることの対処

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -18,7 +18,7 @@ module ReVIEW
         'bookname' => 'book', # it defines epub file name also
         'booktitle' => 'Re:VIEW Sample Book',
         'title' => nil,
-        'aut' => ['anonymous'], # author
+        'aut' => nil, # author
         'prt' => nil, # printer(publisher)
         'asn' => nil, # associated name
         'ant' => nil, # bibliographic antecedent

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -1,50 +1,51 @@
+<%- initialize_metachars(@config['texcommand']) -%>
 \makeatletter
 \def\review@reviewversion{<%= ReVIEW::VERSION %>}
 \def\review@texcompiler{<%= @texcompiler %>}
 \def\review@documentclass{<%= @documentclass %>}
 
 <%- %w(booktitle subtitle).each do |item| -%>
-<%-   if @config[item] -%>\def\review@<%= item %>name{<%= escape_latex(@config.name_of(item)) %>}
+<%-   if @config[item] -%>\def\review@<%= item %>name{<%= escape(@config.name_of(item)) %>}
 <%-   end -%>
 <%- end -%>
 
-<%- %w(aut adp ann arr art asn aqt aft aui ant bkp clb cmm csl dsr edt ill lyr mdc mus nrt oth pht pbl prt red rev spn ths trc trl).each do |item| %><%-   if @config[item] -%>\def\review@<%= item %>names{<%= escape_latex(@config.names_of(item).join(I18n.t('names_splitter'))) %>}
+<%- %w(aut adp ann arr art asn aqt aft aui ant bkp clb cmm csl dsr edt ill lyr mdc mus nrt oth pht pbl prt red rev spn ths trc trl).each do |item| %><%-   if @config[item] -%>\def\review@<%= item %>names{<%= escape(@config.names_of(item).join(I18n.t('names_splitter'))) %>}
 <%-   end -%>
 <%- end -%>
 
 \def\review@titlepageauthors{<%= @authors %>}
-\def\review@date{<%= escape_latex(@config['date'].to_s) %>}
+\def\review@date{<%= escape(@config['date'].to_s) %>}
 
-<%- %w(bookname language urnid isbn).each do |item| -%><%-   if @config[item] -%>\def\review@<%= item %>{<%= escape_latex(@config[item]) %>}
+<%- %w(bookname language urnid isbn).each do |item| -%><%-   if @config[item] -%>\def\review@<%= item %>{<%= escape(@config[item]) %>}
 <%-   end -%>
 <%- end -%>
 <%- %w(rights description subject type format source relation coverage).each do |item| -%>
 <%-   if @config[item] -%>
-<%-     a = [@config[item]].flatten -%>\def\review@<%= item %>{<%= a.map{|s| escape_latex(s)}.join('\\' + '\\') %>}
+<%-     a = [@config[item]].flatten -%>\def\review@<%= item %>{<%= a.map{|s| escape(s)}.join('\\' + '\\') %>}
 <%-   end -%>
 <%- end -%>
 
 <%- if @config['highlight'] && @config['highlight']['latex'] -%>\def\review@highlightlatex{<%= @config['highlight']['latex'] %>}
 <%- end -%>
 
-\def\review@intn@list{<%= escape_latex(I18n.t('list')) %>}
-\def\review@intn@columnhead{<%= escape_latex(I18n.t('column_head')) %>}
-\def\review@intn@image{<%= escape_latex(I18n.t('image')) %>}
-\def\review@intn@table{<%= escape_latex(I18n.t('table')) %>}
-\def\review@intn@equation{<%= escape_latex(I18n.t('equation')) %>}
-\def\review@intn@columnname{<%= escape_latex(I18n.t('columnname')) %>}
-\def\review@intn@memohead{<%= escape_latex(I18n.t('memo_head')) %>}
-\def\review@intn@edition{<%= escape_latex(I18n.t('edition')) %>}
-\def\review@intn@publishedby{<%= escape_latex(I18n.t('published_by', @config.names_of('pbl').join(I18n.t('names_splitter'))))%>}
-\def\review@intn@captionprefix{<%= escape_latex(I18n.t('caption_prefix')) %>}
-\def\review@toctitle{<%= escape_latex(@config['toctitle'].present? ? @config['toctitle'] : I18n.t('toctitle')) %>}
-\def\review@prepartname{<%= escape_latex(@locale_latex['prepartname']) %>}
-\def\review@postpartname{<%= escape_latex(@locale_latex['postpartname']) %>}
-\def\review@prechaptername{<%= escape_latex(@locale_latex['prechaptername']) %>}
-\def\review@postchaptername{<%= escape_latex(@locale_latex['postchaptername']) %>}
-\def\review@figurename{<%= escape_latex(I18n.t('image')) %>}
-\def\review@tablename{<%= escape_latex(I18n.t('table')) %>}
-\def\review@appendixname{<%= escape_latex(@locale_latex['preappendixname']) %>}
+\def\review@intn@list{<%= escape(I18n.t('list')) %>}
+\def\review@intn@columnhead{<%= escape(I18n.t('column_head')) %>}
+\def\review@intn@image{<%= escape(I18n.t('image')) %>}
+\def\review@intn@table{<%= escape(I18n.t('table')) %>}
+\def\review@intn@equation{<%= escape(I18n.t('equation')) %>}
+\def\review@intn@columnname{<%= escape(I18n.t('columnname')) %>}
+\def\review@intn@memohead{<%= escape(I18n.t('memo_head')) %>}
+\def\review@intn@edition{<%= escape(I18n.t('edition')) %>}
+\def\review@intn@publishedby{<%= escape(I18n.t('published_by', @config.names_of('pbl').join(I18n.t('names_splitter'))))%>}
+\def\review@intn@captionprefix{<%= escape(I18n.t('caption_prefix')) %>}
+\def\review@toctitle{<%= escape(@config['toctitle'].present? ? @config['toctitle'] : I18n.t('toctitle')) %>}
+\def\review@prepartname{<%= escape(@locale_latex['prepartname']) %>}
+\def\review@postpartname{<%= escape(@locale_latex['postpartname']) %>}
+\def\review@prechaptername{<%= escape(@locale_latex['prechaptername']) %>}
+\def\review@postchaptername{<%= escape(@locale_latex['postchaptername']) %>}
+\def\review@figurename{<%= escape(I18n.t('image')) %>}
+\def\review@tablename{<%= escape(I18n.t('table')) %>}
+\def\review@appendixname{<%= escape(@locale_latex['preappendixname']) %>}
 
 <%- if @config['toc'] -%>
 \def\review@toc{true}

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,9 +1,9 @@
-\ProvidesClass{review-base}[2020/01/02]
+\ProvidesClass{review-base}[2020/07/11]
 % jlreq用基本設定
 \def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
   \hypersetup{
     pdftitle={\review@booktitlename},
-    pdfauthor={\review@autnames},
+    pdfauthor={\ifdefined\review@autnames\review@autnames\fi},
     pdfcreator={Re:VIEW \review@reviewversion, with LaTeX}
   }
 \else
@@ -12,7 +12,7 @@
   \@onlypreamble\PDFDocumentInformation
   \PDFDocumentInformation{
     /Title    (\review@booktitlename)
-    /Author   (\review@autnames)
+    \ifdefined\review@autnames /Author   (\review@autnames)\fi
     % /Subject  ()
     % /Keywords (,,)
     /Creator  (Re:VIEW \review@reviewversion, with LaTeX)

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2020/01/02]
+\ProvidesClass{review-base}[2020/07/11]
 \RequirePackage{ifthen}
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}
@@ -61,7 +61,7 @@
 
 \PDFDocumentInformation{
   /Title    (\review@booktitlename)
-  /Author   (\review@autnames)
+  \ifdefined\review@autnames /Author   (\review@autnames)\fi
   % /Subject  ()
   % /Keywords (,,)
   /Creator  (Re:VIEW \review@reviewversion, with LaTeX)

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -1,6 +1,6 @@
 \documentclass[dvipdfmx]{review-jsbook}
 \makeatletter
-\def\review@reviewversion{3.2.0}
+\def\review@reviewversion{4.2.0}
 \def\review@texcompiler{uplatex}
 \def\review@documentclass{review-jsbook}
 
@@ -9,7 +9,7 @@
 \def\review@autnames{anonymous}
 
 \def\review@titlepageauthors{anonymous　著}
-\def\review@date{2011{-}01{-}01}
+\def\review@date{2020{-}07{-}11}
 
 \def\review@bookname{sample}
 \def\review@language{ja}
@@ -38,7 +38,7 @@
 \def\review@usecovernombre{true}
 \def\review@titlepage{true}
 
-\def\review@pubhistories{2011年1月1日　発行}
+\def\review@pubhistories{2020年7月11日　発行}
 \def\review@colophonnames{著　者 & anonymous \\
 }
 

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -1,6 +1,6 @@
 \documentclass[dvipdfmx]{review-jsbook}
 \makeatletter
-\def\review@reviewversion{3.2.0}
+\def\review@reviewversion{4.2.0}
 \def\review@texcompiler{uplatex}
 \def\review@documentclass{review-jsbook}
 
@@ -9,7 +9,7 @@
 \def\review@autnames{anonymous}
 
 \def\review@titlepageauthors{anonymous　著}
-\def\review@date{2011{-}01{-}01}
+\def\review@date{2020{-}07{-}11}
 
 \def\review@bookname{sample}
 \def\review@language{ja}
@@ -49,7 +49,7 @@ some ad content
 }
 \null}
 
-\def\review@pubhistories{2011年1月1日　発行}
+\def\review@pubhistories{2020年7月11日　発行}
 \def\review@colophonnames{著　者 & anonymous \\
 }
 

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -10,9 +10,10 @@ class PDFMakerTest < Test::Unit::TestCase
     @config.merge!(
       'bookname' => 'sample',
       'title' => 'Sample Book',
-      'review_version' => 3,
+      'aut' => 'anonymous',
+      'review_version' => 4,
       'urnid' => 'http://example.jp/',
-      'date' => '2011-01-01',
+      'date' => '2020-07-11',
       'language' => 'ja',
       'texcommand' => 'uplatex'
     )
@@ -196,7 +197,7 @@ class PDFMakerTest < Test::Unit::TestCase
     @config['pht'] = ['Mrs.Smith']
     @config['language'] = 'ja'
     history = @maker.make_history_list
-    expect = ['2011年1月1日　発行']
+    expect = ['2020年7月11日　発行']
     assert_equal expect, history
   end
 
@@ -207,9 +208,9 @@ class PDFMakerTest < Test::Unit::TestCase
     @config['language'] = 'ja'
     @config['history'] =
       [['2011-08-03 v1.0.0版発行',
-        '2012-02-15 v1.1.0版発行']]
+        '2020-07-11 v1.2.0版発行']]
     history = @maker.make_history_list
-    expect = ['2011年8月3日　v1.0.0版発行', '2012年2月15日　v1.1.0版発行']
+    expect = ['2011年8月3日　v1.0.0版発行', '2020年7月11日　v1.2.0版発行']
     assert_equal expect, history
   end
 


### PR DESCRIPTION
#1517 への対応

対処していたはずなのにおかしいな、と思っていたのですが、autを空にするといった特定条件だとmetachars定義が初期化されず、escapeメソッドで使おうとしてエラーになっていました。config.erbでまず初期化するように変更しました。

また、autのデフォルトをanonymousではなく空(null)にしました。

PDFプロパティを空autに対処するため、review-base.styも更新しています。