### PR TITLE
Revert "fix to avoid useless Error"

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -135,7 +135,9 @@ module ReVIEW
       I18n.setup(@config['language'])
       @basedir = File.absolute_path(File.dirname(yamlfile))
 
-      unless @config.check_version(ReVIEW::VERSION, exception: false)
+      begin
+        @config.check_version(ReVIEW::VERSION)
+      rescue ReVIEW::ConfigError => e
         warn e.message
       end
 


### PR DESCRIPTION
This reverts commit 6044bda84f9b84c9c423c06d5308333524a9b8b2.

エラーが出たので戻します。