### PR TITLE
chapterlinkをデフォルトで有効にする

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -92,6 +92,9 @@ debug: null
 # ISBN。省略した場合はurnidが入る
 # isbn: null
 #
+# @<chap>, @<chapref>, @<title>, @<hd>命令をハイパーリンクにする(nullでハイパーリンクにしない)
+# chapterlink: true
+
 # HTMLファイルの拡張子(省略した場合はhtml)
 # htmlext: html
 #

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -64,6 +64,7 @@ module ReVIEW
         'bib_file' => 'bib.re',
         'words_file' => nil,
         'colophon_order' => %w[aut csl trl dsr ill cov edt pbl contact prt],
+        'chapterlink' => true,
         'externallink' => true,
         'join_lines_by_lang' => nil, # experimental. default should be nil
         'table_row_separator' => 'tabs',

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -1018,7 +1018,7 @@ EOS
 
     def inline_column_chap(chapter, id)
       if @book.config['chapterlink']
-        %Q(<a href="\##{column_label(id, chapter)}" class="columnref">#{I18n.t('column', compile_inline(chapter.column(id).caption))}</a>)
+        %Q(<a href="#{chapter.id}#{extname}##{column_label(id, chapter)}" class="columnref">#{I18n.t('column', compile_inline(chapter.column(id).caption))}</a>)
       else
         I18n.t('column', compile_inline(chapter.column(id).caption))
       end

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2020/07/23]
+\ProvidesClass{review-base}[2020/08/14]
 % jlreq用基本設定
 \def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
   \hypersetup{
@@ -127,9 +127,9 @@
 \newcommand{\reviewtableref}[2]{\review@intn@table #1}
 \newcommand{\reviewlistref}[1]{\review@intn@list #1}
 \newcommand{\reviewequationref}[1]{\review@intn@equation #1}
-\newcommand{\reviewbibref}[2]{#1}
-\newcommand{\reviewcolumnref}[2]{#1}
-\newcommand{\reviewsecref}[2]{#1}
+\newcommand{\reviewbibref}[2]{\hyperref[#2]{#1}}
+\newcommand{\reviewcolumnref}[2]{#1}% XXX:ハイパーリンクにはreviewcolumn側の調整が必要
+\newcommand{\reviewsecref}[2]{\hyperref[#2]{#1}}
 
 \renewcommand{\contentsname}{\review@toctitle}
 

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2020/07/23]
+\ProvidesClass{review-base}[2020/08/14]
 \RequirePackage{ifthen}
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}
@@ -210,9 +210,9 @@
 \newcommand{\reviewtableref}[2]{\review@intn@table #1}
 \newcommand{\reviewlistref}[1]{\review@intn@list #1}
 \newcommand{\reviewequationref}[1]{\review@intn@equation #1}
-\newcommand{\reviewbibref}[2]{#1}
-\newcommand{\reviewcolumnref}[2]{#1}
-\newcommand{\reviewsecref}[2]{#1}
+\newcommand{\reviewbibref}[2]{\hyperref[#2]{#1}}
+\newcommand{\reviewcolumnref}[2]{#1}% XXX:ハイパーリンクにはreviewcolumn側の調整が必要
+\newcommand{\reviewsecref}[2]{\hyperref[#2]{#1}}
 
 \newenvironment{reviewpart}{%
 \setcounter{section}{0}%

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -847,9 +847,15 @@ inside column
 this is @<column>{foo}.
 EOS
     expected = <<-EOS.chomp
-<column id="column-1"><title aid:pstyle="column-title">test</title><?dtp level="9" section="test"?><p>inside column</p></column><title aid:pstyle="h3">next level</title><?dtp level="3" section="next level"?><p>this is コラム「test」.</p>
+<column id="column-1"><title aid:pstyle="column-title">test</title><?dtp level="9" section="test"?><p>inside column</p></column><title aid:pstyle="h3">next level</title><?dtp level="3" section="next level"?><p>this is <link href="column-1">コラム「test」</link>.</p>
 EOS
 
+    assert_equal expected, column_helper(review)
+
+    @config['chapterlink'] = nil
+    expected = <<-EOS.chomp
+<column id="column-1"><title aid:pstyle="column-title">test</title><?dtp level="9" section="test"?><p>inside column</p></column><title aid:pstyle="h3">next level</title><?dtp level="3" section="next level"?><p>this is コラム「test」.</p>
+EOS
     assert_equal expected, column_helper(review)
   end
 
@@ -861,6 +867,11 @@ EOS
       idx
     end
 
+    actual = compile_inline('test @<column>{chap1|column} test2')
+    expected = 'test <link href="column-1">コラム「column_cap」</link> test2'
+    assert_equal expected, actual
+
+    @config['chapterlink'] = nil
     actual = compile_inline('test @<column>{chap1|column} test2')
     expected = 'test コラム「column_cap」 test2'
     assert_equal expected, actual

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -255,6 +255,10 @@ EOS
 
     @config['secnolevel'] = 3
     actual = compile_inline('test @<hd>{chap1|test} test2')
+    assert_equal 'test \reviewsecref{「1.1.1 te\\textunderscore{}st」}{sec:1-1-1} test2', actual
+
+    @config['chapterlink'] = nil
+    actual = compile_inline('test @<hd>{chap1|test} test2')
     assert_equal 'test 「1.1.1 te\\textunderscore{}st」 test2', actual
   end
 

--- a/test/test_latexbuilder_v2.rb
+++ b/test/test_latexbuilder_v2.rb
@@ -229,6 +229,10 @@ EOS
 
     @config['secnolevel'] = 3
     actual = compile_inline('test @<hd>{chap1|test} test2')
+    assert_equal 'test \reviewsecref{「1.1.1 te\\textunderscore{}st」}{sec:1-1-1} test2', actual
+
+    @config['chapterlink'] = nil
+    actual = compile_inline('test @<hd>{chap1|test} test2')
     assert_equal 'test 「1.1.1 te\\textunderscore{}st」 test2', actual
   end
 


### PR DESCRIPTION
#1529 #1530 の対応です。

- chapterlinkをデフォルトでtrueにしました。
- config.yml.sampleにドキュメント追加しました。
- chapterlink on/off時のテストを追加しました。
- hdインライン命令をLaTeX展開したときのreviewsecrefで、hyperrefを有効にしました。
- 厳密にはchapterlinkとは別の話なんですが、columnインライン命令で別ファイルを参照してもちゃんと動いていなかったので、chapter/idをちゃんと分解してchapterのhtmlを参照するようにしました。
- pdfmakerにおいては、media=printの場合はhyperrefパッケージのオプションでハイパーリンク機能を殺しているので変化はなし。media=ebookの場合はhdインライン命令の箇所がリンクになります。図表・リスト・式のほうはリンクにはしていません(やろうとするとちょっと面倒くさそう)。

LaTeXのreviewcolumnrefのほうは、hyperrefを入れてもうまく動いてくれませんでした。どうもreviewcolumnheadに渡しているhypertargetのほうが無視されてラベルとして見つからないっぽい？ とりあえず今は必須というほどではないので対処から見送っています。