### PR TITLE
Unify call_hook

### DIFF
--- a/lib/epubmaker/epubcommon.rb
+++ b/lib/epubmaker/epubcommon.rb
@@ -25,6 +25,7 @@ module EPUBMaker
       @config = producer.config
       @contents = producer.contents
       @body_ext = nil
+      @logger = ReVIEW.logger
     end
 
     attr_reader :config

--- a/lib/epubmaker/epubv2.rb
+++ b/lib/epubmaker/epubv2.rb
@@ -10,10 +10,13 @@
 
 require 'epubmaker/epubcommon'
 require 'epubmaker/zip_exporter'
+require 'review/call_hook'
 
 module EPUBMaker
   # EPUBv2 is EPUB version 2 producer.
   class EPUBv2 < EPUBCommon
+    include ReVIEW::CallHook
+
     DC_ITEMS = %w[title language date type format source description relation coverage subject rights]
     CREATOR_ATTRIBUTES = %w[aut a-adp a-ann a-arr a-art a-asn a-aqt a-aft a-aui a-ant a-bkp a-clb a-cmm a-dsr a-edt a-ill a-lyr a-mdc a-mus a-nrt a-oth a-pht a-prt a-red a-rev a-spn a-ths a-trc a-trl]
     CONTRIBUTER_ATTRIBUTES = %w[adp ann arr art asn aqt aft aui ant bkp clb cmm dsr edt ill lyr mdc mus nrt oth pht prt red rev spn ths trc trl]
@@ -154,8 +157,8 @@ EOT
     # Produce EPUB file +epubfile+.
     # +basedir+ points the directory has contents.
     # +tmpdir+ defines temporary directory.
-    def produce(epubfile, basedir, tmpdir)
-      produce_write_common(basedir, tmpdir)
+    def produce(epubfile, work_dir, tmpdir, base_dir:)
+      produce_write_common(work_dir, tmpdir)
 
       ncx_file = "#{tmpdir}/OEBPS/#{config['bookname']}.ncx"
       File.write(ncx_file, ncx(config['epubmaker']['ncxindent']))
@@ -165,7 +168,7 @@ EOT
         File.write(toc_file, mytoc)
       end
 
-      call_hook(config['epubmaker']['hook_prepack'], tmpdir)
+      call_hook('hook_prepack', tmpdir, base_dir: base_dir)
       expoter = EPUBMaker::ZipExporter.new(tmpdir, config)
       expoter.export_zip(epubfile)
     end

--- a/lib/epubmaker/epubv3.rb
+++ b/lib/epubmaker/epubv3.rb
@@ -10,10 +10,13 @@
 
 require 'epubmaker/epubcommon'
 require 'epubmaker/zip_exporter'
+require 'review/call_hook'
 
 module EPUBMaker
   # EPUBv3 is EPUB version 3 producer.
   class EPUBv3 < EPUBCommon
+    include ReVIEW::CallHook
+
     DC_ITEMS = %w[title language date type format source description relation coverage subject rights]
     CREATOR_ATTRIBUTES = %w[a-adp a-ann a-arr a-art a-asn a-aqt a-aft a-aui a-ant a-bkp a-clb a-cmm a-csl a-dsr a-edt a-ill a-lyr a-mdc a-mus a-nrt a-oth a-pht a-prt a-red a-rev a-spn a-ths a-trc a-trl aut]
     CONTRIBUTER_ATTRIBUTES = %w[adp ann arr art asn aqt aft aui ant bkp clb cmm csl dsr edt ill lyr mdc mus nrt oth pbd pbl pht prt red rev spn ths trc trl]
@@ -198,15 +201,15 @@ module EPUBMaker
     end
 
     # Produce EPUB file +epubfile+.
-    # +basedir+ points the directory has contents.
+    # +work_dir+ points the directory has contents.
     # +tmpdir+ defines temporary directory.
-    def produce(epubfile, basedir, tmpdir)
-      produce_write_common(basedir, tmpdir)
+    def produce(epubfile, work_dir, tmpdir, base_dir:)
+      produce_write_common(work_dir, tmpdir)
 
       toc_file = "#{tmpdir}/OEBPS/#{config['bookname']}-toc.#{config['htmlext']}"
       File.write(toc_file, ncx(config['epubmaker']['ncxindent']))
 
-      call_hook(config['epubmaker']['hook_prepack'], tmpdir)
+      call_hook('hook_prepack', tmpdir, base_dir: base_dir)
       expoter = EPUBMaker::ZipExporter.new(tmpdir, config)
       expoter.export_zip(epubfile)
     end

--- a/lib/epubmaker/producer.rb
+++ b/lib/epubmaker/producer.rb
@@ -97,11 +97,12 @@ module EPUBMaker
     alias_method :importImageInfo, :import_imageinfo
 
     # Produce EPUB file +epubfile+.
-    # +basedir+ points the directory has contents (default: current directory.)
+    # +work_dir+ points the directory has contents (default: current directory.)
     # +tmpdir+ defines temporary directory.
-    def produce(epubfile, basedir = nil, tmpdir = nil)
+    # +base_dir+ is original root dir.
+    def produce(epubfile, work_dir, tmpdir = nil, base_dir: nil)
       current = Dir.pwd
-      basedir ||= current
+      base_dir ||= current
 
       # use Dir to solve a path for Windows (see #1011)
       new_tmpdir = Dir[File.join(tmpdir.nil? ? Dir.mktmpdir : tmpdir)][0]
@@ -113,7 +114,7 @@ module EPUBMaker
       File.unlink(epubfile) if File.exist?(epubfile)
 
       begin
-        @epub.produce(epubfile, basedir, new_tmpdir)
+        @epub.produce(epubfile, work_dir, new_tmpdir, base_dir: base_dir)
       ensure
         FileUtils.rm_r(new_tmpdir) if tmpdir.nil?
       end

--- a/lib/review/call_hook.rb
+++ b/lib/review/call_hook.rb
@@ -1,0 +1,20 @@
+module ReVIEW
+  module CallHook
+    def call_hook(hook_name, *params, base_dir: nil)
+      maker = @config.maker
+      filename = @config.dig(maker, hook_name)
+      return unless filename
+
+      hook = File.absolute_path(filename, base_dir)
+      @logger.debug("Call #{hook_name}. (#{hook})")
+
+      return if !File.exist?(hook) || !FileTest.executable?(hook)
+
+      if ENV['REVIEW_SAFE_MODE'].to_i & 1 > 0
+        warn 'hook configuration is prohibited in safe mode. ignored.'
+      else
+        system(hook, *params)
+      end
+    end
+  end
+end


### PR DESCRIPTION
`call_hook`の実装が分散していた（そしてちょっとずつ異なっていた）ので、まとめてみます。
EPUBMakerに元々のコンテンツのディレクトリを渡すしくみがなかったので、そこを追加しています（`base_dir`）。