### PR TITLE
mute some stderr outputs in tests

### DIFF
--- a/test/test_idgxmlmaker_cmd.rb
+++ b/test/test_idgxmlmaker_cmd.rb
@@ -28,8 +28,7 @@ class IDGXMLMakerCmdTest < Test::Unit::TestCase
 
       ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']) + RbConfig::CONFIG['EXEEXT']
       Dir.chdir(@tmpdir1) do
-        _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_IDGXMLMAKER} #{option} #{configfile}")
-        STDERR.puts e unless e.empty?
+        _o, _e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_IDGXMLMAKER} #{option} #{configfile}")
         assert s.success?
       end
       assert File.exist?(File.join(@tmpdir1, targetfile))

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1285,6 +1285,9 @@ EOS
       item
     end
 
+    io = StringIO.new
+    @builder.instance_eval{ @logger = ReVIEW::Logger.new(io) }
+
     actual = compile_block("//indepimage[sample_img#&][sample photo]\n")
     expected = <<-EOS
 \\begin{reviewdummyimage}
@@ -1293,6 +1296,7 @@ EOS
 \\end{reviewdummyimage}
 EOS
     assert_equal expected, actual
+    assert_match(/WARN --: :1: image not bound: sample_img#&/, io.string)
   end
 
   def test_table

--- a/test/test_textmaker_cmd.rb
+++ b/test/test_textmaker_cmd.rb
@@ -28,8 +28,7 @@ class TEXTMakerCmdTest < Test::Unit::TestCase
 
       ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']) + RbConfig::CONFIG['EXEEXT']
       Dir.chdir(@tmpdir1) do
-        _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_TEXTMAKER} #{option} #{configfile}")
-        STDERR.puts e unless e.empty?
+        _o, _e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_TEXTMAKER} #{option} #{configfile}")
         assert s.success?
       end
       assert File.exist?(File.join(@tmpdir1, targetfile))


### PR DESCRIPTION
テストで標準エラーにWARNを出してしまうものがあり、取り込む or 捨てる で対処しました。
