### PR TITLE
Vivliostyleビルドルール

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,12 @@ $ echo "export PATH=PATH_OF_REVIEW/bin:$PATH" >> ~/.profile
 $ review-init hello
 $ cd hello
 $ (... add and edit *.re file, config.yml and catalog.yml ...)
-$ rake epub    ## generating EPUB
-$ rake pdf     ## generating PDF (Requirement TeXLive)
-$ rake text    ## generating texts
-$ rake web     ## generating Web pages
-$ rake idgxml  ## generating InDesign XML files
+$ rake epub         ## generating EPUB
+$ rake pdf          ## generating PDF (Requirement TeXLive)
+$ rake text         ## generating texts
+$ rake web          ## generating Web pages
+$ rake idgxml       ## generating InDesign XML files
+$ rake vivliostyle  ## generating PDF using Vivliostyle-CLI (Requirement Vivliostyle-CLI)
 ```
 
 For further information, see [doc/quickstart.md](https://github.com/kmuto/review/blob/master/doc/quickstart.md)

--- a/doc/quickstart.ja.md
+++ b/doc/quickstart.ja.md
@@ -8,7 +8,7 @@ Re:VIEW は GNU Lesser General Public License Version 2.1 に基づいて配布�
 
 このドキュメントでは、Re:VIEW のセットアップから変換の例までを簡単に説明します。
 
-このドキュメントは、Re:VIEW 4.2 に基づいています。
+このドキュメントは、Re:VIEW 5.1 に基づいています。
 
 ## セットアップ
 
@@ -159,6 +159,16 @@ $ rake idgxml ←InDesign XMLの作成
 config.yml のサンプルについては以下を参照してください。
 
 * [config.yml.sample](https://github.com/kmuto/review/blob/master/doc/config.yml.sample)
+
+#### Vivliostyle CLI を使った PDF 化
+
+TeX (`review-pdfmaker`、`rake pdf`) を利用する代わりに、[Vivliostyle CLI](https://github.com/vivliostyle/vivliostyle-cli) を使って PDF を作成することもできます。Re:VIEW が EPUB を作成したあと、VivliostyleCLI がそれを PDF に変換します。
+
+```bash
+$ rake vivliostyle:build    ← Vivliostyle を使って PDF を作成
+$ rake vivliostyle:preview  ← Chrome/Chromium ブラウザでプレビュー
+$ rake vivliostyle          ← vivliostyle:buildのショートカット
+```
 
 ### 章を増やす、カスタマイズする
 作成した PDF あるいは EPUB を見ると、先に作成した RE:VIEW フォーマットテキストファイルが「第1章」となっていることがわかります。

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -9,7 +9,7 @@ Re:VIEW is free software under the terms of the GNU Lesser General Public Licens
 
 This article describes how to setup Re:VIEW and use it.
 
-The supported version of the article is Re:VIEW 4.2.
+The supported version of the article is Re:VIEW 5.1.
 
 ## Set up Re:VIEW
 
@@ -161,6 +161,16 @@ $ rake idgxml    ## generate InDesign XML
 
 There is a sample YAML file [config.yml.sample](https://github.com/kmuto/review/blob/master/doc/config.yml.sample) in the same directory of this document.
 
+#### generate PDF using Vivliostyle CLI
+
+Instead of using TeX (`review-pdfmaker` or `rake pdf`), you can also create a PDF use [Vivliostyle CLI](https://github.com/vivliostyle/vivliostyle-cli). Re:VIEW creates EPUB first and then converts it to PDF with Vivliostyle CLI.
+
+```bash
+$ rake vivliostyle:build    ## build PDF using Viliostyle
+$ rake vivliostyle:preview  ## preview pages in Chrome/Chromium browser
+$ rake vivliostyle          ## shortcut of vivliostyle:build
+```
+
 ### add chapters and modify them
 
 `catalog.yml` file is a catalog of Re:VIEW format files.
@@ -181,7 +191,6 @@ POSTDEF:
 ```
 
 The first item in CHAPS is the first chapter, and the second item (if you add) is the second chapter. PREDEF is for front matter, APPENDIX is for appendix, and POSTDEF is for back matter.  You can see in detail with [catalog.md](https://github.com/kmuto/review/blob/master/doc/catalog.ja.md).
-
 
 ### more information
 

--- a/samples/sample-book/src/lib/tasks/review.rake
+++ b/samples/sample-book/src/lib/tasks/review.rake
@@ -1,4 +1,4 @@
-# Copyright (c) 2006-2020 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
+# Copyright (c) 2006-2021 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -35,6 +35,11 @@ EPUB_OPTIONS = ENV['REVIEW_EPUB_OPTIONS'] || ''
 WEB_OPTIONS = ENV['REVIEW_WEB_OPTIONS'] || ''
 IDGXML_OPTIONS = ENV['REVIEW_IDGXML_OPTIONS'] || ''
 TEXT_OPTIONS = ENV['REVIEW_TEXT_OPTIONS'] || ''
+
+REVIEW_VSBIN = ENV['REVIEW_VSBIN'] || 'vivliostyle'
+REVIEW_VSBIN_USESANDBOX = ENV['REVIEW_VSBIN_USESANDBOX'] ? '' : '--no-sandbox'
+REVIEW_VSBIN_PDF = ENV['REVIEW_VSBIN_PDF'] || BOOK_PDF
+REVIEW_VSBIN_OPTIONS = ENV['REVIEW_VSBIN_OPTIONS'] || ''
 
 def build(mode, chapter)
   sh("review-compile --target=#{mode} --footnotetext --stylesheet=style.css #{chapter} > tmp")
@@ -124,5 +129,16 @@ end
 file IDGXMLROOT => SRC do
   FileUtils.rm_rf([IDGXMLROOT])
 end
+
+desc 'run vivliostyle'
+task 'vivliostyle:preview': BOOK_EPUB do
+  sh "#{REVIEW_VSBIN} preview #{REVIEW_VSBIN_USESANDBOX} #{REVIEW_VSBIN_OPTIONS} #{BOOK_EPUB}"
+end
+
+task 'vivliostyle:build': BOOK_EPUB do
+  sh "#{REVIEW_VSBIN} build #{REVIEW_VSBIN_USESANDBOX} #{REVIEW_VSBIN_OPTIONS} -o #{REVIEW_VSBIN_PDF} #{BOOK_EPUB}"
+end
+
+task vivliostyle: 'vivliostyle:build'
 
 CLEAN.include([BOOK, BOOK_PDF, BOOK_EPUB, BOOK + '-pdf', BOOK + '-epub', WEBROOT, 'images/_review_math', 'images/_review_math_text', TEXTROOT, IDGXMLROOT])

--- a/samples/sample-book/src/lib/tasks/review.rake
+++ b/samples/sample-book/src/lib/tasks/review.rake
@@ -36,10 +36,10 @@ WEB_OPTIONS = ENV['REVIEW_WEB_OPTIONS'] || ''
 IDGXML_OPTIONS = ENV['REVIEW_IDGXML_OPTIONS'] || ''
 TEXT_OPTIONS = ENV['REVIEW_TEXT_OPTIONS'] || ''
 
-REVIEW_VSBIN = ENV['REVIEW_VSBIN'] || 'vivliostyle'
-REVIEW_VSBIN_USESANDBOX = ENV['REVIEW_VSBIN_USESANDBOX'] ? '' : '--no-sandbox'
-REVIEW_VSBIN_PDF = ENV['REVIEW_VSBIN_PDF'] || BOOK_PDF
-REVIEW_VSBIN_OPTIONS = ENV['REVIEW_VSBIN_OPTIONS'] || ''
+REVIEW_VSCLI = ENV['REVIEW_VSCLI'] || 'vivliostyle'
+REVIEW_VSCLI_USESANDBOX = ENV['REVIEW_VSCLI_USESANDBOX'] ? '' : '--no-sandbox'
+REVIEW_VSCLI_PDF = ENV['REVIEW_VSCLI_PDF'] || BOOK_PDF
+REVIEW_VSCLI_OPTIONS = ENV['REVIEW_VSCLI_OPTIONS'] || ''
 
 def build(mode, chapter)
   sh("review-compile --target=#{mode} --footnotetext --stylesheet=style.css #{chapter} > tmp")
@@ -132,11 +132,11 @@ end
 
 desc 'run vivliostyle'
 task 'vivliostyle:preview': BOOK_EPUB do
-  sh "#{REVIEW_VSBIN} preview #{REVIEW_VSBIN_USESANDBOX} #{REVIEW_VSBIN_OPTIONS} #{BOOK_EPUB}"
+  sh "#{REVIEW_VSCLI} preview #{REVIEW_VSCLI_USESANDBOX} #{REVIEW_VSCLI_OPTIONS} #{BOOK_EPUB}"
 end
 
 task 'vivliostyle:build': BOOK_EPUB do
-  sh "#{REVIEW_VSBIN} build #{REVIEW_VSBIN_USESANDBOX} #{REVIEW_VSBIN_OPTIONS} -o #{REVIEW_VSBIN_PDF} #{BOOK_EPUB}"
+  sh "#{REVIEW_VSCLI} build #{REVIEW_VSCLI_USESANDBOX} #{REVIEW_VSCLI_OPTIONS} -o #{REVIEW_VSCLI_PDF} #{BOOK_EPUB}"
 end
 
 task vivliostyle: 'vivliostyle:build'


### PR DESCRIPTION
vivliostyle-cli https://github.com/vivliostyle/vivliostyle-cli がインストールされている環境において、

- rake vivliostyle:build (または rake vivliostyle) →PDFを作成
- rake vivliostyle:preview →プレビューを開く

のルールを実行できるようにしました。
具体的にはEPUBを普通に作ったあと、vivliostyleに食わせてPDFかプレビューを作ります。

環境変数は以下のとおりです。
- `REVIEW_VSBIN`: vivliostyleコマンドのパス(PATHが通ってない場合用)
- `REVIEW_VSBIN_USESANDBOX`: とりあえずLinuxだと`--no-sandbox`付けないと変なクラッシュになるので、デフォルトでそれを使います。この変数に値が何か入ってるときには`--no-sandbox`付けをやめます。
- `REVIEW_VSBIN_OPTIONS`: それ以外に何かオプションを付けたいとき用
- `REVIEW_VSBIN_PDF`: 出力ファイル名。デフォルトはpdfmakerと同じくBOOK+`.pdf`。