### PR TITLE
do not allow tricky id used as path; fix #1393

### DIFF
--- a/lib/review/book/index/item.rb
+++ b/lib/review/book/index/item.rb
@@ -32,7 +32,16 @@ module ReVIEW
         alias_method :content, :caption
 
         def path
-          @path ||= @index.find_path(id)
+          if @path
+            return @path
+          end
+
+          unless @id =~ /\A[A-Za-z0-9_:=+\-()|]+\z/
+            raise ReVIEW::SyntaxError, "invalid ID character for path: `#{@id}`"
+          end
+          @path = @index.find_path(@id)
+
+          @path
         end
       end
     end

--- a/lib/review/book/index/item.rb
+++ b/lib/review/book/index/item.rb
@@ -36,7 +36,7 @@ module ReVIEW
             return @path
           end
 
-          unless @id =~ /\A[A-Za-z0-9_:=+\-()|]+\z/
+          if @id =~ /\s/
             raise ReVIEW::SyntaxError, "invalid ID character for path: `#{@id}`"
           end
           @path = @index.find_path(@id)

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -665,23 +665,16 @@ EOS
     assert_equal expected, actual
   end
 
-  def test_image_with_tricky_id
-    def @chapter.image(_id)
-      item = Book::Index::Item.new('123 あ_;', 1)
-      item.instance_eval { @path = './images/chap1-123 あ_;.png' }
-      item
+  def test_image_with_tricky_id_kana
+    assert_raise(ReVIEW::SyntaxError) do
+      _result = compile_block("//image[123あいう][sample photo]{\n//}\n")
     end
+  end
 
-    actual = compile_block("//image[123 あ_;][sample photo]{\n//}\n")
-    expected = <<-EOS
-<div id="id_123-_E3_81_82___3B" class="image">
-<img src="images/chap1-123 あ_;.png" alt="sample photo" />
-<p class="caption">
-図1.1: sample photo
-</p>
-</div>
-EOS
-    assert_equal expected, actual
+  def test_image_with_tricky_id_space
+    assert_raise(ReVIEW::SyntaxError) do
+      _result = compile_block("//image[123 abc][sample photo]{\n//}\n")
+    end
   end
 
   def test_indepimage

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -666,9 +666,23 @@ EOS
   end
 
   def test_image_with_tricky_id_kana
-    assert_raise(ReVIEW::SyntaxError) do
-      _result = compile_block("//image[123あいう][sample photo]{\n//}\n")
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('123あいう', 1)
+      item.instance_eval { @path = './images/123あいう.png' }
+      item
     end
+    @chapter.instance_eval { @name = 'ch01' }
+    actual = compile_block("//image[123あいう][sample photo]{\n//}\nimg: @<img>{123あいう}\n")
+    expected = <<-EOS
+<div id="id_123_E3_81_82_E3_81_84_E3_81_86" class="image">
+<img src="images/123あいう.png" alt="sample photo" />
+<p class="caption">
+図1.1: sample photo
+</p>
+</div>
+<p>img: <span class="imgref"><a href="./ch01.html#id_123_E3_81_82_E3_81_84_E3_81_86">図1.1</a></span></p>
+EOS
+    assert_equal expected, actual
   end
 
   def test_image_with_tricky_id_space


### PR DESCRIPTION
path characters: `A-Z` + `a-z` + `0-9` + `_:=+-()|`