### PR TITLE
Suppress warning about ERB.new

### DIFF
--- a/lib/review/template.rb
+++ b/lib/review/template.rb
@@ -19,11 +19,11 @@ module ReVIEW
       return unless filename
 
       content = File.read(filename)
-      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.6')
-        @erb = ERB.new(content, nil, mode)
-      else
-        @erb = ERB.new(content, trim_mode: mode)
-      end
+      @erb = if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
+               ERB.new(content, trim_mode: mode)
+             else
+               ERB.new(content, nil, mode)
+             end
     end
 
     def result(bind_data = nil)

--- a/lib/review/template.rb
+++ b/lib/review/template.rb
@@ -19,7 +19,11 @@ module ReVIEW
       return unless filename
 
       content = File.read(filename)
-      @erb = ERB.new(content, trim_mode: mode)
+      if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.6')
+        @erb = ERB.new(content, nil, mode)
+      else
+        @erb = ERB.new(content, trim_mode: mode)
+      end
     end
 
     def result(bind_data = nil)

--- a/lib/review/template.rb
+++ b/lib/review/template.rb
@@ -19,7 +19,7 @@ module ReVIEW
       return unless filename
 
       content = File.read(filename)
-      @erb = ERB.new(content, nil, mode)
+      @erb = ERB.new(content, trim_mode: mode)
     end
 
     def result(bind_data = nil)


### PR DESCRIPTION
Re:VIEWありがたく使わせていただいております。
いつもはプロジェクト直下で npm run pdfしているのですが、たまたま articles 以下で rake pdf したところ warningが出ていることに気がつきました。

```Shell
% rake pdf
review-pdfmaker  config.yml
ℹ INFO    compiling preface.tex    
ℹ INFO    compiling introduction.tex
ℹ INFO    compiling hardware.tex   
ℹ INFO    compiling firmware.tex   
ℹ INFO    compiling software.tex   
ℹ INFO    compiling bib.tex        
ℹ INFO    compiling contributors.tex
/opt/homebrew/lib/ruby/gems/3.0.0/gems/review-5.1.1/lib/review/template.rb:22: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/opt/homebrew/lib/ruby/gems/3.0.0/gems/review-5.1.1/lib/review/template.rb:22: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
/opt/homebrew/lib/ruby/gems/3.0.0/gems/review-5.1.1/lib/review/template.rb:22: warning: Passing safe_level with the 2nd argument of ERB.new is deprecated. Do not use it, and specify other arguments as keyword arguments.
/opt/homebrew/lib/ruby/gems/3.0.0/gems/review-5.1.1/lib/review/template.rb:22: warning: Passing trim_mode with the 3rd argument of ERB.new is deprecated. Use keyword argument like ERB.new(str, trim_mode: ...) instead.
ℹ INFO    uplatex -interaction=nonstopmode -file-line-error -halt-on-error __REVIEW_BOOK__.tex
ℹ INFO    uplatex -interaction=nonstopmode -file-line-error -halt-on-error __REVIEW_BOOK__.tex
ℹ INFO    uplatex -interaction=nonstopmode -file-line-error -halt-on-error __REVIEW_BOOK__.tex
ℹ INFO    dvipdfmx -d 5 -z 9 __REVIEW_BOOK__.dvi
✔ SUCCESS built PolarDrawingMachine.pdf
```

Rubyは詳しくないのですが、Version 2.6 からERB.new の2番目の引数safe_levelが廃止され、2番目の引数以降がキーワード引数にとなった影響によめました。
https://bugs.ruby-lang.org/issues/14256

おそらくwarningには気づいておられ、旧バージョンのRubyとの互換性を意識されて今の状態であると想像します。

私はmacOS Big Surユーザなのですが、OSバンドルのRubyは2.6.3p62、Homebrewで入るRubyは3.0.1p64でした。
個人的にはRuby2.6以降前提でも良いのかなと思い、ごく簡単ですが引数の修正をプルリクエストさせていただきます。
(もちろん、変更されるかどうかはkmutoさんのご判断におまかせいたします）

修正後は警告が消えることが確認できています。
```Shell
% rake pdf                                                                     
review-pdfmaker  config.yml
ℹ INFO    compiling preface.tex    
ℹ INFO    compiling introduction.tex
ℹ INFO    compiling hardware.tex   
ℹ INFO    compiling firmware.tex   
ℹ INFO    compiling software.tex   
ℹ INFO    compiling bib.tex        
ℹ INFO    compiling contributors.tex
ℹ INFO    uplatex -interaction=nonstopmode -file-line-error -halt-on-error __REVIEW_BOOK__.tex
ℹ INFO    uplatex -interaction=nonstopmode -file-line-error -halt-on-error __REVIEW_BOOK__.tex
ℹ INFO    uplatex -interaction=nonstopmode -file-line-error -halt-on-error __REVIEW_BOOK__.tex
ℹ INFO    dvipdfmx -d 5 -z 9 __REVIEW_BOOK__.dvi
✔ SUCCESS built PolarDrawingMachine.pdf
```

当方の環境は次の通りです。
```Shell
% uname -a
Darwin macmini.local 20.3.0 Darwin Kernel Version 20.3.0: Thu Jan 21 00:06:51 PST 2021; root:xnu-7195.81.3~1/RELEASE_ARM64_T8101 arm64
% ruby -v
ruby 3.0.1p64 (2021-04-05 revision 0fb782ee38) [arm64-darwin20]
% gem -v
3.2.15
% gem info review

*** LOCAL GEMS ***

review (5.1.1, 5.0.0)
    Authors: kmuto, takahashim
    Homepage: http://github.com/kmuto/review
    License: LGPL
    Installed at (5.1.1): /opt/homebrew/lib/ruby/gems/3.0.0
                 (5.0.0): /opt/homebrew/lib/ruby/gems/3.0.0

    Re:VIEW: a easy-to-use digital publishing system
```
