### PR TITLE
escape unsafe character in EPUB ID

### DIFF
--- a/lib/epubmaker/content.rb
+++ b/lib/epubmaker/content.rb
@@ -1,6 +1,6 @@
 # = content.rb -- Content object for EPUBMaker.
 #
-# Copyright (c) 2010-2017 Kenshi Muto
+# Copyright (c) 2010-2020 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -78,6 +78,7 @@ module EPUBMaker
       if @id =~ /\A[^a-z]/i
         @id = "rv-#{@id}"
       end
+      @id = CGI.escape(@id)
 
       if !@file.nil? && @media.nil?
         @media = @file.sub(/.+\./, '').downcase

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -819,4 +819,11 @@ EOT
 EOT
     assert_equal expect, @output.string
   end
+
+  def test_epub_unsafe_id
+    content = Content.new({ 'file' => 'sample.png' })
+    assert_equal 'sample-png', content.id
+    content = Content.new({ 'file' => 'sample-&()-=+@:,漢字.png' })
+    assert_equal 'sample-%26%28%29-%3D%2B%40%3A%2C%E6%BC%A2%E5%AD%97-png', content.id
+  end
 end


### PR DESCRIPTION
#1574 の対応
EPUBのほうでのitem IDまわりでの文字についてはCGI.escapeを使ったエスケープをするようにします。
