### PR TITLE
markdown: paragraph separator should be empty line

### DIFF
--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -155,7 +155,7 @@ module ReVIEW
       puts %Q(<div class="#{type}">)
       puts %Q(<p class="caption">#{compile_inline(caption)}</p>) if caption.present?
       blocked_lines = split_paragraph(lines)
-      puts blocked_lines.join("\n")
+      puts blocked_lines.join("\n\n")
       puts '</div>'
     end
 

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -48,6 +48,7 @@ EOS
 <div class="memo">
 <p class="caption">this is **test**<&>_</p>
 test1
+
 test*2*
 </div>
 EOS


### PR DESCRIPTION
Markdownのcaptionblock内で、paragraphを（改行区切りではなく）空行区切りに修正します。