### PR TITLE
introduce reviewchapref to avoid escaping in dt

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -1045,7 +1045,7 @@ module ReVIEW
     def inline_chapref(id)
       title = super
       if @book.config['chapterlink']
-        "\\hyperref[chap:#{id}]{#{title}}"
+        "\\reviewchapref{#{title}}{chap:#{id}}"
       else
         title
       end
@@ -1056,7 +1056,7 @@ module ReVIEW
 
     def inline_chap(id)
       if @book.config['chapterlink']
-        "\\hyperref[chap:#{id}]{#{@book.chapter_index.number(id)}}"
+        "\\reviewchapref{#{@book.chapter_index.number(id)}}{chap:#{id}}"
       else
         @book.chapter_index.number(id)
       end
@@ -1068,7 +1068,7 @@ module ReVIEW
     def inline_title(id)
       title = super
       if @book.config['chapterlink']
-        "\\hyperref[chap:#{id}]{#{title}}"
+        "\\reviewchapref{#{title}}{chap:#{id}}"
       else
         title
       end

--- a/samples/syntax-book/ch02.re
+++ b/samples/syntax-book/ch02.re
@@ -339,6 +339,19 @@ labelで定義したラベルへの参照の例です。EPUBだと@<href>{#inlin
 #@# FIXME:EPUB側にTeXのほうを寄せるようにRe:VIEWコードを直す
 #@# FIXME:TeXではpagerefがほしい、ということがありそう。EPUBとの整合性を検討
 
+説明箇条書きはTeXで特殊な扱いをしているため、参照の確認を以下でしておきます。
+
+ : @<chap>{ch01}
+	章番号
+ : @<title>{ch01}
+	章題
+ : @<chapref>{ch01}
+	章番号+題
+ : @<hd>{ch02|crossref}
+	節
+ : @<column>{ch03|column2}
+	コラム参照
+
 === 参考文献
 参考文献@<tt>{bib.re}ファイルへの文献参照は、@<bib>{lins}とします。
 

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -116,6 +116,9 @@
   \ifdefined\covermatter\else% for 4.0.0 compatibility
     \def\covermatter{}
   \fi
+  \ifdefined\reviewchapref\else% for 5.1.0 compatibility
+    \newcommand{\reviewchapref}[2]{\hyperref[##2]{##1}}
+  \fi
 }
 
 \makeatother

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -137,6 +137,7 @@
 \newcommand{\reviewequationref}[1]{\review@intn@equation #1}
 \newcommand{\reviewbibref}[2]{\hyperref[#2]{#1}}
 \newcommand{\reviewcolumnref}[2]{#1}% XXX:ハイパーリンクにはreviewcolumn側の調整が必要
+\newcommand{\reviewchapref}[2]{\hyperref[#2]{#1}}
 \newcommand{\reviewsecref}[2]{\hyperref[#2]{#1}}
 
 \renewcommand{\contentsname}{\review@toctitle}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -200,6 +200,7 @@
 \newcommand{\reviewequationref}[1]{\review@intn@equation #1}
 \newcommand{\reviewbibref}[2]{\hyperref[#2]{#1}}
 \newcommand{\reviewcolumnref}[2]{#1}% XXX:ハイパーリンクにはreviewcolumn側の調整が必要
+\newcommand{\reviewchapref}[2]{\hyperref[#2]{#1}}
 \newcommand{\reviewsecref}[2]{\hyperref[#2]{#1}}
 
 \newenvironment{reviewpart}{%

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -1,6 +1,6 @@
 \documentclass[dvipdfmx]{review-jsbook}
 \makeatletter
-\def\review@reviewversion{4.2.0}
+\def\review@reviewversion{5.1.0}
 \def\review@texcompiler{uplatex}
 \def\review@documentclass{review-jsbook}
 
@@ -57,6 +57,9 @@
   \fi
   \ifdefined\covermatter\else% for 4.0.0 compatibility
     \def\covermatter{}
+  \fi
+  \ifdefined\reviewchapref\else% for 5.1.0 compatibility
+    \newcommand{\reviewchapref}[2]{\hyperref[##2]{##1}}
   \fi
 }
 

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -1,6 +1,6 @@
 \documentclass[dvipdfmx]{review-jsbook}
 \makeatletter
-\def\review@reviewversion{4.2.0}
+\def\review@reviewversion{5.1.0}
 \def\review@texcompiler{uplatex}
 \def\review@documentclass{review-jsbook}
 
@@ -68,6 +68,9 @@ some ad content
   \fi
   \ifdefined\covermatter\else% for 4.0.0 compatibility
     \def\covermatter{}
+  \fi
+  \ifdefined\reviewchapref\else% for 5.1.0 compatibility
+    \newcommand{\reviewchapref}[2]{\hyperref[##2]{##1}}
   \fi
 }
 


### PR DESCRIPTION
#1619 の対応です。
[]があるとエスケープされちゃうので、chap, title, chaprefに`\reviewchapref`を使うようにしました。
互換性のためにconfig.erbで未定義(review-base.styが古い)のときには暗黙に定義するようにもしています。
