### PR TITLE
ID類のチェック

### DIFF
--- a/lib/epubmaker/content.rb
+++ b/lib/epubmaker/content.rb
@@ -78,7 +78,7 @@ module EPUBMaker
       if @id =~ /\A[^a-z]/i
         @id = "rv-#{@id}"
       end
-      @id = CGI.escape(@id).gsub('%', '_RVPERCENT_')
+      @id = CGI.escape(@id).gsub('%', '_25_')
 
       if !@file.nil? && @media.nil?
         @media = @file.sub(/.+\./, '').downcase

--- a/lib/epubmaker/content.rb
+++ b/lib/epubmaker/content.rb
@@ -1,6 +1,6 @@
 # = content.rb -- Content object for EPUBMaker.
 #
-# Copyright (c) 2010-2017 Kenshi Muto
+# Copyright (c) 2010-2020 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of

--- a/lib/epubmaker/content.rb
+++ b/lib/epubmaker/content.rb
@@ -78,7 +78,7 @@ module EPUBMaker
       if @id =~ /\A[^a-z]/i
         @id = "rv-#{@id}"
       end
-      @id = CGI.escape(@id)
+      @id = CGI.escape(@id).gsub('%', '_RVPERCENT_')
 
       if !@file.nil? && @media.nil?
         @media = @file.sub(/.+\./, '').downcase

--- a/lib/review/book/index/item.rb
+++ b/lib/review/book/index/item.rb
@@ -36,9 +36,6 @@ module ReVIEW
             return @path
           end
 
-          if @id =~ /\s/
-            raise ReVIEW::SyntaxError, "invalid ID character for path: `#{@id}`"
-          end
           @path = @index.find_path(@id)
 
           @path

--- a/lib/review/index_builder.rb
+++ b/lib/review/index_builder.rb
@@ -21,6 +21,12 @@ module ReVIEW
       super
     end
 
