### PR TITLE
remove a method `Builder#builder_init()`

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -31,18 +31,13 @@ module ReVIEW
 
     attr_accessor :doc_status
 
-    def initialize(strict = false, *args)
+    def initialize(strict = false, *_args)
       @strict = strict
       @output = nil
       @logger = ReVIEW.logger
       @doc_status = {}
       @dictionary = {}
-      builder_init(*args)
     end
-
-    def builder_init(*args)
-    end
-    private :builder_init
 
     def bind(compiler, chapter, location)
       @compiler = compiler

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -41,10 +41,6 @@ module ReVIEW
       ".#{@book.config['htmlext']}"
     end
 
-    def builder_init
-    end
-    private :builder_init
-
     def builder_init_file
       @noindent = nil
       @ol_num = nil

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -46,10 +46,6 @@ module ReVIEW
       '.xml'
     end
 
-    def builder_init
-    end
-    private :builder_init
-
     def builder_init_file
       @warns = []
       @errors = []

--- a/test/test_review_ext.rb
+++ b/test/test_review_ext.rb
@@ -11,7 +11,8 @@ class ReviewExtTest < Test::Unit::TestCase
 module ReVIEW
   class HTMLBuilder
     attr_reader :builder_init_test
-    def builder_init
+    def initialize(strict = false)
+      super
       @builder_init_test = "test"
     end
   end


### PR DESCRIPTION
When you want to do something in `*Builder.new`, define the method `initialize` and use `super` in it.