### PR TITLE
Refactor EPUB2HTML

### DIFF
--- a/lib/review/epub2html.rb
+++ b/lib/review/epub2html.rb
@@ -23,7 +23,7 @@ module ReVIEW
       new.execute(*args)
     end
 
-    def execute(*args)
+    def parse_options!(*args)
       opts = OptionParser.new
 
       opts.banner = <<EOT
@@ -47,8 +47,17 @@ EOT
         exit 1
       end
 
-      htmls = parse_epub(args[0])
-      puts join_html(args[1], htmls)
+      args
+    end
+
+    def execute(*args)
+      params = parse_options!(*args)
+      execute_with_params(*params)
+    end
+
+    def execute_with_params(epubname, reffile)
+      htmls = parse_epub(epubname)
+      puts join_html(reffile, htmls)
     end
 
     def initialize

--- a/lib/review/epub2html.rb
+++ b/lib/review/epub2html.rb
@@ -23,6 +23,11 @@ module ReVIEW
       new.execute(*args)
     end
 
+    def initialize
+      @opfxml = nil
+      @inline_footnote = nil
+    end
+
     def parse_options!(*args)
       opts = OptionParser.new
 
@@ -58,11 +63,6 @@ EOT
     def execute_with_params(epubname, reffile)
       htmls = parse_epub(epubname)
       puts join_html(reffile, htmls)
-    end
-
-    def initialize
-      @opfxml = nil
-      @inline_footnote = nil
     end
 
     def parse_epub(epubname)

--- a/lib/review/epub2html.rb
+++ b/lib/review/epub2html.rb
@@ -64,7 +64,7 @@ EOT
             opf = entry.get_input_stream.read
             @opfxml = REXML::Document.new(opf)
           elsif entry.name =~ /.+\.x?html\Z/
-            htmls[entry.name.sub('OEBPS/', '')] = entry.get_input_stream.read.force_encoding('utf-8')
+            htmls[File.basename(entry.name)] = entry.get_input_stream.read.force_encoding('utf-8')
           end
         end
       end
@@ -145,7 +145,8 @@ EOT
     def join_html(reffile, htmls)
       head = tail = nil
       body = []
-      make_list.each do |fname|
+      make_list.each do |href_value|
+        fname = File.basename(href_value)
         if head.nil? && (reffile.nil? || reffile == fname)
           head, tail = take_headtail(htmls[fname])
         end

--- a/lib/review/epub2html.rb
+++ b/lib/review/epub2html.rb
@@ -47,35 +47,35 @@ EOT
         exit 1
       end
 
-      parse_epub(args[0])
-      puts join_html(args[1])
+      htmls = parse_epub(args[0])
+      puts join_html(args[1], htmls)
     end
 
     def initialize
       @opfxml = nil
-      @htmls = {}
-      @head = nil
-      @tail = nil
       @inline_footnote = nil
     end
 
     def parse_epub(epubname)
+      htmls = {}
       Zip::File.open(epubname) do |zio|
         zio.each do |entry|
           if entry.name =~ /.+\.opf\Z/
             opf = entry.get_input_stream.read
             @opfxml = REXML::Document.new(opf)
           elsif entry.name =~ /.+\.x?html\Z/
-            @htmls[entry.name.sub('OEBPS/', '')] = entry.get_input_stream.read.force_encoding('utf-8')
+            htmls[entry.name.sub('OEBPS/', '')] = entry.get_input_stream.read.force_encoding('utf-8')
           end
         end
       end
-      nil
+      htmls
     end
 
     def take_headtail(html)
-      @head = html.sub(/(<body.*?>).*/m, '\1')
-      @tail = html.sub(%r{.*(</body>)}m, '\1')
+      head = html.sub(/(<body.*?>).*/m, '\1')
+      tail = html.sub(%r{.*(</body>)}m, '\1')
+
+      [head, tail]
     end
 
     def sanitize(s)
@@ -142,16 +142,17 @@ EOT
         sub(%r{(</body>).*}m, '</section>')
     end
 
-    def join_html(reffile)
+    def join_html(reffile, htmls)
+      head = tail = nil
       body = []
       make_list.each do |fname|
-        if @head.nil? && (reffile.nil? || reffile == fname)
-          take_headtail(@htmls[fname])
+        if head.nil? && (reffile.nil? || reffile == fname)
+          head, tail = take_headtail(htmls[fname])
         end
 
-        body << modify_html(fname, @htmls[fname])
+        body << modify_html(fname, htmls[fname])
       end
-      "#{@head}\n#{body.join("\n")}\n#{@tail}"
+      "#{head}\n#{body.join("\n")}\n#{tail}"
     end
 
     def make_list


### PR DESCRIPTION
EPUBを経由しないで一発でHTML吐けないかな…と思いながらリファクタリングしてみました。

* `@htmls`、`@head`、`@tail`の各インスタンス変数は、スコープを狭くしても混乱しなさそうだったのでローカル変数にしました
* HTMLファイルの比較はファイル名でやれば良さそうだったので`File.basename()`同士で比較するようにしました
* `EPUB2HTML.new.execute_with_params(...)`で、CLIからじゃなくても使えるようにしました