### PR TITLE
refactor: extract headline in IDGXMLBuilder

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -549,7 +549,7 @@ Metrics/MethodLength:
 
 ### should be < 20
 Metrics/CyclomaticComplexity:
-  Max: 32
+  Max: 25
 
 ### should be < 60
 Metrics/AbcSize:

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -103,15 +103,9 @@ module ReVIEW
     end
 
     def headline(level, label, caption)
+      output_close_sect_tags(level)
       case level
       when 1
-        if @secttags
-          print '</sect4>' if @subsubsubsection > 0
-          print '</sect3>' if @subsubsection > 0
-          print '</sect2>' if @subsection > 0
-          print '</sect>' if @section > 0
-        end
-
         print %Q(<chapter id="chap:#{@chapter.number}">) if @secttags
 
         @section = 0
@@ -119,12 +113,6 @@ module ReVIEW
         @subsubsection = 0
         @subsubsubsection = 0
       when 2
-        if @secttags
-          print '</sect4>' if @subsubsubsection > 0
-          print '</sect3>' if @subsubsection > 0
-          print '</sect2>' if @subsection > 0
-          print '</sect>' if @section > 0
-        end
         @section += 1
         print %Q(<sect id="sect:#{@chapter.number}.#{@section}">) if @secttags
 
@@ -132,30 +120,17 @@ module ReVIEW
         @subsubsection = 0
         @subsubsubsection = 0
       when 3
-        if @secttags
-          print '</sect4>' if @subsubsubsection > 0
-          print '</sect3>' if @subsubsection > 0
-          print '</sect2>' if @subsection > 0
-        end
-
         @subsection += 1
         print %Q(<sect2 id="sect:#{@chapter.number}.#{@section}.#{@subsection}">) if @secttags
 
         @subsubsection = 0
         @subsubsubsection = 0
       when 4
-        if @secttags
-          print '</sect4>' if @subsubsubsection > 0
-          print '</sect3>' if @subsubsection > 0
-        end
-
         @subsubsection += 1
         print %Q(<sect3 id="sect:#{@chapter.number}.#{@section}.#{@subsection}.#{@subsubsection}">) if @secttags
 
         @subsubsubsection = 0
       when 5
-        print '</sect4>' if @secttags && @subsubsubsection > 0
-
         @subsubsubsection += 1
         print %Q(<sect4 id="sect:#{@chapter.number}.#{@section}.#{@subsection}.#{@subsubsection}.#{@subsubsubsection}">) if @secttags
       when 6 # rubocop:disable Lint/EmptyWhen
@@ -168,6 +143,23 @@ module ReVIEW
       label = label.nil? ? '' : %Q( id="#{label}")
       toccaption = escape(compile_inline(caption.gsub(/@<fn>\{.+?\}/, '')).gsub(/<[^>]+>/, ''))
       puts %Q(<title#{label} aid:pstyle="h#{level}">#{prefix}#{compile_inline(caption)}</title><?dtp level="#{level}" section="#{prefix}#{toccaption}"?>)
+    end
+
+    def output_close_sect_tags(level)
+      if @secttags
+        if level <= 5 && @subsubsubsection > 0
+          print '</sect4>'
+        end
+        if level <= 4 && @subsubsection > 0
+          print '</sect3>'
+        end
+        if level <= 3 && @subsection > 0
+          print '</sect2>'
+        end
+        if level <= 2 && @section > 0
+          print '</sect>'
+        end
+      end
     end
 
     def ul_begin

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -48,6 +48,19 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(<title id="test" aid:pstyle="h3">1.0.1　this is test.</title><?dtp level="3" section="1.0.1　this is test."?>), actual
   end
 
+  def test_headline_secttags
+    @config['structuredxml'] = true
+    actual = compile_block("= HEAD1\n== HEAD1-1\n\n=== HEAD1-1-1\n\n== HEAD1-2\n\n==== HEAD1-2-0-1\n\n===== HEAD1-2-0-1-1\n\n== HEAD1-3\n")
+    expected = '<chapter id="chap:1"><title aid:pstyle="h1">第1章　HEAD1</title><?dtp level="1" section="第1章　HEAD1"?>' +
+               '<sect id="sect:1.1"><title aid:pstyle="h2">1.1　HEAD1-1</title><?dtp level="2" section="1.1　HEAD1-1"?>' +
+               '<sect2 id="sect:1.1.1"><title aid:pstyle="h3">HEAD1-1-1</title><?dtp level="3" section="HEAD1-1-1"?></sect2></sect>' +
+               '<sect id="sect:1.2"><title aid:pstyle="h2">1.2　HEAD1-2</title><?dtp level="2" section="1.2　HEAD1-2"?>' +
+               '<sect3 id="sect:1.2.0.1"><title aid:pstyle="h4">HEAD1-2-0-1</title><?dtp level="4" section="HEAD1-2-0-1"?>' +
+               '<sect4 id="sect:1.2.0.1.1"><title aid:pstyle="h5">HEAD1-2-0-1-1</title><?dtp level="5" section="HEAD1-2-0-1-1"?></sect4></sect3></sect>' +
+               '<sect id="sect:1.3"><title aid:pstyle="h2">1.3　HEAD1-3</title><?dtp level="2" section="1.3　HEAD1-3"?></sect></chapter>'
+    assert_equal expected, actual
+  end
+
   def test_label
     actual = compile_block("//label[label_test]\n")
     assert_equal %Q(<label id='label_test' />), actual


### PR DESCRIPTION
`</sect>`タグを出力する部分をメソッドに分解してシンプルにしてみました。ついでにテストも追加しています。
これで `Metrics/CyclomaticComplexity`が減らせました。