### PR TITLE
webmaker, review-vol, review-indexのパラメータ値取り込み方法を修正

### DIFF
--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2020 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
+# Copyright (c) 2012-2021 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -7,6 +7,7 @@
 # For details of the GNU LGPL, see the file "COPYING".
 #
 require 'securerandom'
+require 'review/yamlloader'
 
 module ReVIEW
   class Configure < Hash
@@ -127,7 +128,7 @@ module ReVIEW
           loader = ReVIEW::YAMLLoader.new
           conf.deep_merge!(loader.load_file(yamlfile))
         rescue => e
-          error "yaml error #{e.message}"
+          raise ReVIEW::ConfigError, "yaml error #{e.message}"
         end
       end
 

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2020 Minero Aoki, Kenshi Muto
+# Copyright (c) 2008-2021 Minero Aoki, Kenshi Muto
 #               1999-2007 Minero Aoki
 #
 # This program is free software.
@@ -48,9 +48,7 @@ module ReVIEW
 
     def initialize
       @logger = ReVIEW.logger
-      @config = ReVIEW::Configure.values
       @yamlfile = 'config.yml'
-      @book = ReVIEW::Book::Base.new('.', config: @config)
       @upper = 4
       @indent = true
       @buildonly = nil
@@ -59,11 +57,12 @@ module ReVIEW
 
     def execute(*args)
       parse_options(args)
+      @config = ReVIEW::Configure.create(yamlfile: @yamlfile)
+      @book = ReVIEW::Book::Base.new('.', config: @config)
       unless File.readable?(@yamlfile)
         @logger.error("No such fiile or can't open #{@yamlfile}.")
         exit 1
       end
-      @book.load_config(@yamlfile)
       I18n.setup(@config['language'])
 
       if @detail

--- a/lib/review/volumeprinter.rb
+++ b/lib/review/volumeprinter.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2020 Minero Aoki, Kenshi Muto
+# Copyright (c) 2014-2021 Minero Aoki, Kenshi Muto
 #               2003-2014 Minero Aoki
 #
 # This program is free software.
@@ -22,18 +22,17 @@ module ReVIEW
 
     def initialize
       @logger = ReVIEW.logger
-      @config = ReVIEW::Configure.values
       @yamlfile = 'config.yml'
     end
 
     def execute(*args)
       parse_options(args)
+      @config = ReVIEW::Configure.create(yamlfile: @yamlfile)
       @book = ReVIEW::Book::Base.new('.', config: @config)
       unless File.readable?(@yamlfile)
         @logger.error("No such fiile or can't open #{@yamlfile}.")
         exit 1
       end
-      @book.load_config(@yamlfile)
       I18n.setup(@book.config['language'])
 
       begin


### PR DESCRIPTION
#1633 の修正。
`ReVIEW::Configure.create`で設定を作り、それをBookに渡すというやり方に統一しました。
これでcontentdirなどでエラーになる問題は修正できています。
