### PR TITLE
call after_makeindex hook just after running mendex

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -244,9 +244,9 @@ module ReVIEW
         call_hook('hook_beforemakeindex')
         if @config['pdfmaker']['makeindex'] && File.size?("#{@mastertex}.idx")
           system_or_raise(*[makeindex_command, makeindex_options, @mastertex].flatten.compact)
+          call_hook('hook_aftermakeindex')
           system_or_raise(*[texcommand, texoptions, "#{@mastertex}.tex"].flatten.compact)
         end
-        call_hook('hook_aftermakeindex')
 
         system_or_raise(*[texcommand, texoptions, "#{@mastertex}.tex"].flatten.compact)
         call_hook('hook_aftertexcompile')


### PR DESCRIPTION
PDFMakerのafter_makeindexフックは、mendex実行のあとにind書き換えをするために呼び出すものなのに、コンパイルが走ってしまってから呼び出す形になってしまっていました(これでは修正が効かない)。
mendex実行後すぐに呼び出すように変更します。
