### PR TITLE
脚注が泣き別れしないようにする

### DIFF
--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -333,5 +333,8 @@
   \fi
 }
 
+%% 脚注がページをまたいで泣き別れさせない
+\interfootnotelinepenalty\@M
+
 \listfiles
 \endinput

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -492,5 +492,8 @@
 \def\coverpagezero#1{\expandafter\@coverpagezero\csname c@#1\endcsname}
 \def\@coverpagezero#1{cover}
 
+%% 脚注がページをまたいで泣き別れさせない
+\interfootnotelinepenalty\@M
+
 \listfiles
 \endinput


### PR DESCRIPTION
#1607 の対応

おおむねこの設定で脚注が別れることはないはず。たくさんあったりすると挙動が変になるかもしれないが、それはかなり特殊な文章ということで自分で設定を直してもらう…。
