### PR TITLE
parsing catalog.yml is not lazy

### DIFF
--- a/lib/review/catalog.rb
+++ b/lib/review/catalog.rb
@@ -89,7 +89,7 @@ module ReVIEW
         filenames.concat(postdef)
       end
       filenames.each do |filename|
-        refile = File.join(basedir, config['contentdir'], filename)
+        refile = File.expand_path(File.join(config['contentdir'], filename), basedir)
         unless File.exist?(refile)
           raise FileNotFound, "file not found in catalog.yml: #{refile}"
         end

--- a/test/book_test_helper.rb
+++ b/test/book_test_helper.rb
@@ -13,12 +13,19 @@ module BookTestHelper
     Dir.mktmpdir do |tmpdir|
       Dir.chdir(tmpdir) do
         dir = '.'
-        files.each_pair do |basename, content|
-          path = File.join(dir, basename)
+        files.each_pair do |filename, content|
+          path = File.join(dir, filename)
+          FileUtils.mkdir_p(File.dirname(path))
           File.open(path, 'w') { |o| o.print content }
-          created_files[basename] = path
+          created_files[filename] = path
         end
-        book = Book::Base.load(dir, config: ReVIEW::Configure.values)
+        conf_path = File.expand_path('config.yml', dir)
+        if File.exist?(conf_path)
+          config = ReVIEW::Configure.create(yamlfile: conf_path)
+        else
+          config = ReVIEW::Configure.values
+        end
+        book = Book::Base.load(dir, config: config)
         yield(dir, book, created_files)
       end
     end

--- a/test/test_book.rb
+++ b/test/test_book.rb
@@ -560,12 +560,9 @@ EOC
   end
 
   def test_contentdir
-    mktmpbookdir('config.yml' => "contentdir: content\n", 'catalog.yml' => "CHAPS:\n - ch01.re\n") do |dir, _book, _files|
-      Dir.mkdir('content')
-      File.open('content/ch01.re', 'w') { |f| f.puts "foo\n" }
-      book = Book::Base.new(dir)
-      config_file = File.join(dir, 'config.yml')
-      book.load_config(config_file)
+    mktmpbookdir('config.yml' => "contentdir: content\n",
+                 'catalog.yml' => "CHAPS:\n - ch01.re\n",
+                 'content/ch01.re' => "foo\n") do |_dir, book, _files|
       assert_equal "foo\n", book.chapters[0].content
     end
   end
@@ -578,19 +575,13 @@ EOC
   end
 
   def test_page_metric_config
-    mktmpbookdir('config.yml' => "bookname: book\npage_metric: B5\n") do |dir, _book, _files|
-      book = Book::Base.new(dir)
-      config_file = File.join(dir, 'config.yml')
-      book.load_config(config_file)
+    mktmpbookdir('config.yml' => "bookname: book\npage_metric: B5\n") do |_dir, book, _files|
       assert_equal ReVIEW::Book::PageMetric::B5, book.page_metric
     end
   end
 
   def test_page_metric_config_array
-    mktmpbookdir('config.yml' => "bookname: book\npage_metric: [50, 40, 36, 40, 1]\n") do |dir, _book, _files|
-      book = Book::Base.new(dir)
-      config_file = File.join(dir, 'config.yml')
-      book.load_config(config_file)
+    mktmpbookdir('config.yml' => "bookname: book\npage_metric: [50, 40, 36, 40, 1]\n") do |_dir, book, _files|
       assert_equal ReVIEW::Book::PageMetric::B5, book.page_metric
     end
   end


### PR DESCRIPTION
* add `Base#parse_catalog_file()` and use it in `ReVIEW::Book::Base.new()`.
  `Base#catalog` is just getter now.
* fix some tests because timing of parse config.yml and catalog.yml are changed.