### PR TITLE
EPUBMaker: use template in build_part

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -319,13 +319,9 @@ module ReVIEW
     def build_part(part, basetmpdir, htmlfile)
       log("Create #{htmlfile} from a template.")
       File.open(File.join(basetmpdir, htmlfile), 'w') do |f|
-        @body = ''
-        @body << %Q(<div class="part">\n)
-        @body << %Q(<h1 class="part-number">#{h(ReVIEW::I18n.t('part', part.number))}</h1>\n)
-        if part.name.strip.present?
-          @body << %Q(<h2 class="part-title">#{h(part.name.strip)}</h2>\n)
-        end
-        @body << %Q(</div>\n)
+        @part_number = part.number
+        @part_title = part.name.strip
+        @body = ReVIEW::Template.generate(path: 'html/_part_body.html.erb', binding: binding)
 
         @language = @producer.config['language']
         @stylesheets = @producer.config['stylesheet']

--- a/templates/html/_part_body.html.erb
+++ b/templates/html/_part_body.html.erb
@@ -1,0 +1,6 @@
+<div class="part">
+<h1 class="part-number"><%= h(ReVIEW::I18n.t('part', @part_number)) %></h1>
+<% if @part_title.present? %>
+<h2 class="part-title"><%= h(@part_title) %></h2>
+<% end %>
+</div>

--- a/test/test_epub3maker.rb
+++ b/test/test_epub3maker.rb
@@ -695,4 +695,39 @@ large.svg: 250x150 exceeds a limit. suggeted value is 95x57
 EOS
     assert_equal expected, err
   end
+
+  def test_build_part
+    Dir.mktmpdir do |tmpdir|
+      book = ReVIEW::Book::Base.new
+      book.catalog = ReVIEW::Catalog.new('CHAPS' => %w[ch1.re])
+      io1 = StringIO.new("//list[sampletest][a]{\nfoo\n//}\n")
+      chap1 = ReVIEW::Book::Chapter.new(book, 1, 'ch1', 'ch1.re', io1)
+      part1 = ReVIEW::Book::Part.new(book, 1, [chap1])
+      book.parts = [part1]
+      epubmaker = ReVIEW::EPUBMaker.new
+      epubmaker.instance_eval do
+        @config = book.config
+        @producer = ReVIEW::EPUBMaker::Producer.new(@config)
+      end
+      epubmaker.build_part(part1, tmpdir, 'part1.html')
+
+      expected = <<-EOB
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" xmlns:epub="http://www.idpf.org/2007/ops" xmlns:ops="http://www.idpf.org/2007/ops" xml:lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="generator" content="Re:VIEW" />
+  <title></title>
+</head>
+<body>
+<div class="part">
+<h1 class="part-number">第I部</h1>
+</div>
+</body>
+</html>
+      EOB
+      assert_equal expected, File.read(File.join(tmpdir, 'part1.html'))
+    end
+  end
 end


### PR DESCRIPTION
partのHTMLファイルをテンプレート化します。
テストも追加しておきました（実装はだいぶマズいというか、APIが足りてない…）