### PR TITLE
remove unnecessary [dvipdfmx] option of pxjahyper

### DIFF
--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -218,7 +218,7 @@
 ]{hyperref}
 
 \def\recls@tmp{uplatex}\ifx\recls@tmp\recls@engine
-  \RequirePackage[\recls@driver]{pxjahyper}
+  \RequirePackage{pxjahyper}
 \fi
 
 %% include fullpage graphics

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -389,7 +389,7 @@
   hidelinks,
   setpagesize=false,
 ]{hyperref}
-\RequirePackage[dvipdfmx]{pxjahyper}
+\RequirePackage{pxjahyper}
 
 %% more useful macros
 %% ----------


### PR DESCRIPTION
最近のTeXLIveのplautopatchとの組み合わせで、review-jsbook.cls,review-jlreq.clsで
```
\RequirePackage[dvipdfmx]{pxjahyper}
```
としていると `LaTeX Error: Option clash for package pxjahyper.` というエラーになります。plautopatchの事前処理と`[dvipdfmx]`が衝突するようです。

リファレンスバージョンとなるDebian 10 BusterのTeXLive 2018の時点でもplautopatchに関係なくdvipdfmxを明示する必要なく動作する(bookmarkが化けない)ことを確認したので、`[dvipdfmx]` を外します。