### PR TITLE
縦中横が指定された範囲をそのように表示するためのCSSを追加

### DIFF
--- a/doc/writing_vertical.ja.md
+++ b/doc/writing_vertical.ja.md
@@ -35,6 +35,12 @@ body {
     -epub-writing-mode:   vertical-rl;
     writing-mode: tb-rl;
 }
+
+span.tcy {
+    -webkit-text-combine: horizontal;
+    -ms-text-combine-horizontal: all;
+    text-combine-upright: all;
+}
 ```
 
 また、縦書きの書籍は通常、「左開き」（右ページから左ページへ進む）となるので、config.yml の direction パラメータを設定します。


### PR DESCRIPTION
本文を@<tcy>{～}で囲むだけでは縦中横にならず、このCSSを追加する必要がありました。
少なくともKinoppyでの閲覧においてはベンダープレフィックスも必要でした。
ご確認ください。