### PR TITLE
prefer hypersetup for pdf information

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -7,16 +7,24 @@
     pdfcreator={Re:VIEW \review@reviewversion, with LaTeX}
   }
 \else
-  \newcommand*\PDFDocumentInformation[1]{%
-    \AtBeginShipoutFirst{\special{pdf:docinfo <<#1>>}}}
-  \@onlypreamble\PDFDocumentInformation
-  \PDFDocumentInformation{
-    /Title    (\review@booktitlename)
-    \ifdefined\review@autnames /Author   (\review@autnames)\fi
-    % /Subject  ()
-    % /Keywords (,,)
-    /Creator  (Re:VIEW \review@reviewversion, with LaTeX)
-  }
+  \def\recls@tmp{ebook}\ifx\recls@cameraready\recls@tmp
+    \hypersetup{
+      pdftitle={\review@booktitlename},
+      pdfauthor={\ifdefined\review@autnames\review@autnames\fi},
+      pdfcreator={Re:VIEW \review@reviewversion, with LaTeX}
+    }
+  \else
+    \newcommand*\PDFDocumentInformation[1]{%
+      \AtBeginShipoutFirst{\special{pdf:docinfo <<#1>>}}}
+    \@onlypreamble\PDFDocumentInformation
+    \PDFDocumentInformation{
+      /Title    (\review@booktitlename)
+      \ifdefined\review@autnames /Author   (\review@autnames)\fi
+      % /Subject  ()
+      % /Keywords (,,)
+      /Creator  (Re:VIEW \review@reviewversion, with LaTeX)
+    }
+  \fi
 \fi
 
 \RequirePackage{pxrubrica}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2020/08/14]
+\ProvidesClass{review-base}[2020/08/15]
 \RequirePackage{ifthen}
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}
@@ -59,18 +59,6 @@
  {\endMakeFramed}
 
 \newcommand{\parasep}{\vspace*{3zh}}
-
-\newcommand*\PDFDocumentInformation[1]{%
-  \AtBeginShipoutFirst{\special{pdf:docinfo <<#1>>}}}
-\@onlypreamble\PDFDocumentInformation
-
-\PDFDocumentInformation{
-  /Title    (\review@booktitlename)
-  \ifdefined\review@autnames /Author   (\review@autnames)\fi
-  % /Subject  ()
-  % /Keywords (,,)
-  /Creator  (Re:VIEW \review@reviewversion, with LaTeX)
-}
 
 \RequirePackage{pxrubrica}
 \@ifpackagelater{pxrubrica}{2017/04/20}{%
@@ -376,6 +364,28 @@
 \fi
 \ifdefined\appendixname
   \renewcommand{\appendixname}{\reviewappendixname}
+\fi
+
+% PDF meta information
+\def\recls@tmp{ebook}\ifx\recls@cameraready\recls@tmp
+\hypersetup{
+    pdftitle={\review@booktitlename},
+    pdfauthor={\ifdefined\review@autnames\review@autnames\fi},
+    pdfcreator={Re:VIEW \review@reviewversion, with LaTeX}
+  }
+\else
+\newcommand*\PDFDocumentInformation[1]{%
+  \AtBeginShipoutFirst{\special{pdf:docinfo <<#1>>}}}
+\@onlypreamble\PDFDocumentInformation
+
+% for non hyperref. escaped character will be displayed funny...
+\PDFDocumentInformation{
+  /Title    (\review@booktitlename)
+  \ifdefined\review@autnames /Author   (\review@autnames)\fi
+  % /Subject  ()
+  % /Keywords (,,)
+  /Creator  (Re:VIEW \review@reviewversion, with LaTeX)
+}
 \fi
 
 %% maxwidth is the original width if it is less than linewidth


### PR DESCRIPTION
#1533 の対応。
media=ebook (hyperref有効)のときにはhypersetupでPDFメタ情報を記載するようにしました。
media=print + upLaTeXのときはエスケープが変に出るのは諦めてpdf:docinfoへの生記述を使い続けます(media=print+LuaLaTeXのときは何も入らない)。
