### PR TITLE
tty-loggerによるログの色付け

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -99,8 +99,13 @@ module ReVIEW
 
     def update_log_level
       if @config['debug']
-        @logger.level = Logger::DEBUG
-      else
+        if @logger.ttylogger?
+          ReVIEW.logger = nil
+          @logger = ReVIEW.logger(level: 'debug')
+        else
+          @logger.level = Logger::DEBUG
+        end
+      elsif !@logger.ttylogger?
         @logger.level = Logger::INFO
       end
     end
@@ -190,6 +195,9 @@ module ReVIEW
         log('Call ePUB producer.')
         @producer.produce("#{bookname}.epub", basetmpdir, epubtmpdir, base_dir: @basedir)
         log('Finished.')
+        if @logger.ttylogger?
+          @logger.success("built #{@basedir}/#{bookname}.epub")
+        end
       rescue ApplicationError => e
         raise if @config['debug']
 

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -195,9 +195,7 @@ module ReVIEW
         log('Call ePUB producer.')
         @producer.produce("#{bookname}.epub", basetmpdir, epubtmpdir, base_dir: @basedir)
         log('Finished.')
-        if @logger.ttylogger?
-          @logger.success("built #{@basedir}/#{bookname}.epub")
-        end
+        @logger.success("built #{bookname}.epub")
       rescue ApplicationError => e
         raise if @config['debug']
 

--- a/lib/review/idgxmlmaker.rb
+++ b/lib/review/idgxmlmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2019 Kenshi Muto
+# Copyright (c) 2019-2021 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -86,6 +86,9 @@ module ReVIEW
       I18n.setup(@config['language'])
       begin
         generate_idgxml_files(yamlfile)
+        if @logger.ttylogger?
+          @logger.success("built #{Dir.pwd}/#{build_path}")
+        end
       rescue ApplicationError => e
         raise if @config['debug']
 

--- a/lib/review/idgxmlmaker.rb
+++ b/lib/review/idgxmlmaker.rb
@@ -86,9 +86,7 @@ module ReVIEW
       I18n.setup(@config['language'])
       begin
         generate_idgxml_files(yamlfile)
-        if @logger.ttylogger?
-          @logger.success("built #{Dir.pwd}/#{build_path}")
-        end
+        @logger.success("built #{build_path}")
       rescue ApplicationError => e
         raise if @config['debug']
 

--- a/lib/review/logger.rb
+++ b/lib/review/logger.rb
@@ -6,10 +6,45 @@ module ReVIEW
       super(io, progname: progname)
       self.formatter = ->(severity, _datetime, name, msg) { "#{severity} #{name}: #{msg}\n" }
     end
+
+    def ttylogger?
+      nil
+    end
   end
 
-  def self.logger
-    @logger ||= ReVIEW::Logger.new($stderr, progname: File.basename($PROGRAM_NAME, '.*'))
+  begin
+    require 'tty-logger'
+    class TTYLogger < ::TTY::Logger
+      def ttylogger?
+        true
+      end
+    end
+  rescue LoadError
+    nil
+  end
+
+  def self.logger(level: 'info')
+    if const_defined?(:TTYLogger)
+      @logger ||= TTYLogger.new do |config|
+        config.level = level.to_sym
+        config.handlers = [
+          [:console,
+           {
+             styles: {
+               debug: { label: 'DEBUG' },
+               info: { label: 'INFO', color: :magenta },
+               success: { label: 'SUCCESS' },
+               wait: { label: 'WAIT' },
+               warn: { label: 'WARN' },
+               error: { label: 'ERROR' },
+               fatal: { label: 'FATAL' }
+             }
+           }]
+        ]
+      end
+    else
+      @logger ||= ReVIEW::Logger.new($stderr, progname: File.basename($PROGRAM_NAME, '.*'))
+    end
   end
 
   def self.logger=(logger)

--- a/lib/review/logger.rb
+++ b/lib/review/logger.rb
@@ -10,6 +10,10 @@ module ReVIEW
     def ttylogger?
       nil
     end
+
+    def success(_log)
+      # empty (for backward compatibility)
+    end
   end
 
   begin

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -291,9 +291,7 @@ module ReVIEW
         build_pdf
 
         FileUtils.cp(File.join(@path, "#{@mastertex}.pdf"), pdf_filepath)
-        if @logger.ttylogger?
-          @logger.success("built #{pdf_filepath}")
-        end
+        @logger.success("built #{File.basename(pdf_filepath)}")
       ensure
         remove_entry_secure(@path) unless @config['debug']
       end

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -291,6 +291,9 @@ module ReVIEW
         build_pdf
 
         FileUtils.cp(File.join(@path, "#{@mastertex}.pdf"), pdf_filepath)
+        if @logger.ttylogger?
+          @logger.success("built #{pdf_filepath}")
+        end
       ensure
         remove_entry_secure(@path) unless @config['debug']
       end

