### PR TITLE
check stderr output from textmaker/idgxmlmaker is empty

### DIFF
--- a/test/test_idgxmlmaker_cmd.rb
+++ b/test/test_idgxmlmaker_cmd.rb
@@ -28,7 +28,8 @@ class IDGXMLMakerCmdTest < Test::Unit::TestCase
 
       ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']) + RbConfig::CONFIG['EXEEXT']
       Dir.chdir(@tmpdir1) do
-        _o, _e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_IDGXMLMAKER} #{option} #{configfile}")
+        _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_IDGXMLMAKER} #{option} #{configfile}")
+        assert_equal '', e
         assert s.success?
       end
       assert File.exist?(File.join(@tmpdir1, targetfile))

--- a/test/test_textmaker_cmd.rb
+++ b/test/test_textmaker_cmd.rb
@@ -28,7 +28,8 @@ class TEXTMakerCmdTest < Test::Unit::TestCase
 
       ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']) + RbConfig::CONFIG['EXEEXT']
       Dir.chdir(@tmpdir1) do
-        _o, _e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_TEXTMAKER} #{option} #{configfile}")
+        _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_TEXTMAKER} #{option} #{configfile}")
+        assert_equal '', e
         assert s.success?
       end
       assert File.exist?(File.join(@tmpdir1, targetfile))


### PR DESCRIPTION
テストのSTDERR挙動をいくぶん戻してみました。
idgxmlmaker_cmd, textmaker_cmdはstderrが空であることを期待。
pdfmaker_cmdは今のところ必ずINFO等が出てしまうので前のとおりs.success以外のときにSTDERR.putsするだけ。

idgxmlmaker,textmakerもpdfmaker同様にしたほうがいいかなぁ。