### PR TITLE
Release 5.1.0

### DIFF
--- a/NEWS.ja.md
+++ b/NEWS.ja.md
@@ -1,3 +1,103 @@
+# Version 5.1.0
+## 新機能
+* CSS 組版ソフトウェア [Vivliostyle-CLI](https://github.com/vivliostyle/vivliostyle-cli) を呼び出す Rake ルールを追加しました。Vivliostyle-CLI をインストールした環境において、`rake vivliostyle:build` または `rake vivliostyle` で PDF を作成、`rake vivliostyle:preview` でブラウザのプレビューが開きます ([#1663])
+* PDFMaker: `config.yml` に `boxsetting` パラメータを新設し、column・note・memo・tip・info・warning・important・caution・notice の囲み飾りを事前定義のものや独自に作成したものから選択およびカスタマイズできるようにしました ([#1637])
+* 挿入箇所を示す `@<ins>`、削除箇所を示す `@<del>` の2つのインライン命令を追加しました ([#1630])
+* EPUBMaker, WebMaker: 数式表現手法として MathJax をサポートし、数式表現手法を `math_format` パラメータで選択するようにしました ([#1587], [#1614])
+
+## 非互換の変更
+* EPUBMaker: `urnid` パラメータのデフォルト値のプレフィクスを、`urn:uid` から `urn:uuid` に変更しました ([#1658])
+* PDFMaker: 長い脚注がページ分断されないようにしました ([#1607])
+
+## バグ修正
+* `contentdir` を設定しているときに WebMaker, review-vol, review-index がエラーになるのを修正しました ([#1633])
+* WebMaker: `images/html` 図版フォルダが見つけられないのを修正しました ([#1623])
+* PDFMaker: 用語リストの見出しで chapterlink がおかしな結果になるのを修正しました ([#1619])
+* PDFMaker: 索引に `{`, `}`, `|` が含まれているときにエラーや奇妙な文字に変換されるのを修正しました ([#1611])
+* review-vol: 不正な見出しがあったときに妥当なエラーメッセージを出力するようにしました ([#1604])
+* PDFMaker: `after_makeindex` フックを LaTeX コンパイル後ではなく `mendex` 実行後に実行するように修正しました ([#1605])
+
+## 機能強化
+* tty-loger gem パッケージがインストールされている場合、Re:VIEW の各 Maker コマンドの進行状態をアイコンおよびカラーで示すようにしました ([#1660])
+* PDFMaker: クラスファイルで `\RequirePackage{plautopatch}` を最初に評価するようにしました ([#1644])
+* MARKDOWNBuilder: `@<hd>` をサポートしました ([#1629])
+* Re:VIEW ドキュメントファイルに不正なエスケープシーケンス文字が含まれているときにエラーを出すようにしました ([#1596], [#1602])
+* `=` の数が6を超える見出し扱いの行があるときにエラーを出すようにしました ([#1591])
+
+## ドキュメント
+* 画像探索の際に各 Maker が参照するサブフォルダ名について記載しました ([#1626])
+
+## その他
+* EPUBMaker: EPUB ライブラリ一式を `lib/epubmaker` から `lib/review/epubmaker` に移動し、リファクタリングしました ([#1575], [#1617], [#1635], [#1640], [#1641], [#1650], [#1653], [#1655])
+* EPUBMaker: テストを追加しました ([#1656])
+* PDFMaker: いくつかの処理をリファクタリングしました ([#1664])
+* 数式画像生成処理を `ReVIEW::ImgMath` クラスにまとめました ([#1642], [#1649], [#1659])
+* IDGXMLMaker: いくつかの処理をリファクタリングしました ([#1654])
+* MakerHelper: いくつかの処理をリファクタリングしました ([#1652])
+* テンプレート処理を `ReVIEW::Template.generate` メソッドに統一しました ([#1648])
+* GitHub Actions で TeX コンパイルのテストも行うようにしました ([#1643])
+* Rubocop 1.8 に対応しました ([#1593], [#1598], [#1613], [#1636], [#1647])
+* サンプル syntax-book の重複 ID を修正しました ([#1646])
+* ライブラリの相対パスの参照方法をリファクタリングしました ([#1639])
+* `ReVIEW::LineInput` クラスをリファタクタリングしました ([#1638])
+* Copyright を2021年に更新しました ([#1632])
+* Ruby 3.0 でのテストを実行するようにしました ([#1622])
+* 不安定な Pygments のテストを抑制しました ([#1610], [#1618])
+* WebTocPrinter: テストのエラーを修正しました ([#1606])
+* テストのターゲットを指定しやすいようにしました ([#1594])
+
+[#1664]: https://github.com/kmuto/review/pull/1664
+[#1663]: https://github.com/kmuto/review/pull/1663
+[#1660]: https://github.com/kmuto/review/issues/1660
+[#1659]: https://github.com/kmuto/review/pull/1659
+[#1658]: https://github.com/kmuto/review/pull/1658
+[#1656]: https://github.com/kmuto/review/pull/1656
+[#1655]: https://github.com/kmuto/review/pull/1655
+[#1654]: https://github.com/kmuto/review/pull/1654
+[#1653]: https://github.com/kmuto/review/pull/1653
+[#1652]: https://github.com/kmuto/review/pull/1652
+[#1650]: https://github.com/kmuto/review/pull/1650
+[#1649]: https://github.com/kmuto/review/pull/1649
+[#1648]: https://github.com/kmuto/review/pull/1648
+[#1647]: https://github.com/kmuto/review/pull/1647
+[#1646]: https://github.com/kmuto/review/pull/1646
+[#1644]: https://github.com/kmuto/review/issues/1644
+[#1643]: https://github.com/kmuto/review/pull/1643
+[#1642]: https://github.com/kmuto/review/pull/1642
+[#1641]: https://github.com/kmuto/review/pull/1641
+[#1640]: https://github.com/kmuto/review/pull/1640
+[#1639]: https://github.com/kmuto/review/pull/1639
+[#1638]: https://github.com/kmuto/review/pull/1638
+[#1637]: https://github.com/kmuto/review/pull/1637
+[#1636]: https://github.com/kmuto/review/pull/1636
+[#1635]: https://github.com/kmuto/review/pull/1635
+[#1633]: https://github.com/kmuto/review/issues/1633
+[#1632]: https://github.com/kmuto/review/issues/1632
+[#1630]: https://github.com/kmuto/review/issues/1630
+[#1629]: https://github.com/kmuto/review/pull/1629
+[#1626]: https://github.com/kmuto/review/pull/1626
+[#1623]: https://github.com/kmuto/review/issues/1623
+[#1622]: https://github.com/kmuto/review/pull/1622
+[#1619]: https://github.com/kmuto/review/issues/1619
+[#1618]: https://github.com/kmuto/review/pull/1618
+[#1617]: https://github.com/kmuto/review/pull/1617
+[#1614]: https://github.com/kmuto/review/pull/1614
+[#1613]: https://github.com/kmuto/review/pull/1613
+[#1611]: https://github.com/kmuto/review/issues/1611
+[#1610]: https://github.com/kmuto/review/pull/1610
+[#1607]: https://github.com/kmuto/review/issues/1607
+[#1606]: https://github.com/kmuto/review/issues/1606
+[#1605]: https://github.com/kmuto/review/issues/1605
+[#1604]: https://github.com/kmuto/review/issues/1604
+[#1602]: https://github.com/kmuto/review/pull/1602
+[#1598]: https://github.com/kmuto/review/pull/1598
+[#1596]: https://github.com/kmuto/review/issues/1596
+[#1594]: https://github.com/kmuto/review/pull/1594
+[#1593]: https://github.com/kmuto/review/pull/1593
+[#1591]: https://github.com/kmuto/review/issues/1591
+[#1587]: https://github.com/kmuto/review/issues/1587
+[#1575]: https://github.com/kmuto/review/issues/1575
+
 # Version 5.0.0
 ## 新機能
 * review-jsbook / review-jlreq クラスに、`cover_fit_page` オプションを追加しました。`texdocumentclass` パラメータに `cover_fit_page=true` を付けると、画像サイズがどのようなものであっても仕上がりサイズに拡縮して表紙に貼り込みます。なお、制作において図版は実寸で作成することを推奨します ([#1534])

--- a/NEWS.ja.md
+++ b/NEWS.ja.md
@@ -17,6 +17,7 @@
 * review-vol: 不正な見出しがあったときに妥当なエラーメッセージを出力するようにしました ([#1604])
 * PDFMaker: `after_makeindex` フックを LaTeX コンパイル後ではなく `mendex` 実行後に実行するように修正しました ([#1605])
 * PDFMaker: `//image` のキャプションが空だったときに内部エラーではなく図番号が出力されるように修正しました ([#1666])
+* review-vol, review-index が不正なファイルを受け取ったときのエラー処理を修正しました ([#1671])
 
 ## 機能強化
 * tty-loger gem パッケージがインストールされている場合、Re:VIEW の各 Maker コマンドの進行状態をアイコンおよびカラーで示すようにしました ([#1660])
@@ -47,6 +48,7 @@
 * WebTocPrinter: テストのエラーを修正しました ([#1606])
 * テストのターゲットを指定しやすいようにしました ([#1594])
 
+[#1671]: https://github.com/kmuto/review/issues/1671
 [#1666]: https://github.com/kmuto/review/issues/1666
 [#1664]: https://github.com/kmuto/review/pull/1664
 [#1663]: https://github.com/kmuto/review/pull/1663

--- a/NEWS.ja.md
+++ b/NEWS.ja.md
@@ -18,6 +18,7 @@
 * PDFMaker: `after_makeindex` フックを LaTeX コンパイル後ではなく `mendex` 実行後に実行するように修正しました ([#1605])
 * PDFMaker: `//image` のキャプションが空だったときに内部エラーではなく図番号が出力されるように修正しました ([#1666])
 * review-vol, review-index が不正なファイルを受け取ったときのエラー処理を修正しました ([#1671])
+* EPUBMaker: author などの静的ファイルを指示したときに、ファイルが存在しないと内部エラーを起こしていたのを修正しました ([#1670])
 
 ## 機能強化
 * tty-loger gem パッケージがインストールされている場合、Re:VIEW の各 Maker コマンドの進行状態をアイコンおよびカラーで示すようにしました ([#1660])
@@ -38,7 +39,7 @@
 * MakerHelper: いくつかの処理をリファクタリングしました ([#1652])
 * テンプレート処理を `ReVIEW::Template.generate` メソッドに統一しました ([#1648])
 * GitHub Actions で TeX コンパイルのテストも行うようにしました ([#1643])
-* Rubocop 1.8 に対応しました ([#1593], [#1598], [#1613], [#1636], [#1647])
+* Rubocop 1.10 に対応しました ([#1593], [#1598], [#1613], [#1636], [#1647], [#1669])
 * サンプル syntax-book の重複 ID を修正しました ([#1646])
 * ライブラリの相対パスの参照方法をリファクタリングしました ([#1639])
 * `ReVIEW::LineInput` クラスをリファタクタリングしました ([#1638])
@@ -49,6 +50,8 @@
 * テストのターゲットを指定しやすいようにしました ([#1594])
 
 [#1671]: https://github.com/kmuto/review/issues/1671
+[#1670]: https://github.com/kmuto/review/pull/1670
+[#1669]: https://github.com/kmuto/review/pull/1669
 [#1666]: https://github.com/kmuto/review/issues/1666
 [#1664]: https://github.com/kmuto/review/pull/1664
 [#1663]: https://github.com/kmuto/review/pull/1663

--- a/NEWS.ja.md
+++ b/NEWS.ja.md
@@ -16,6 +16,7 @@
 * PDFMaker: 索引に `{`, `}`, `|` が含まれているときにエラーや奇妙な文字に変換されるのを修正しました ([#1611])
 * review-vol: 不正な見出しがあったときに妥当なエラーメッセージを出力するようにしました ([#1604])
 * PDFMaker: `after_makeindex` フックを LaTeX コンパイル後ではなく `mendex` 実行後に実行するように修正しました ([#1605])
+* PDFMaker: `//image` のキャプションが空だったときに内部エラーではなく図番号が出力されるように修正しました ([#1666])
 
 ## 機能強化
 * tty-loger gem パッケージがインストールされている場合、Re:VIEW の各 Maker コマンドの進行状態をアイコンおよびカラーで示すようにしました ([#1660])
@@ -31,7 +32,7 @@
 * EPUBMaker: EPUB ライブラリ一式を `lib/epubmaker` から `lib/review/epubmaker` に移動し、リファクタリングしました ([#1575], [#1617], [#1635], [#1640], [#1641], [#1650], [#1653], [#1655])
 * EPUBMaker: テストを追加しました ([#1656])
 * PDFMaker: いくつかの処理をリファクタリングしました ([#1664])
-* 数式画像生成処理を `ReVIEW::ImgMath` クラスにまとめました ([#1642], [#1649], [#1659])
+* 数式画像生成処理を `ReVIEW::ImgMath` クラスにまとめました ([#1642], [#1649], [#1659], [#1662])
 * IDGXMLMaker: いくつかの処理をリファクタリングしました ([#1654])
 * MakerHelper: いくつかの処理をリファクタリングしました ([#1652])
 * テンプレート処理を `ReVIEW::Template.generate` メソッドに統一しました ([#1648])
@@ -46,8 +47,10 @@
 * WebTocPrinter: テストのエラーを修正しました ([#1606])
 * テストのターゲットを指定しやすいようにしました ([#1594])
 
+[#1666]: https://github.com/kmuto/review/issues/1666
 [#1664]: https://github.com/kmuto/review/pull/1664
 [#1663]: https://github.com/kmuto/review/pull/1663
+[#1662]: https://github.com/kmuto/review/issues/1662
 [#1660]: https://github.com/kmuto/review/issues/1660
 [#1659]: https://github.com/kmuto/review/pull/1659
 [#1658]: https://github.com/kmuto/review/pull/1658

--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * review-vol: valid error messages will be displayed when invalid headings are found ([#1604])
 * PDFMaker: `after_makeindex` hook to be executed after `mendex` execution, not after LaTeX compilation ([#1605])
 * PDFMaker: if the caption of `//image` is empty, the figure number will be printed instead of an internal error ([#1666])
+* fixed review-vol and review-index errors when a file is invalid ([#1671])
 
 ## Enhancements
 * Maker commands now display with nice colors and icons for their progress status when tty-logger gem is installed ([#1660])
@@ -47,6 +48,7 @@
 * WebTocPrinter: fixed an error of test ([#1606])
 * improved to make it easier to specify the target of the test ([#1594])
 
+[#1671]: https://github.com/kmuto/review/issues/1671
 [#1666]: https://github.com/kmuto/review/issues/1666
 [#1664]: https://github.com/kmuto/review/pull/1664
 [#1663]: https://github.com/kmuto/review/pull/1663

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,103 @@
+# Version 5.1.0
+## New Features
+* added Rake rule to call [Vivliostyle-CLI](https://github.com/vivliostyle/vivliostyle-cli), CSS typesetting formatter. Create a PDF with `rake vivliostyle:build` or `rake vivliostyle`, and open a preview with `rake vivliostyle:preview` ([#1663])
+* PDFMaker: introduced `boxsetting` parameter to choose and customize the decorations for column, note, memo, tip, info, warning, important, caution and notice ([#1637])
+* added inline op, `@<ins>` (indicates an insertion) and `@<del>` (indicates a deletion) ([#1630])
+* EPUBMaker, WebMaker: MathJax is now supported. Added `math_format` parameter to choose the mathematical expression method ([#1587], [#1614])
+
+## Breaking Changes
+* EPUBMaker: changed the default value of the `urnid` parameter from `urn:uid` to `urn:uuid` ([#1658])
+* PDFMaker: footnotes are no longer broken up by a page ([#1607])
+
+## Bug Fixes
+* fixed WebMaker, review-vol and review-index errors when `contentdir` is defined ([#1633])
+* WebMaker: fixed `images/html` foder not being found ([#1623])
+* PDFMaker: fixed chapterlink in term list ([#1619])
+* PDFMaker: fixed errors when index contains `{`, `}`, or `|` ([#1611])
+* review-vol: valid error messages will be displayed when invalid headings are found ([#1604])
+* PDFMaker: `after_makeindex` hook to be executed after `mendex` execution, not after LaTeX compilation ([#1605])
+
+## Enhancements
+* Maker commands now display with nice colors and icons for their progress status when tty-logger gem is installed ([#1660])
+* PDFMaker: added `\RequirePackage{plautopatch}` definition to class files ([#1644])
+* MARKDOWNBuilder: supported `@<hd>` ([#1629])
+* Re:VIEW now reports an error when a document file contains invalid escape sequence characters ([#1596], [#1602])
+* an error is raised when there are more than 6 `=` in a heading ([#1591])
+
+## Docs
+* documented the name of the image folder referenced by Makers ([#1626])
+
+## Others
+* EPUBMaker: moved EPUB library from `lib/epubmaker` to `lib/review/epubmaker` and refactored it ([#1575], [#1617], [#1635], [#1640], [#1641], [#1650], [#1653], [#1655])
+* EPUBMaker: added tests ([#1656])
+* PDFMaker: refactored some ([#1664])
+* introduced `ReVIEW::ImgMath` class to handle mathematic images ([#1642], [#1649], [#1659])
+* IDGXMLMaker: refactored some ([#1654])
+* MakerHelper: refactored some ([#1652])
+* introduced `ReVIEW::Template.generate` class to handle the templates ([#1648])
+* added a test of TeX compilation to GitHub Actions ([#1643])
+* refactored codes according to Rubocop 1.8 ([#1593], [#1598], [#1613], [#1636], [#1647])
+* fixed duplicate IDs of syntax-book sample ([#1646])
+* refactored the way to reference relative pathes ([#1639])
+* refactored `ReVIEW::LineInput` class ([#1638])
+* update Copyright to 2021 ([#1632])
+* added Ruby 3.0 to the test platform ([#1622])
+* suppressed tests for Pygments ([#1610], [#1618])
+* WebTocPrinter: fixed an error of test ([#1606])
+* improved to make it easier to specify the target of the test ([#1594])
+
+[#1664]: https://github.com/kmuto/review/pull/1664
+[#1663]: https://github.com/kmuto/review/pull/1663
+[#1660]: https://github.com/kmuto/review/issues/1660
+[#1659]: https://github.com/kmuto/review/pull/1659
+[#1658]: https://github.com/kmuto/review/pull/1658
+[#1656]: https://github.com/kmuto/review/pull/1656
+[#1655]: https://github.com/kmuto/review/pull/1655
+[#1654]: https://github.com/kmuto/review/pull/1654
+[#1653]: https://github.com/kmuto/review/pull/1653
+[#1652]: https://github.com/kmuto/review/pull/1652
+[#1650]: https://github.com/kmuto/review/pull/1650
+[#1649]: https://github.com/kmuto/review/pull/1649
+[#1648]: https://github.com/kmuto/review/pull/1648
+[#1647]: https://github.com/kmuto/review/pull/1647
+[#1646]: https://github.com/kmuto/review/pull/1646
+[#1644]: https://github.com/kmuto/review/issues/1644
+[#1643]: https://github.com/kmuto/review/pull/1643
+[#1642]: https://github.com/kmuto/review/pull/1642
+[#1641]: https://github.com/kmuto/review/pull/1641
+[#1640]: https://github.com/kmuto/review/pull/1640
+[#1639]: https://github.com/kmuto/review/pull/1639
+[#1638]: https://github.com/kmuto/review/pull/1638
+[#1637]: https://github.com/kmuto/review/pull/1637
+[#1636]: https://github.com/kmuto/review/pull/1636
+[#1635]: https://github.com/kmuto/review/pull/1635
+[#1633]: https://github.com/kmuto/review/issues/1633
+[#1632]: https://github.com/kmuto/review/issues/1632
+[#1630]: https://github.com/kmuto/review/issues/1630
+[#1629]: https://github.com/kmuto/review/pull/1629
+[#1626]: https://github.com/kmuto/review/pull/1626
+[#1623]: https://github.com/kmuto/review/issues/1623
+[#1622]: https://github.com/kmuto/review/pull/1622
+[#1619]: https://github.com/kmuto/review/issues/1619
+[#1618]: https://github.com/kmuto/review/pull/1618
+[#1617]: https://github.com/kmuto/review/pull/1617
+[#1614]: https://github.com/kmuto/review/pull/1614
+[#1613]: https://github.com/kmuto/review/pull/1613
+[#1611]: https://github.com/kmuto/review/issues/1611
+[#1610]: https://github.com/kmuto/review/pull/1610
+[#1607]: https://github.com/kmuto/review/issues/1607
+[#1606]: https://github.com/kmuto/review/issues/1606
+[#1605]: https://github.com/kmuto/review/issues/1605
+[#1604]: https://github.com/kmuto/review/issues/1604
+[#1602]: https://github.com/kmuto/review/pull/1602
+[#1598]: https://github.com/kmuto/review/pull/1598
+[#1596]: https://github.com/kmuto/review/issues/1596
+[#1594]: https://github.com/kmuto/review/pull/1594
+[#1593]: https://github.com/kmuto/review/pull/1593
+[#1591]: https://github.com/kmuto/review/issues/1591
+[#1587]: https://github.com/kmuto/review/issues/1587
+[#1575]: https://github.com/kmuto/review/issues/1575
+
 # Version 5.0.0
 ## New Features
 * added `cover_fit_page` option to review-jsbook / review-jlreq classes. When `cover_fit_page=true` is specified in the `texdocumentclass` parameter, the cover image is scaled to paper size. Note: it is recommended that the images should be created at actual size ([#1534])

--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * PDFMaker: fixed errors when index contains `{`, `}`, or `|` ([#1611])
 * review-vol: valid error messages will be displayed when invalid headings are found ([#1604])
 * PDFMaker: `after_makeindex` hook to be executed after `mendex` execution, not after LaTeX compilation ([#1605])
+* PDFMaker: if the caption of `//image` is empty, the figure number will be printed instead of an internal error ([#1666])
 
 ## Enhancements
 * Maker commands now display with nice colors and icons for their progress status when tty-logger gem is installed ([#1660])
@@ -31,7 +32,7 @@
 * EPUBMaker: moved EPUB library from `lib/epubmaker` to `lib/review/epubmaker` and refactored it ([#1575], [#1617], [#1635], [#1640], [#1641], [#1650], [#1653], [#1655])
 * EPUBMaker: added tests ([#1656])
 * PDFMaker: refactored some ([#1664])
-* introduced `ReVIEW::ImgMath` class to handle mathematic images ([#1642], [#1649], [#1659])
+* introduced `ReVIEW::ImgMath` class to handle mathematic images ([#1642], [#1649], [#1659], [#1662])
 * IDGXMLMaker: refactored some ([#1654])
 * MakerHelper: refactored some ([#1652])
 * introduced `ReVIEW::Template.generate` class to handle the templates ([#1648])
@@ -46,8 +47,10 @@
 * WebTocPrinter: fixed an error of test ([#1606])
 * improved to make it easier to specify the target of the test ([#1594])
 
+[#1666]: https://github.com/kmuto/review/issues/1666
 [#1664]: https://github.com/kmuto/review/pull/1664
 [#1663]: https://github.com/kmuto/review/pull/1663
+[#1662]: https://github.com/kmuto/review/issues/1662
 [#1660]: https://github.com/kmuto/review/issues/1660
 [#1659]: https://github.com/kmuto/review/pull/1659
 [#1658]: https://github.com/kmuto/review/pull/1658

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * PDFMaker: `after_makeindex` hook to be executed after `mendex` execution, not after LaTeX compilation ([#1605])
 * PDFMaker: if the caption of `//image` is empty, the figure number will be printed instead of an internal error ([#1666])
 * fixed review-vol and review-index errors when a file is invalid ([#1671])
+* EPUBMaker: fixed an error when static file is missing ([#1670])
 
 ## Enhancements
 * Maker commands now display with nice colors and icons for their progress status when tty-logger gem is installed ([#1660])
@@ -38,7 +39,7 @@
 * MakerHelper: refactored some ([#1652])
 * introduced `ReVIEW::Template.generate` class to handle the templates ([#1648])
 * added a test of TeX compilation to GitHub Actions ([#1643])
-* refactored codes according to Rubocop 1.8 ([#1593], [#1598], [#1613], [#1636], [#1647])
+* refactored codes according to Rubocop 1.10 ([#1593], [#1598], [#1613], [#1636], [#1647], [#1669])
 * fixed duplicate IDs of syntax-book sample ([#1646])
 * refactored the way to reference relative pathes ([#1639])
 * refactored `ReVIEW::LineInput` class ([#1638])
@@ -49,6 +50,8 @@
 * improved to make it easier to specify the target of the test ([#1594])
 
 [#1671]: https://github.com/kmuto/review/issues/1671
+[#1670]: https://github.com/kmuto/review/pull/1670
+[#1669]: https://github.com/kmuto/review/pull/1669
 [#1666]: https://github.com/kmuto/review/issues/1666
 [#1664]: https://github.com/kmuto/review/pull/1664
 [#1663]: https://github.com/kmuto/review/pull/1663

--- a/lib/review/version.rb
+++ b/lib/review/version.rb
@@ -1,3 +1,3 @@
 module ReVIEW
-  VERSION = '5.0.0'.freeze
+  VERSION = '5.1.0'.freeze
 end

--- a/review.gemspec
+++ b/review.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |gem|
   gem.platform    = Gem::Platform::RUBY
   gem.license     = 'LGPL'
   gem.authors     = %w[kmuto takahashim]
-  gem.email       = 'kmuto@debian.org'
+  gem.email       = 'kmuto@kmuto.jp'
   gem.homepage    = 'http://github.com/kmuto/review'
   gem.summary     = 'Re:VIEW: a easy-to-use digital publishing system'
   gem.description = 'Re:VIEW is a digital publishing system for books and ebooks. It supports InDesign, EPUB and LaTeX.'


### PR DESCRIPTION
@takahashim 
あとは27か28あたりにリリースよろしくお願いします、でよいでしょうか。
(今月は29がないですね)

news510ブランチから継承させています。
debian.orgアドレスはもう使えないのでpandoc2reviewと同じくkmuto.jpアドレスにしました。
