### PR TITLE
refactor: rename strategy to builder

### DIFF
--- a/bin/review-compile
+++ b/bin/review-compile
@@ -85,7 +85,7 @@ def _main
         error("file not found: #{item}") unless File.exist?(File.join(book.config['contentdir'], item))
         chap_name = File.basename(item, '.*')
         chap = book.chapter(chap_name)
-        compiler = ReVIEW::Compiler.new(load_strategy_class(@target, @check_only))
+        compiler = ReVIEW::Compiler.new(load_builder_class(@target, @check_only))
         result = compiler.compile(chap)
         if @output_filename
           write(@output_filename, result)
@@ -96,15 +96,15 @@ def _main
     when :dir
       book = @basedir ? ReVIEW::Book.load(@basedir) : ReVIEW::Book::Base.load
       book.config = @config
-      compiler = ReVIEW::Compiler.new(load_strategy_class(@target, @check_only))
+      compiler = ReVIEW::Compiler.new(load_builder_class(@target, @check_only))
       book.chapters.each do |chap|
         str = compiler.compile(chap)
-        write("#{chap.name}#{compiler.strategy.extname}", str) unless @check_only
+        write("#{chap.name}#{compiler.builder.extname}", str) unless @check_only
       end
       # PART
       book.parts_in_file.each do |part|
         str = compiler.compile(part)
-        write("#{part.name}#{compiler.strategy.extname}", str) unless @check_only
+        write("#{part.name}#{compiler.builder.extname}", str) unless @check_only
       end
     else
       raise "must not happen: #{@mode}"
@@ -178,7 +178,7 @@ def warn(msg)
   @logger.warn msg
 end
 
-def load_strategy_class(target, strict)
+def load_builder_class(target, strict)
   require "review/#{target}builder"
   ReVIEW.const_get("#{target.upcase}Builder").new(strict)
 end


### PR DESCRIPTION
ReVIEW::Compiler にある `@strategy` が実はBuilder、という混乱の元を解決します。

`Compiler#strategy` は現状ではerrorにしてますが（不具合の早期検出のため）、リリース時にはwarnにしても良いかもです。