### PR TITLE
<section>のサポート

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -118,6 +118,7 @@ module ReVIEW
       unless @use_section
         return ''
       end
+
       "</section>\n" * @section_stack.size
     end
 

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -133,6 +133,67 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(\n<h3 id="test"><a id="h1-0-1"></a><span class="secno">1.0.1　</span>this is test.</h3>\n), actual
   end
 
+  def test_headline_sections
+    @book.config['epubmaker']['use_section'] = true
+    actual = compile_block("= H1\n== H2\n== H2-2\n")
+    expected = <<-EOS
+<section>
+<h1><a id="h1"></a><span class="secno">第1章　</span>H1</h1>
+<section>
+
+<h2><a id="h1-1"></a><span class="secno">1.1　</span>H2</h2>
+</section>
+<section>
+
+<h2><a id="h1-2"></a><span class="secno">1.2　</span>H2-2</h2>
+</section>
+</section>
+EOS
+    assert_equal expected, actual
+
+    actual = compile_block("= H1\n== H2\n==== H4\n== H2-2\n")
+    expected = <<-EOS
+<section>
+<h1><a id="h1"></a><span class="secno">第1章　</span>H1</h1>
+<section>
+
+<h2><a id="h1-1"></a><span class="secno">1.1　</span>H2</h2>
+<section>
+<section>
+
+<h4><a id="h1-1-0-1"></a>H4</h4>
+</section>
+</section>
+</section>
+<section>
+
+<h2><a id="h1-2"></a><span class="secno">1.2　</span>H2-2</h2>
+</section>
+</section>
+EOS
+    assert_equal expected, actual
+
+    actual = compile_block("===== H5\n= H1\n")
+    expected = <<-EOS
+<section>
+<section>
+<section>
+<section>
+<section>
+
+<h5><a id="h1-0-0-0-1"></a>H5</h5>
+</section>
+</section>
+</section>
+</section>
+</section>
+<section>
+<h1><a id="h1"></a><span class="secno">第1章　</span>H1</h1>
+</section>
+EOS
+    assert_equal expected, actual
+  end
+
   def test_label
     actual = compile_block("//label[label_test]\n")
     assert_equal %Q(<a id="label_test"></a>\n), actual

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -137,14 +137,11 @@ class HTMLBuidlerTest < Test::Unit::TestCase
     @book.config['epubmaker']['use_section'] = true
     actual = compile_block("= H1\n== H2\n== H2-2\n")
     expected = <<-EOS
+<section><h1><a id="h1"></a><span class="secno">第1章　</span>H1</h1>
 <section>
-<h1><a id="h1"></a><span class="secno">第1章　</span>H1</h1>
-<section>
-
 <h2><a id="h1-1"></a><span class="secno">1.1　</span>H2</h2>
 </section>
 <section>
-
 <h2><a id="h1-2"></a><span class="secno">1.2　</span>H2-2</h2>
 </section>
 </section>
@@ -153,20 +150,14 @@ EOS
 
     actual = compile_block("= H1\n== H2\n==== H4\n== H2-2\n")
     expected = <<-EOS
+<section><h1><a id="h1"></a><span class="secno">第1章　</span>H1</h1>
 <section>
-<h1><a id="h1"></a><span class="secno">第1章　</span>H1</h1>
-<section>
-
 <h2><a id="h1-1"></a><span class="secno">1.1　</span>H2</h2>
 <section>
-<section>
-
 <h4><a id="h1-1-0-1"></a>H4</h4>
 </section>
 </section>
-</section>
 <section>
-
 <h2><a id="h1-2"></a><span class="secno">1.2　</span>H2-2</h2>
 </section>
 </section>
@@ -176,19 +167,9 @@ EOS
     actual = compile_block("===== H5\n= H1\n")
     expected = <<-EOS
 <section>
-<section>
-<section>
-<section>
-<section>
-
 <h5><a id="h1-0-0-0-1"></a>H5</h5>
 </section>
-</section>
-</section>
-</section>
-</section>
-<section>
-<h1><a id="h1"></a><span class="secno">第1章　</span>H1</h1>
+<section><h1><a id="h1"></a><span class="secno">第1章　</span>H1</h1>
 </section>
 EOS
     assert_equal expected, actual


### PR DESCRIPTION
CSS組版との親和性を上げるため、
HTMLビルダにおいて、headlineレベルに基づき `<section>` 要素で囲んで構造化する機能を追加しようと思います。通常の見出しのみが対象で、コラムについてはこれまでどおりdivです。

Makerに応じて `epubmaker/use_section: true` か `webmaker/use_section: true` で有効になります。
