### PR TITLE
extractbb明示呼び出しの廃止と、bbox設定の引き渡し

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -311,23 +311,12 @@ module ReVIEW
       end
     end
 
-    # PDFMaker#copy_images should copy image files _AND_ execute extractbb (or ebb).
+    # PDFMaker#copy_images should copy image files
     #
     def copy_images(from, to)
       return unless File.exist?(from)
       Dir.mkdir(to)
       ReVIEW::MakerHelper.copy_images_to_dir(from, to)
-      Dir.chdir(to) do
-        images = Dir.glob('**/*').find_all { |f| File.file?(f) and f =~ /\.(jpg|jpeg|png|pdf|ai|eps|tif)\z/i }
-        break if images.empty?
-        if @config['pdfmaker']['bbox']
-          system_with_info('extractbb', '-B', @config['pdfmaker']['bbox'], *images)
-          system_or_raise('ebb', '-B', @config['pdfmaker']['bbox'], *images) unless system('extractbb', '-B', @config['pdfmaker']['bbox'], '-m', *images)
-        else
-          system_with_info('extractbb', *images)
-          system_or_raise('ebb', *images) unless system('extractbb', '-m', *images)
-        end
-      end
     end
 
     def make_custom_page(file)

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -101,6 +101,9 @@
 <%- if @config['use_part'] -%>
 \def\reviewusepart{true}
 <%- end -%>
+<%- if @config['pdfmaker']['bbox'] -%>
+\def\review@bbox{<%= @config['pdfmaker']['bbox'] %>}
+<%- end -%>
 
 \def\reviewbackcompatibilityhook{
   \ifdefined\reviewimagecaption\else% for 3.0.0 compatibility

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2020/07/11]
+\ProvidesClass{review-base}[2020/07/23]
 % jlreq用基本設定
 \def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
   \hypersetup{
@@ -25,6 +25,11 @@
 \rubysetup{g}}
 
 \long\def\review@ifempty#1{\expandafter\ifx\expandafter\relax\detokenize{#1}\relax\expandafter\@firstoftwo\else\expandafter\@secondoftwo\fi}
+
+%% pass bbox setting to extractbb of graphicx
+\ifdefined\review@bbox
+  \def\Gin@pagebox{\review@bbox}
+\fi
 
 % コードリスト装飾のデフォルト
 \newenvironment{reviewemlist}{%

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2020/07/11]
+\ProvidesClass{review-base}[2020/07/23]
 \RequirePackage{ifthen}
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}
@@ -47,6 +47,11 @@
 }
 
 \long\def\review@ifempty#1{\expandafter\ifx\expandafter\relax\detokenize{#1}\relax\expandafter\@firstoftwo\else\expandafter\@secondoftwo\fi}
+
+%% pass bbox setting to extractbb of graphicx
+\ifdefined\review@bbox
+  \def\Gin@pagebox{\review@bbox}
+\fi
 
 \newenvironment{shadedb}{%
   \def\FrameCommand{\fboxsep=\FrameSep \colorbox{shadecolorb}}%


### PR DESCRIPTION
#1483  の対応
LaTeXで画像のバウンディングボックスを取るのに使っているextractbbですが、TeXLive2015以降では内部で呼び出されるので不要そうなのと、#1483 のとおり拡張子以外同名のときにおかしなことになるので呼び出しコードを削除します。

これに伴い、pdfmaker/bboxの設定は、config.erb経由でreview-base.styに渡し、graphicx.styのデフォルト値を変えることで対処するようにしています。