+    def check_id(id)
+      if id && (id =~ %r![#%\\{}~/$'"|*?<>`\s]! || id.start_with?('.'))
+        warn "unsafe ID character: `#{id}`"
+      end
+    end
+
     def pre_paragraph
       ''
     end
@@ -72,6 +78,7 @@ module ReVIEW
     end
 
     def headline(level, label, caption)
+      check_id(label)
       @sec_counter.inc(level)
       return if level < 2
 
@@ -93,6 +100,7 @@ module ReVIEW
     end
 
     def nonum_begin(level, label, caption)
+      check_id(label)
       return if level < 2
 
       cursor = level - 2
@@ -116,6 +124,7 @@ module ReVIEW
     end
 
     def notoc_begin(level, label, caption)
+      check_id(label)
       return if level < 2
 
       cursor = level - 2
@@ -139,6 +148,7 @@ module ReVIEW
     end
 
     def nodisp_begin(level, label, caption)
+      check_id(label)
       return if level < 2
 
       cursor = level - 2
@@ -162,6 +172,7 @@ module ReVIEW
     end
 
     def column_begin(_level, label, caption)
+      check_id(label)
       item_id = label || caption
       item = ReVIEW::Book::Index::Item.new(item_id, @column_index.size + 1, caption)
       @column_index.add_item(item)
@@ -170,13 +181,15 @@ module ReVIEW
     def column_end(_level)
     end
 
-    def xcolumn_begin(level, label, caption)
+    def xcolumn_begin(_level, label, _caption)
+      check_id(label)
     end
 
     def xcolumn_end(_level)
     end
 
-    def sup_begin(level, label, caption)
+    def sup_begin(_level, label, _caption)
+      check_id(label)
     end
 
     def sup_end(_level)
@@ -232,6 +245,7 @@ module ReVIEW
     alias_method :lead, :read
 
     def list(_lines, id, _caption, _lang = nil)
+      check_id(id)
       item = ReVIEW::Book::Index::Item.new(id, @list_index.size + 1)
       @list_index.add_item(item)
     end
@@ -240,6 +254,7 @@ module ReVIEW
     end
 
     def listnum(_lines, id, _caption, _lang = nil)
+      check_id(id)
       item = ReVIEW::Book::Index::Item.new(id, @list_index.size + 1)
       @list_index.add_item(item)
     end
@@ -257,11 +272,13 @@ module ReVIEW
     end
 
     def image(_lines, id, caption, _metric = nil)
+      check_id(id)
       item = ReVIEW::Book::Index::Item.new(id, @image_index.size + 1, caption)
       @image_index.add_item(item)
     end
 
     def table(_lines, id = nil, caption = nil)
+      check_id(id)
       if id
         item = ReVIEW::Book::Index::Item.new(id, @table_index.size + 1, caption)
         @table_index.add_item(item)
@@ -277,6 +294,7 @@ module ReVIEW
     end
 
     def imgtable(_lines, id, _caption = nil, _metric = nil)
+      check_id(id)
       item = ReVIEW::Book::Index::Item.new(id, @table_index.size + 1)
       @table_index.add_item(item)
 
@@ -286,16 +304,19 @@ module ReVIEW
     end
 
     def footnote(id, str)
+      check_id(id)
       item = ReVIEW::Book::Index::Item.new(id, @footnote_index.size + 1, str)
       @footnote_index.add_item(item)
     end
 
     def indepimage(_lines, id, _caption = '', _metric = nil)
+      check_id(id)
       item = ReVIEW::Book::Index::Item.new(id, @indepimage_index.size + 1)
       @indepimage_index.add_item(item)
     end
 
     def numberlessimage(_lines, id, _caption = '', _metric = nil)
+      check_id(id)
       item = ReVIEW::Book::Index::Item.new(id, @indepimage_index.size + 1)
       @indepimage_index.add_item(item)
     end
@@ -303,7 +324,8 @@ module ReVIEW
     def hr
     end
 
-    def label(_id)
+    def label(id)
+      check_id(id)
     end
 
     def blankline
@@ -440,6 +462,7 @@ module ReVIEW
     end
 
     def bibpaper(_lines, id, caption)
+      check_id(id)
       item = ReVIEW::Book::Index::Item.new(id, @bibpaper_index.size + 1, caption)
       @bibpaper_index.add_item(item)
     end
@@ -553,6 +576,7 @@ module ReVIEW
     end
 
     def inline_icon(id)
+      check_id(id)
       item = ReVIEW::Book::Index::Item.new(id, @icon_index.size + 1)
       @icon_index.add_item(item)
       ''
@@ -583,6 +607,7 @@ module ReVIEW
     end
 
     def texequation(_lines, id = nil, _caption = '')
+      check_id(id)
       if id
         item = ReVIEW::Book::Index::Item.new(id, @equation_index.size + 1)
         @equation_index.add_item(item)

--- a/lib/review/index_builder.rb
+++ b/lib/review/index_builder.rb
@@ -23,7 +23,7 @@ module ReVIEW
 
     def check_id(id)
       if id
-        if id =~ %r![#%\\{}~/$'"|*?&<>`\s]!
+        if id =~ %r![#%\\{}\[\]~/$'"|*?&<>`\s]!
           warn "deprecated ID: `#{$&}` in `#{id}`"
         elsif id.start_with?('.')
           warn "deprecated ID: `#{id}` begins from `.`"

--- a/lib/review/index_builder.rb
+++ b/lib/review/index_builder.rb
@@ -22,8 +22,12 @@ module ReVIEW
     end
 
     def check_id(id)
-      if id && (id =~ %r![#%\\{}~/$'"|*?<>`\s]! || id.start_with?('.'))
-        warn "unsafe ID character: `#{id}`"
+      if id
+        if id =~ %r![#%\\{}~/$'"|*?&<>`\s]!
+          warn "deprecated ID: `#{$&}` in `#{id}`"
+        elsif id.start_with?('.')
+          warn "deprecated ID: `#{id}` begins from `.`"
+        end
       end
     end
 

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -824,6 +824,6 @@ EOT
     content = Content.new({ 'file' => 'sample.png' })
     assert_equal 'sample-png', content.id
     content = Content.new({ 'file' => 'sample-&()-=+@:,漢字.png' })
-    assert_equal 'sample-%26%28%29-%3D%2B%40%3A%2C%E6%BC%A2%E5%AD%97-png', content.id
+    assert_equal 'sample-_RVPERCENT_26_RVPERCENT_28_RVPERCENT_29-_RVPERCENT_3D_RVPERCENT_2B_RVPERCENT_40_RVPERCENT_3A_RVPERCENT_2C_RVPERCENT_E6_RVPERCENT_BC_RVPERCENT_A2_RVPERCENT_E5_RVPERCENT_AD_RVPERCENT_97-png', content.id
   end
 end

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -824,6 +824,6 @@ EOT
     content = Content.new({ 'file' => 'sample.png' })
     assert_equal 'sample-png', content.id
     content = Content.new({ 'file' => 'sample-&()-=+@:,漢字.png' })
-    assert_equal 'sample-_RVPERCENT_26_RVPERCENT_28_RVPERCENT_29-_RVPERCENT_3D_RVPERCENT_2B_RVPERCENT_40_RVPERCENT_3A_RVPERCENT_2C_RVPERCENT_E6_RVPERCENT_BC_RVPERCENT_A2_RVPERCENT_E5_RVPERCENT_AD_RVPERCENT_97-png', content.id
+    assert_equal 'sample-_25_26_25_28_25_29-_25_3D_25_2B_25_40_25_3A_25_2C_25_E6_25_BC_25_A2_25_E5_25_AD_25_97-png', content.id
   end
 end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -106,8 +106,8 @@ class HTMLBuidlerTest < Test::Unit::TestCase
   end
 
   def test_headline_level1_with_tricky_id
-    actual = compile_block("={123 あ_;} this is test.\n")
-    assert_equal %Q(<h1 id="id_123-_E3_81_82___3B"><a id="h1"></a><span class="secno">第1章　</span>this is test.</h1>\n), actual
+    actual = compile_block("={123あ_} this is test.\n")
+    assert_equal %Q(<h1 id="id_123_E3_81_82__"><a id="h1"></a><span class="secno">第1章　</span>this is test.</h1>\n), actual
   end
 
   def test_headline_level1_with_inlinetag
@@ -137,8 +137,8 @@ class HTMLBuidlerTest < Test::Unit::TestCase
   end
 
   def test_label_with_tricky_id
-    actual = compile_block("//label[123 あ_;]\n")
-    assert_equal %Q(<a id="id_123-_E3_81_82___3B"></a>\n), actual
+    actual = compile_block("//label[123あ_]\n")
+    assert_equal %Q(<a id="id_123_E3_81_82__"></a>\n), actual
   end
 
   def test_href
@@ -2203,9 +2203,9 @@ EOS
   end
 
   def test_footnote_with_tricky_id
-    actual = compile_block("//footnote[123 あ_;][bar\\a\\$buz]\n")
+    actual = compile_block("//footnote[123あ_;][bar\\a\\$buz]\n")
     expected = <<-'EOS'
-<div class="footnote" epub:type="footnote" id="fn-id_123-_E3_81_82___3B"><p class="footnote">[*1] bar\a\$buz</p></div>
+<div class="footnote" epub:type="footnote" id="fn-id_123_E3_81_82___3B"><p class="footnote">[*1] bar\a\$buz</p></div>
 EOS
     assert_equal expected, actual
   end

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -685,12 +685,6 @@ EOS
     assert_equal expected, actual
   end
 
-  def test_image_with_tricky_id_space
-    assert_raise(ReVIEW::SyntaxError) do
-      _result = compile_block("//image[123 abc][sample photo]{\n//}\n")
-    end
-  end
-
   def test_indepimage
     def @chapter.image(_id)
       item = Book::Index::Item.new('sampleimg', 1)

--- a/test/test_indexbuilder.rb
+++ b/test/test_indexbuilder.rb
@@ -1,0 +1,52 @@
+require 'test_helper'
+require 'review/builder'
+
+require 'review/book'
+
+class MockCompiler
+  def text(s)
+    [:text, s]
+  end
+end
+
+class IndexBuidlerTest < Test::Unit::TestCase
+  include ReVIEW
+
+  def setup
+    @b = IndexBuilder.new
+    chap = ReVIEW::Book::Chapter.new(nil, nil, '-', nil)
+    @b.bind(MockCompiler.new, chap, nil)
+  end
+
+  def test_initialize
+    assert IndexBuilder.new
+  end
+
+  def test_check_id
+    io = StringIO.new
+    @b.instance_eval{ @logger = ReVIEW::Logger.new(io) }
+    @b.check_id('ABC')
+    assert_match('', io.string)
+
+    %w(# % \\ { } [ ] ~ / $ ' " | * ? & < > `).each do |c|
+      io = StringIO.new
+      @b.instance_eval{ @logger = ReVIEW::Logger.new(io) }
+      @b.check_id("id#{c}")
+      assert_match(/deprecated ID: `#{Regexp.escape(c)}` in `id#{Regexp.escape(c)}`/, io.string)
+    end
+    io = StringIO.new
+    @b.instance_eval{ @logger = ReVIEW::Logger.new(io) }
+    @b.check_id('A B C#')
+    assert_match(/deprecated ID: ` ` in `A B C#`/, io.string)
+
+    io = StringIO.new
+    @b.instance_eval{ @logger = ReVIEW::Logger.new(io) }
+    @b.check_id("A\tB")
+    assert_match(/deprecated ID: `\t` in `A\tB`/, io.string)
+
+    io = StringIO.new
+    @b.instance_eval{ @logger = ReVIEW::Logger.new(io) }
+    @b.check_id('.ABC')
+    assert_match(/deprecated ID: `.ABC` begins from `.`/, io.string)
+  end
+end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1276,7 +1276,7 @@ EOS
 
   def test_indepimage_nofile
     def @chapter.image(_id)
-      item = Book::Index::Item.new('sample_img#&', 1)
+      item = Book::Index::Item.new('sample_img_nofile_', 1)
       item.instance_eval do
         def path
           nil
@@ -1288,15 +1288,15 @@ EOS
     io = StringIO.new
     @builder.instance_eval{ @logger = ReVIEW::Logger.new(io) }
 
-    actual = compile_block("//indepimage[sample_img#&][sample photo]\n")
+    actual = compile_block("//indepimage[sample_img_nofile_][sample photo]\n")
     expected = <<-EOS
 \\begin{reviewdummyimage}
---[[path = sample\\textunderscore{}img\\#\\& (not exist)]]--
+--[[path = sample\\textunderscore{}img\\textunderscore{}nofile\\textunderscore{} (not exist)]]--
 \\reviewindepimagecaption{図: sample photo}
 \\end{reviewdummyimage}
 EOS
     assert_equal expected, actual
-    assert_match(/WARN --: :1: image not bound: sample_img#&/, io.string)
+    assert_match(/WARN --: :1: image not bound: sample_img_nofile_/, io.string)
   end
 
   def test_table


### PR DESCRIPTION
#1574 の対応

IndexBuilderをこういう使い方にしてよいのかというところはありますが、idあるいはラベルをとったときに検証しやすいので、ここにcheck_idメソッドを立てて、安全なIDかどうかをチェックするようにしています。WARNにしましたがERRORでもいいかも。

今はまだ残していますが、このやり方だと、item.rbのほうのチェックは不要になりそうです(itemのほうはファイルパスにしか効かないですし)。

方針的によさそうであればテストを追加します。