### PR TITLE
migrate_parameters should be an instance method

### DIFF
--- a/bin/review-compile
+++ b/bin/review-compile
@@ -126,7 +126,7 @@ def parse_opts
   opts.on('--chapref="before,middle,after"', 'Chapref decoration. (idgxml)') { |cdec| @config['chapref'] = cdec }
   opts.on('--chapterlink', 'make chapref hyperlink') { @config['chapterlink'] = true }
   opts.on('--stylesheet=file', 'Stylesheet file for HTML (comma separated)') { |files| @config['stylesheet'] = files.split(/\s*,\s*/) }
-  opts.on('--mathml', 'Use MathML for TeX equation in HTML') { @config['mathml'] = true }
+  opts.on('--mathml', 'Use MathML for TeX equation in HTML') { @config['math_format'] = 'mathml' }
   opts.on('--htmlversion=VERSION', 'HTML version.') do |v|
     v = v.to_i
     @config['htmlversion'] = v if [4, 5].include?(v)

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -130,29 +130,28 @@ module ReVIEW
           error "yaml error #{e.message}"
         end
       end
-      conf = migrate_parameters(conf)
 
       # YAML configs will be overridden by command line options.
       if config
         conf.deep_merge!(config)
       end
 
+      conf.migrate_parameters
+
       conf
     end
 
-    def self.migrate_parameters(conf)
+    def migrate_parameters
       # backward compatibility
-      if conf['mathml']
+      if self['mathml']
         warn '"mathml: true" is obsoleted. Please use "math_format: mathml"'
-        conf['math_format'] = 'mathml'
+        self['math_format'] = 'mathml'
       end
 
-      if conf['imgmath']
+      if self['imgmath']
         warn '"imgmath: true" is obsoleted. Please use "math_format: imgmath"'
-        conf['math_format'] = 'imgmath'
+        self['math_format'] = 'imgmath'
       end
-
-      conf
     end
 
     def [](key)


### PR DESCRIPTION
and apply this migration to command line options

`--mathml` オプションなどもあったので、`migrate_parameters` は最後に行うのが正しいようでした。