### PR TITLE
fix to find html/ directory correctly in webmaker

### DIFF
--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -103,6 +103,7 @@ module ReVIEW
       Dir.mkdir(@path)
 
       @book = ReVIEW::Book::Base.new(@basedir, config: @config)
+      @converter = ReVIEW::Converter.new(@book, ReVIEW::HTMLBuilder.new)
 
       copy_stylesheet(@path)
       copy_frontmatter(@path)
@@ -123,8 +124,6 @@ module ReVIEW
 
     def build_body(basetmpdir, _yamlfile)
       base_path = Pathname.new(@basedir)
-      builder = ReVIEW::HTMLBuilder.new
-      @converter = ReVIEW::Converter.new(@book, builder)
       @book.parts.each do |part|
         if part.name.present?
           if part.file?


### PR DESCRIPTION
#1623 の対応

pdfmaker.rbなどと同様に`@converter`の定義位置を変更して期待の動作になりました。
