### PR TITLE
handle invalid encoding

### DIFF
--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -68,20 +68,24 @@ module ReVIEW
 
       def find_first_header_option
         f = LineInput.new(StringIO.new(@content))
-        while f.next?
-          case f.peek
-          when /\A=+[\[\s{]/
-            m = /\A(=+)(?:\[(.+?)\])?(?:\{(.+?)\})?(.*)/.match(f.gets)
-            return m[2] # tag
-          when %r{/\A//[a-z]+/}
-            line = f.gets
-            if line.rstrip[-1, 1] == '{'
-              f.until_match(%r{\A//\}})
+        begin
+          while f.next?
+            case f.peek
+            when /\A=+[\[\s{]/
+              m = /\A(=+)(?:\[(.+?)\])?(?:\{(.+?)\})?(.*)/.match(f.gets)
+              return m[2] # tag
+            when %r{/\A//[a-z]+/}
+              line = f.gets
+              if line.rstrip[-1, 1] == '{'
+                f.until_match(%r{\A//\}})
+              end
             end
+            f.gets
           end
-          f.gets
+          nil
+        rescue ArgumentError => e
+          raise ReVIEW::CompileError, "#{@name}: #{e}"
         end
-        nil
       end
 
       def inspect

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -108,7 +108,7 @@ module ReVIEW
             result_array.push({ part: 'end' })
           end
         end
-      rescue ReVIEW::FileNotFound => e
+      rescue ReVIEW::FileNotFound, ReVIEW::CompileError => e
         @logger.error e
         exit 1
       end

--- a/lib/review/volumeprinter.rb
+++ b/lib/review/volumeprinter.rb
@@ -46,7 +46,7 @@ module ReVIEW
             print_chapter_volume(chap)
           end
         end
-      rescue ReVIEW::FileNotFound => e
+      rescue ReVIEW::FileNotFound, ReVIEW::CompileError => e
         @logger.error e
         exit 1
       end

--- a/test/test_book_chapter.rb
+++ b/test/test_book_chapter.rb
@@ -130,7 +130,8 @@ class ChapterTest < Test::Unit::TestCase
       assert Book::Chapter.new(book, 1, 'chapter1', files['chapter1.re'])
     end
 
-    %w[CP932 SHIFT_JIS EUC-JP UTF-16LE UTF-16BE UTF-32LE UTF-32BE].each do |enc|
+    # UTF-16LE UTF-16BE UTF-32LE UTF-32BE cause error on Windows
+    %w[CP932 SHIFT_JIS EUC-JP].each do |enc|
       mktmpbookdir 'CHAPS' => 'chapter1.re',
                    'chapter1.re' => "= 日本語UTF-8\n".encode(enc) do |_dir, book, files|
         e = assert_raises(ReVIEW::CompileError) { Book::Chapter.new(book, 1, 'chapter1', files['chapter1.re']) }

--- a/test/test_book_chapter.rb
+++ b/test/test_book_chapter.rb
@@ -111,16 +111,31 @@ class ChapterTest < Test::Unit::TestCase
       assert ch1.on_chaps?
       assert !pre.on_chaps?
 
-      ch2_path = File.join(dir, 'chapter2.er')
+      ch2_path = File.join(dir, 'chapter2.re')
       File.open(ch2_path, 'w') {}
       ch2 = Book::Chapter.new(book, 2, 'chapter2', ch2_path)
 
-      ch3_path = File.join(dir, 'chapter3.er')
+      ch3_path = File.join(dir, 'chapter3.re')
       File.open(ch3_path, 'w') {}
       ch3 = Book::Chapter.new(book, 3, 'chapter3', ch3_path)
 
       assert ch2.on_chaps?
       assert !ch3.on_chaps?
+    end
+  end
+
+  def test_invalid_encoding
+    mktmpbookdir 'CHAPS' => 'chapter1.re',
+                 'chapter1.re' => "= 日本語UTF-8\n" do |_dir, book, files|
+      assert Book::Chapter.new(book, 1, 'chapter1', files['chapter1.re'])
+    end
+
+    %w[CP932 SHIFT_JIS EUC-JP UTF-16LE UTF-16BE UTF-32LE UTF-32BE].each do |enc|
+      mktmpbookdir 'CHAPS' => 'chapter1.re',
+                   'chapter1.re' => "= 日本語UTF-8\n".encode(enc) do |_dir, book, files|
+        e = assert_raises(ReVIEW::CompileError) { Book::Chapter.new(book, 1, 'chapter1', files['chapter1.re']) }
+        assert_equal 'chapter1: invalid byte sequence in UTF-8', e.message
+      end
     end
   end
 


### PR DESCRIPTION
#1544 の対処です。
UTF-8以外のエンコーディングファイルを読み込もうとした時点でArgumentErrorが発生するので、その発生箇所でReVIEW::CompileErrorを出し、ツール側ではそれを捕捉するようにしました。
