### PR TITLE
GA: ignore push to non-master

### DIFF
--- a/.github/workflows/ruby-tex.yml
+++ b/.github/workflows/ruby-tex.yml
@@ -1,6 +1,10 @@
 name: Test with TeXLive
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/ruby-win.yml
+++ b/.github/workflows/ruby-win.yml
@@ -1,6 +1,10 @@
 name: TestWin
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
本リポジトリ内でのpull requestのときにGitHub Actionsが2回実行されていたのを1回にします