### PR TITLE
add defminicolumn

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -19,7 +19,7 @@ module ReVIEW
   class Builder
     include TextUtils
 
-    CAPTION_TITLES = %w[note memo tip info warning important caution notice].freeze
+    CAPTION_TITLES = Compiler.minicolumn_names
 
     def pre_paragraph
       nil

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -73,12 +73,16 @@ module ReVIEW
         end
       end
 
+      def minicolumn?
+        @type == :minicolumn
+      end
+
       def block_required?
-        @type == :block
+        @type == :block or @type == :minicolumn
       end
 
       def block_allowed?
-        @type == :block or @type == :optional
+        @type == :block or @type == :optional or @type == :minicolumn
       end
     end
 
@@ -86,6 +90,10 @@ module ReVIEW
 
     def self.defblock(name, argc, optional = false, &block)
       defsyntax(name, (optional ? :optional : :block), argc, &block)
+    end
+
+    def self.defminicolumn(name, argc, _optional = false, &block)
+      defsyntax(name, :minicolumn, argc, &block)
     end
 
     def self.defsingle(name, argc, &block)
@@ -98,6 +106,16 @@ module ReVIEW
 
     def self.definline(name)
       INLINE[name] = InlineSyntaxElement.new(name)
+    end
+
+    def self.minicolumn_names
+      buf = []
+      SYNTAX.each do |name, syntax|
+        if syntax.minicolumn?
+          buf << name.to_s
+        end
+      end
+      buf
     end
 
     def syntax_defined?(name)
@@ -148,17 +166,18 @@ module ReVIEW
     defblock :bpo, 0
     defblock :flushright, 0
     defblock :centering, 0
-    defblock :note, 0..1
-    defblock :memo, 0..1
-    defblock :info, 0..1
-    defblock :important, 0..1
-    defblock :caution, 0..1
-    defblock :notice, 0..1
-    defblock :warning, 0..1
-    defblock :tip, 0..1
     defblock :box, 0..1
     defblock :comment, 0..1, true
     defblock :embed, 0..1
+
+    defminicolumn :note, 0..1
+    defminicolumn :memo, 0..1
+    defminicolumn :tip, 0..1
+    defminicolumn :info, 0..1
+    defminicolumn :warning, 0..1
+    defminicolumn :important, 0..1
+    defminicolumn :caution, 0..1
+    defminicolumn :notice, 0..1
 
     defsingle :footnote, 2
     defsingle :noindent, 0

--- a/lib/review/index_builder.rb
+++ b/lib/review/index_builder.rb
@@ -13,8 +13,6 @@ require 'review/sec_counter'
 
 module ReVIEW
   class IndexBuilder < Builder
-    CAPTION_TITLES = %w[note memo tip info warning important caution notice box].freeze
-
     attr_reader :list_index, :table_index, :equation_index, :footnote_index,
                 :numberless_image_index, :image_index, :icon_index, :indepimage_index,
                 :headline_index, :column_index, :bibpaper_index
@@ -595,14 +593,6 @@ module ReVIEW
 
     def captionblock(_type, _lines, _caption, _specialstyle = nil)
       ''
-    end
-
-    CAPTION_TITLES.each do |name|
-      class_eval %Q(
-        def #{name}(lines, caption = nil)
-          captionblock("#{name}", lines, caption)
-        end
-      ), __FILE__, __LINE__ - 4
     end
 
     def tsize(_str)


### PR DESCRIPTION
minicolumnの定義にはblockの定義とは別のメソッドを使うようにして、後から追加しやすくするものです。