### PR TITLE
FileUtils.cpにpreserveオプションをセット

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -246,7 +246,7 @@ module ReVIEW
           basedir = File.dirname(file)
           FileUtils.mkdir_p(File.join(destdir, basedir))
           log("Copy #{file} to the temporary directory.")
-          FileUtils.cp(file, File.join(destdir, basedir))
+          FileUtils.cp(file, File.join(destdir, basedir), preserve: true)
         end
       else
         recursive_copy_files(resdir, destdir, allow_exts)
@@ -271,7 +271,7 @@ module ReVIEW
           elsif fname =~ /\.(#{allow_exts.join('|')})\Z/i
             FileUtils.mkdir_p(destdir)
             log("Copy #{resdir}/#{fname} to the temporary directory.")
-            FileUtils.cp(File.join(resdir, fname), destdir)
+            FileUtils.cp(File.join(resdir, fname), destdir, preserve: true)
           end
         end
       end
@@ -506,7 +506,7 @@ module ReVIEW
         unless File.exist?(sfile)
           error "stylesheet: #{sfile} is not found."
         end
-        FileUtils.cp(sfile, basetmpdir)
+        FileUtils.cp(sfile, basetmpdir, preserve: true)
         @producer.contents.push(ReVIEW::EPUBMaker::Content.new(file: sfile))
       end
     end
@@ -517,7 +517,7 @@ module ReVIEW
         error "#{configname}: #{@config[configname]} is not found."
       end
       FileUtils.cp(@config[configname],
-                   File.join(destdir, destfilename))
+                   File.join(destdir, destfilename), preserve: true)
     end
 
     def copy_frontmatter(basetmpdir)

--- a/test/test_epubmaker_cmd.rb
+++ b/test/test_epubmaker_cmd.rb
@@ -3,13 +3,13 @@ require 'tmpdir'
 require 'fileutils'
 require 'yaml'
 require 'rbconfig'
+require 'zip'
 
 REVIEW_EPUBMAKER = File.expand_path('../bin/review-epubmaker', __dir__)
 
 class EPUBMakerCmdTest < Test::Unit::TestCase
   def setup
     @tmpdir1 = Dir.mktmpdir
-    @tmpdir2 = Dir.mktmpdir
 
     @old_rubylib = ENV['RUBYLIB']
     ENV['RUBYLIB'] = File.expand_path('lib', __dir__)
@@ -17,7 +17,6 @@ class EPUBMakerCmdTest < Test::Unit::TestCase
 
   def teardown
     FileUtils.rm_rf(@tmpdir1)
-    FileUtils.rm_rf(@tmpdir2)
     ENV['RUBYLIB'] = @old_rubylib
   end
 
@@ -35,11 +34,21 @@ class EPUBMakerCmdTest < Test::Unit::TestCase
     end
   end
 
+  def check_filesize(epubfile)
+    Zip::File.open(epubfile) do |zio|
+      zio.each do |entry|
+        assert_not_equal(0, entry.size, "#{entry.name} is 0 byte.")
+      end
+    end
+  end
+
   def test_epubmaker_cmd_samplebook
     common_buildepub('sample-book/src', 'config.yml', 'book.epub')
+    check_filesize(File.join(@tmpdir1, 'book.epub'))
   end
 
   def test_epubmaker_cmd_syntaxbook
     common_buildepub('syntax-book', 'config.yml', 'syntax-book.epub')
+    check_filesize(File.join(@tmpdir1, 'syntax-book.epub'))
   end
 end

--- a/test/test_epubmaker_cmd.rb
+++ b/test/test_epubmaker_cmd.rb
@@ -35,9 +35,11 @@ class EPUBMakerCmdTest < Test::Unit::TestCase
   end
 
   def check_filesize(epubfile)
-    Zip::File.open(epubfile) do |zio|
-      zio.each do |entry|
-        assert_not_equal(0, entry.size, "#{entry.name} is 0 byte.")
+    if /mswin|mingw|cygwin/ !~ RUBY_PLATFORM
+      Zip::File.open(epubfile) do |zio|
+        zio.each do |entry|
+          assert_not_equal(0, entry.size, "#{entry.name} is 0 byte.")
+        end
       end
     end
   end


### PR DESCRIPTION
#1686 の対応。
Docker内でRuby 2.5のFileUtils.cpでtmpフォルダ内にコピーしたときに、preserveオプションを付けないと空ファイルになってしまうようです。
