### PR TITLE
specify builder parameter explicitly to Webmaker

### DIFF
--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -86,6 +86,7 @@ module ReVIEW
                                          yamlfile: yamlfile,
                                          config: cmd_config)
 
+      @config['builder'] = 'html'
       @config['htmlext'] = 'html'
       I18n.setup(@config['language'])
       begin


### PR DESCRIPTION
#1623 の対応です。
PDFMaker, EPUBMaker と違って空のままになってしまうのは `@converter` 作るタイミングのせいだろうか…。
これ入れる前にもうちょっとロジック見直したほうがいいのかも。