--- a/lib/review/textmaker.rb
+++ b/lib/review/textmaker.rb
@@ -88,9 +88,7 @@ module ReVIEW
       I18n.setup(@config['language'])
       begin
         generate_text_files(yamlfile)
-        if @logger.ttylogger?
-          @logger.success("built #{Dir.pwd}/#{build_path}")
-        end
+        @logger.success("built #{build_path}")
       rescue ApplicationError => e
         raise if @config['debug']
 

--- a/lib/review/textmaker.rb
+++ b/lib/review/textmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 Kenshi Muto
+# Copyright (c) 2018-2021 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -88,6 +88,9 @@ module ReVIEW
       I18n.setup(@config['language'])
       begin
         generate_text_files(yamlfile)
+        if @logger.ttylogger?
+          @logger.success("built #{Dir.pwd}/#{build_path}")
+        end
       rescue ApplicationError => e
         raise if @config['debug']
 

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -94,9 +94,7 @@ module ReVIEW
       I18n.setup(@config['language'])
       begin
         generate_html_files(yamlfile)
-        if @logger.ttylogger?
-          @logger.success("built #{Dir.pwd}/#{build_path}")
-        end
+        @logger.success("built #{build_path}")
       rescue ApplicationError => e
         raise if @config['debug']
 

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2020 Masayoshi Takahashi, Masanori Kado, Kenshi Muto
+# Copyright (c) 2016-2021 Masayoshi Takahashi, Masanori Kado, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -94,6 +94,9 @@ module ReVIEW
       I18n.setup(@config['language'])
       begin
         generate_html_files(yamlfile)
+        if @logger.ttylogger?
+          @logger.success("built #{Dir.pwd}/#{build_path}")
+        end
       rescue ApplicationError => e
         raise if @config['debug']
 

--- a/review.gemspec
+++ b/review.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('image_size')
   gem.add_dependency('rouge')
   gem.add_dependency('rubyzip')
+  gem.add_dependency('tty-logger')
   gem.add_development_dependency('mini_magick')
   gem.add_development_dependency('pygments.rb')
   gem.add_development_dependency('rake')

--- a/test/test_idgxmlmaker_cmd.rb
+++ b/test/test_idgxmlmaker_cmd.rb
@@ -30,7 +30,7 @@ class IDGXMLMakerCmdTest < Test::Unit::TestCase
       Dir.chdir(@tmpdir1) do
         _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_IDGXMLMAKER} #{option} #{configfile}")
         if defined?(ReVIEW::TTYLogger)
-          assert_match /SUCCESS/, e
+          assert_match(/SUCCESS/, e)
         else
           assert_equal '', e
         end

--- a/test/test_idgxmlmaker_cmd.rb
+++ b/test/test_idgxmlmaker_cmd.rb
@@ -29,7 +29,11 @@ class IDGXMLMakerCmdTest < Test::Unit::TestCase
       ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']) + RbConfig::CONFIG['EXEEXT']
       Dir.chdir(@tmpdir1) do
         _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_IDGXMLMAKER} #{option} #{configfile}")
-        assert_equal '', e
+        if defined?(ReVIEW::TTYLogger)
+          assert_match /SUCCESS/, e
+        else
+          assert_equal '', e
+        end
         assert s.success?
       end
       assert File.exist?(File.join(@tmpdir1, targetfile))

--- a/test/test_textmaker_cmd.rb
+++ b/test/test_textmaker_cmd.rb
@@ -30,7 +30,7 @@ class TEXTMakerCmdTest < Test::Unit::TestCase
       Dir.chdir(@tmpdir1) do
         _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_TEXTMAKER} #{option} #{configfile}")
         if defined?(ReVIEW::TTYLogger)
-          assert_match /SUCCESS/, e
+          assert_match(/SUCCESS/, e)
         else
           assert_equal '', e
         end

--- a/test/test_textmaker_cmd.rb
+++ b/test/test_textmaker_cmd.rb
@@ -29,7 +29,11 @@ class TEXTMakerCmdTest < Test::Unit::TestCase
       ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']) + RbConfig::CONFIG['EXEEXT']
       Dir.chdir(@tmpdir1) do
         _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_TEXTMAKER} #{option} #{configfile}")
-        assert_equal '', e
+        if defined?(ReVIEW::TTYLogger)
+          assert_match /SUCCESS/, e
+        else
+          assert_equal '', e
+        end
         assert s.success?
       end
       assert File.exist?(File.join(@tmpdir1, targetfile))


### PR DESCRIPTION
#1660 の対応

tty-loggerは基本的にラベル部分しかカラーリングは付かないのかな。
リダイレクトすると普通に黒くなります。

寂しいので成功したときにはSUCCESSを出すようにしました。

外部gemはあくまでおまけというポリシーなので、tty-color gemが見つからないときにはこれまでどおり普通のLoggerを使うようにしています。
