### PR TITLE
cover_fit_pageクラスオプションの追加

### DIFF
--- a/templates/latex/review-jlreq/README.md
+++ b/templates/latex/review-jlreq/README.md
@@ -38,7 +38,9 @@ texdocumentclass: ["review-jlreq", "クラスオプションたち（省略可�
 
 `media` の値によって表紙（config.yml の coverimage に指定した画像）の配置の有無は自動で切り替わりますが、`cover=true` とすれば必ず表紙を入れるようになります。
 
-なお、config.yml の coverimage で指定する画像ファイルは、原寸を想定しています。
+### 表紙画像のサイズの仕上がり紙面合わせ `cover_fit_page=<trueまたはfalse>`
+
+上記の coverimage で指定する画像ファイルは、原寸を想定しているため、サイズが異なる場合にははみ出たり、小さすぎたりすることになります。できるだけ原寸で用意することを推奨しますが、`cover_fit_page=true` とすれば表紙画像を紙面の仕上がりサイズに合わせて拡縮します。
 
 ### 特定の用紙サイズ `paper=<用紙サイズ>`
 

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2020/08/14]
+\ProvidesClass{review-base}[2020/08/16]
 % jlreq用基本設定
 \def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
   \hypersetup{
@@ -338,6 +338,9 @@
 
 \if@reclscover
   \ifdefined\review@coverimage
+    \ifrecls@coverfitpage
+       \def\review@coverimageoption{width=\paperwidth,height=\paperheight}
+    \fi
     \def\reviewcoverpagecont{%
       \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
       \cleardoublepage

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -20,7 +20,7 @@
 % THE SOFTWARE.
 
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{review-jlreq}[2020/07/23 Re:VIEW upLaTeX/LuaLaTeX class modified for jlreq.cls]
+\ProvidesClass{review-jlreq}[2020/08/16 Re:VIEW 5.0 upLaTeX/LuaLaTeX class modified for jlreq.cls]
 
 %% hook at end of reviewmacro
 \let\@endofreviewmacrohook\@empty
@@ -92,12 +92,14 @@
 \newif\if@pdfhyperlink \@pdfhyperlinkfalse
 \newif\if@pdftombo \@pdftombofalse
 \newif\if@reclscover \@reclscovertrue
+\newif\ifrecls@coverfitpage \recls@coverfitpagefalse
 \newif\ifrecls@serialpage \recls@serialpagefalse
 \DeclareOptionX{cameraready}[print]{\gdef\recls@cameraready{#1}}
 \DeclareOptionX{media}[print]{\gdef\recls@cameraready{#1}}
 \DeclareOptionX{tombopaper}[a4]{\gdef\recls@tombopaper{#1}}
 \DeclareOptionX{bleed_margin}[3mm]{\gdef\recls@tombobleed{#1}}
 \DeclareOptionX{cover}[\@empty]{\gdef\recls@forcecover{#1}}
+\DeclareOptionX{cover_fit_page}[false]{\csname recls@coverfitpage#1\endcsname}
 \DeclareOptionX{startpage}[1]{\gdef\recls@startpage{\numexpr #1\relax}}
 \DeclareOptionX{serial_pagination}[false]{\csname recls@serialpage#1\endcsname}
 

--- a/templates/latex/review-jsbook/README.md
+++ b/templates/latex/review-jsbook/README.md
@@ -40,19 +40,21 @@ texdocumentclass: ["review-jsbook", "クラスオプションたち（省略可�
 
 `media` の値によって表紙（config.yml の coverimage に指定した画像）の配置の有無は自動で切り替わりますが、`cover=true` とすれば必ず表紙を入れるようになります。
 
-なお、config.yml の coverimage で指定する画像ファイルは、原寸を想定しています。
+### 表紙画像のサイズの仕上がり紙面合わせ `cover_fit_page=<trueまたはfalse>`
+
+上記の coverimage で指定する画像ファイルは、原寸を想定しているため、サイズが異なる場合にははみ出たり、小さすぎたりすることになります。できるだけ原寸で用意することを推奨しますが、`cover_fit_page=true` とすれば表紙画像を紙面の仕上がりサイズに合わせて拡縮します。
 
 ### 特定の用紙サイズ `paper=<用紙サイズ>`
 
 利用可能な特定の用紙サイズを指定できます。
 
- * `a3` 
+ * `a3`
  * `a4` ［デフォルト］
  * `a5`
- * `a6` 
- * `b4`：JIS B4 
+ * `a6`
+ * `b4`：JIS B4
  * `b5`：JIS B5
- * `b6`：JIS B6 
+ * `b6`：JIS B6
  * `a4var`：210mm x 283mm
  * `b5var`：182mm x 230mm
  * `letter`

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2020/08/15]
+\ProvidesClass{review-base}[2020/08/16]
 \RequirePackage{ifthen}
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}
@@ -432,6 +432,9 @@
 
 \if@reclscover
   \ifdefined\review@coverimage
+    \ifrecls@coverfitpage
+       \def\review@coverimageoption{width=\paperwidth,height=\paperheight}
+    \fi
     \def\reviewcoverpagecont{%
       \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
       \cleardoublepage

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -1,5 +1,5 @@
 %#!ptex2pdf -l -u -ot '-synctex=1' test-rejsbk
-% Copyright (c) 2018-2019 Munehiro Yamamoto, Kenshi Muto.
+% Copyright (c) 2018-2020 Munehiro Yamamoto, Kenshi Muto.
 %
 % Permission is hereby granted, free of charge, to any person obtaining a copy
 % of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
 
 \NeedsTeXFormat{pLaTeX2e}
 \ProvidesClass{review-jsbook}
-  [2019/09/22 v4.0  Re:VIEW pLaTeX class modified for jsbook.cls]
+  [2020/08/16 v5.0  Re:VIEW pLaTeX class modified for jsbook.cls]
 
 \def\recls@error{\ClassError{review-jsbook}}
 \def\recls@warning{\ClassWarning{review-jsbook}}
@@ -226,8 +226,10 @@
 
 %% 表紙・開始番号・通しノンブル
 \newif\if@reclscover \@reclscovertrue
+\newif\ifrecls@coverfitpage \recls@coverfitpagefalse
 \newif\ifrecls@serialpage \recls@serialpagefalse
 \DeclareOptionX{cover}[\@empty]{\gdef\recls@forcecover{#1}}
+\DeclareOptionX{cover_fit_page}[false]{\csname recls@coverfitpage#1\endcsname}
 \DeclareOptionX{startpage}[1]{\gdef\recls@startpage{\numexpr#1}}
 \DeclareOptionX{serial_pagination}[false]{\csname recls@serialpage#1\endcsname}
 


### PR DESCRIPTION
#1534 の対処。
config.ymlパラメータでやるのはやっぱりちょっと嫌なので、review-jsbook/review-jlreqのクラスファイルオプションにしました。
`cover_fit_page=true`のときに縦横比無視で仕上がりサイズに拡縮貼り付けします。
