### PR TITLE
PDFMaker: キャプション文字列が空のときには採番あり・説明なし のキャプションにする

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -575,7 +575,7 @@ module ReVIEW
       array.join(',')
     end
 
-    def image_image(id, caption='', metric=nil)
+    def image_image(id, caption = '', metric = nil)
       captionstr = nil
       @doc_status[:caption] = true
       if @book.config.check_version('2', exception: false)
@@ -605,7 +605,7 @@ module ReVIEW
         puts "\\#{command}[width=\\maxwidth]{#{@chapter.image(id).path}}"
       end
 
-      if !caption_top?('image')
+      unless caption_top?('image')
         puts captionstr
       end
 

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -1,6 +1,6 @@
 # Copyright (c) 2002-2007 Minero Aoki
 #               2008-2009 Minero Aoki, Kenshi Muto
-#               2010-2020 Minero Aoki, Kenshi Muto, TAKAHASHI Masayoshi
+#               2010-2021 Minero Aoki, Kenshi Muto, TAKAHASHI Masayoshi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -575,13 +575,13 @@ module ReVIEW
       array.join(',')
     end
 
-    def image_image(id, caption, metric)
+    def image_image(id, caption='', metric=nil)
       captionstr = nil
       @doc_status[:caption] = true
       if @book.config.check_version('2', exception: false)
-        captionstr = macro('caption', compile_inline(caption)) + "\n" if caption.present?
+        captionstr = macro('caption', compile_inline(caption)) + "\n"
       else
-        captionstr = macro('reviewimagecaption', compile_inline(caption)) + "\n" if caption.present?
+        captionstr = macro('reviewimagecaption', compile_inline(caption)) + "\n"
       end
       captionstr << macro('label', image_label(id))
       @doc_status[:caption] = nil
@@ -590,7 +590,7 @@ module ReVIEW
       # image is always bound here
       puts "\\begin{reviewimage}%%#{id}"
 
-      if caption_top?('image') && captionstr
+      if caption_top?('image')
         puts captionstr
       end
 
@@ -605,7 +605,7 @@ module ReVIEW
         puts "\\#{command}[width=\\maxwidth]{#{@chapter.image(id).path}}"
       end
 
-      if !caption_top?('image') && captionstr
+      if !caption_top?('image')
         puts captionstr
       end
 

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -630,6 +630,20 @@ EOS
 EOS
     assert_equal expected, actual
 
+    actual = compile_block("//image[sampleimg][]{\n//}\n")
+    expected = <<-EOS
+<div id="sampleimg" class="image">
+<img src="images/chap1-sampleimg.png" alt="" />
+<p class="caption">
+図1.1: 
+</p>
+</div>
+EOS
+    assert_equal expected, actual
+
+    actual = compile_block("//image[sampleimg][][]{\n//}\n")
+    assert_equal expected, actual
+
     @config['caption_position']['image'] = 'top'
     actual = compile_block("//image[sampleimg][sample photo]{\n//}\n")
     expected = <<-EOS
@@ -745,6 +759,12 @@ EOS
 <img src="images/chap1-sampleimg.png" alt="" />
 </div>
 EOS
+    assert_equal expected, actual
+
+    actual = compile_block("//indepimage[sampleimg][]\n")
+    assert_equal expected, actual
+
+    actual = compile_block("//indepimage[sampleimg][][]\n")
     assert_equal expected, actual
   end
 

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1101,6 +1101,19 @@ EOS
 \\end{reviewimage}
 EOS
     assert_equal expected, actual
+
+    actual = compile_block("//image[sampleimg][]{\n//}\n")
+    expected = <<-EOS
+\\begin{reviewimage}%%sampleimg
+\\reviewimagecaption{}
+\\label{image:chap1:sampleimg}
+\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
+
+    actual = compile_block("//image[sampleimg][][]{\n//}\n")
+    assert_equal expected, actual
   end
 
   def test_image_with_metric
@@ -1249,6 +1262,13 @@ EOS
 \\end{reviewimage}
 EOS
     assert_equal expected, actual
+
+    actual = compile_block("//indepimage[sampleimg][]\n")
+    assert_equal expected, actual
+
+
+    actual = compile_block("//indepimage[sampleimg][][]\n")
+    assert_equal expected, actual
   end
 
   def test_indepimage_with_metric
@@ -1383,6 +1403,16 @@ EOS
 ccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline
 \\end{reviewtable}
 \\end{table}
+EOS
+    assert_equal expected, actual
+
+    actual = compile_block("//table[foo][]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+\\begin{reviewtable}{|l|l|}
+\\hline
+\\reviewth{aaa} & \\reviewth{bbb} \\\\  \\hline
+ccc & ddd\\textless{}\\textgreater{}\\& \\\\  \\hline
+\\end{reviewtable}
 EOS
     assert_equal expected, actual
 
@@ -1551,6 +1581,18 @@ EOS
 \\end{reviewimage}
 \\end{table}
 EOS
+    assert_equal expected, actual
+
+    actual = compile_block("//imgtable[sampleimg][]{\n//}\n")
+    expected = <<-EOS
+\\label{table:chap1:sampleimg}
+\\begin{reviewimage}%%sampleimg
+\\reviewincludegraphics[width=\\maxwidth]{./images/chap1-sampleimg.png}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
+
+    actual = compile_block("//imgtable[sampleimg][][]{\n//}\n")
     assert_equal expected, actual
 
     @book.config['pdfmaker']['use_original_image_size'] = true

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1266,7 +1266,6 @@ EOS
     actual = compile_block("//indepimage[sampleimg][]\n")
     assert_equal expected, actual
 
-
     actual = compile_block("//indepimage[sampleimg][][]\n")
     assert_equal expected, actual
   end


### PR DESCRIPTION
#1666 の修正

`//image[ID][]{` のように指定されたときにエラーになるのを防ぎます。

キャプションなしにしてしまうことも考えましたがそういう用途にはindepimageがあること、「図X.Xだけで説明なし」というケースは手元だとけっこう多いことから、空文字列をそのまま使うことにしました。

なお、これでとりあえず#1666を直しますが、ビルダ間や表/リスト/図でキャプションなしのときの出力が若干違うのは迷うので、そのあたりは別PR立てて直したいところではあります。
