### PR TITLE
set title to auto built page

### DIFF
--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -156,6 +156,7 @@ module ReVIEW
     end
 
     def build_part(part, basetmpdir, htmlfile)
+      @title = "#{ReVIEW::I18n.t('part', part.number)} #{part.name.strip}"
       File.open("#{basetmpdir}/#{htmlfile}", 'w') do |f|
         @body = ''
         @body << %Q(<div class="part">\n)
@@ -259,6 +260,7 @@ module ReVIEW
     end
 
     def build_indexpage(basetmpdir)
+      @title = 'index'
       File.open("#{basetmpdir}/index.html", 'w') do |f|
         if @config['coverimage']
           file = File.join(@config['imagedir'], @config['coverimage'])
@@ -281,6 +283,7 @@ module ReVIEW
     end
 
     def build_titlepage(basetmpdir, htmlfile)
+      @title = 'titlepage'
       File.open("#{basetmpdir}/#{htmlfile}", 'w') do |f|
         @body = ''
         @body << %Q(<div class="titlepage">)

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -156,7 +156,7 @@ module ReVIEW
     end
 
     def build_part(part, basetmpdir, htmlfile)
-      @title = "#{ReVIEW::I18n.t('part', part.number)} #{part.name.strip}"
+      @title = h("#{ReVIEW::I18n.t('part', part.number)} #{part.name.strip}")
       File.open("#{basetmpdir}/#{htmlfile}", 'w') do |f|
         @body = ''
         @body << %Q(<div class="part">\n)
@@ -260,7 +260,7 @@ module ReVIEW
     end
 
     def build_indexpage(basetmpdir)
-      @title = 'index'
+      @title = h('index')
       File.open("#{basetmpdir}/index.html", 'w') do |f|
         if @config['coverimage']
           file = File.join(@config['imagedir'], @config['coverimage'])
@@ -283,7 +283,7 @@ module ReVIEW
     end
 
     def build_titlepage(basetmpdir, htmlfile)
-      @title = 'titlepage'
+      @title = h('titlepage')
       File.open("#{basetmpdir}/#{htmlfile}", 'w') do |f|
         @body = ''
         @body << %Q(<div class="titlepage">)

--- a/templates/web/html/layout-html5.html.erb
+++ b/templates/web/html/layout-html5.html.erb
@@ -11,7 +11,7 @@
 <% if @next.present? %><link rel="next" title="<%= h(@next_title)%>" href="<%= h(@next.id.to_s+"."+@book.config['htmlext']) %>" /><% end %>
 <% if @prev.present? %><link rel="prev" title="<%= h(@prev_title)%>" href="<%= h(@prev.id.to_s+"."+@book.config['htmlext']) %>" /><% end %>
   <meta name="generator" content="Re:VIEW" />
-  <title><%=h @title %> | <%=h @book.config.name_of("booktitle")%></title>
+  <title><%= @title %> | <%=h @book.config.name_of("booktitle")%></title>
 </head>
 <body<%= @body_ext %>>
   <div class="book">


### PR DESCRIPTION
#1545 の修正

普通のページはHTMLBuilderの働きで `@title` が入るのだけど、

- WebMaker固有で作っているindex, titlepage, part(文字列のみしかない部)については`@title`を定義していなかった。これにより、最初のindexのところでnilをエスケープしようとしてエラーになっていた。
- HTMLBuilderが作る `@title`はエスケープ済みだが、templates側でエスケープして二重になっていた
