### PR TITLE
escape indepimage warning string

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -637,7 +637,7 @@ module ReVIEW
       else
         warn "image not bound: #{id}"
         puts '\begin{reviewdummyimage}'
-        puts "--[[path = #{id} (#{existence(id)})]]--"
+        puts "--[[path = #{escape(id)} (#{existence(id)})]]--"
         lines.each do |line|
           puts detab(line.rstrip)
         end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1270,6 +1270,27 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_indepimage_nofile
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('sample_img#&', 1)
+      item.instance_eval do
+        def path
+          nil
+        end
+      end
+      item
+    end
+
+    actual = compile_block("//indepimage[sample_img#&][sample photo]\n")
+    expected = <<-EOS
+\\begin{reviewdummyimage}
+--[[path = sample\\textunderscore{}img\\#\\& (not exist)]]--
+\\reviewindepimagecaption{図: sample photo}
+\\end{reviewdummyimage}
+EOS
+    assert_equal expected, actual
+  end
+
   def test_table
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     expected = <<-EOS


### PR DESCRIPTION
//indepimageで画像がないときに
```
//indepimage[sample_img#&]
 ↓
\\begin{reviewdummyimage}
--[[path = sample_img#& (not exist)]]--
\\reviewindepimagecaption{図: sample photo}
\\end{reviewdummyimage}
```
という展開をしますが、IDをそのまま渡していたので`_`などのリテラルに使えない文字がID内にあるとコンパイルエラーが発生していました。
単純に出力前にエスケープすることにします。