### PR TITLE
rubocop: enabled Naming/MemoizedInstanceVariableName

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -587,7 +587,7 @@ Naming/HeredocDelimiterNaming:
   Enabled: false
 
 Naming/MemoizedInstanceVariableName:
-  Enabled: false
+  Enabled: true
 
 Naming/MethodName:
   Enabled: true

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -200,7 +200,7 @@ module ReVIEW
 
     def ol_begin
       puts '<ol>'
-      @ol_num ||= 1
+      @ol_num ||= 1 # rubocop:disable Naming/MemoizedInstanceVariableName
     end
 
     def ol_item(lines, num)


### PR DESCRIPTION
rubocopルールの適用を追加します。
誤検出があったのでコメントで抑制します。