### PR TITLE
意図しない制御コード文字をエラーにする

### DIFF
--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -85,6 +85,8 @@ module ReVIEW
           nil
         rescue ArgumentError => e
           raise ReVIEW::CompileError, "#{@name}: #{e}"
+        rescue SyntaxError => e
+          raise ReVIEW::SyntaxError, "#{@name}:#{f.lineno}: #{e}"
         end
       end
 

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -333,6 +333,8 @@ module ReVIEW
         end
       end
       close_all_tagged_section
+    rescue SyntaxError => e
+      error e
     end
 
     def compile_minicolumn_begin(name, caption = nil)

--- a/lib/review/lineinput.rb
+++ b/lib/review/lineinput.rb
@@ -13,5 +13,21 @@ module ReVIEW
       end
       n
     end
+
+    def gets
+      unless @buf.empty?
+        @lineno += 1
+        return @buf.pop
+      end
+      return nil if @eof_p # to avoid ARGF blocking.
+      line = @input.gets
+      @eof_p = true unless line
+      @lineno += 1
+      if line =~ /[\x00-\x08]/ || line =~ /[\x0b-\x0c]/ || line =~ /[\x0e-\x1f]/
+        # accept 0x09: TAB, 0x0a: LF, 0x0d: CR
+        raise SyntaxError, "found invalid control-sequence character (#{sprintf('%#x', $&.codepoints[0])})."
+      end
+      line
+    end
   end
 end

--- a/test/test_lineinput.rb
+++ b/test/test_lineinput.rb
@@ -1,5 +1,6 @@
 require 'test_helper'
-require 'lineinput'
+require 'review/lineinput'
+require 'review/exception'
 require 'tempfile'
 require 'stringio'
 
@@ -177,5 +178,19 @@ class LineInputTest < Test::Unit::TestCase
     data = li.getblock(%r<\A//\}>)
     assert_equal ["abc\n", "def\n"], data
     assert_equal 3, li.lineno
+  end
+
+  def test_invalid_control_sequence
+    0.upto(31) do |n|
+      content = n.chr
+      io = StringIO.new(content)
+      li = ReVIEW::LineInput.new(io)
+      if [9, 10, 13].include?(n) # TAB, LF, CR
+        assert_equal content, li.gets
+      else
+        e = assert_raise(ReVIEW::SyntaxError) { li.gets }
+        assert_match(/found invalid control/, e.message)
+      end
+    end
   end
 end


### PR DESCRIPTION
#1596 の対処です。
TAB, LF, CR以外のASCII制御コード文字はUTF-8ドキュメント内で登場することはないはずなので、読み込み時に発見したらエラーにします。

例外はSyntaxErrorを使うことにしました。
