### PR TITLE
refactor: move `@doc_status` into compiler

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -32,14 +32,12 @@ module ReVIEW
       nil
     end
 
-    attr_accessor :doc_status
     attr_reader :location
 
     def initialize(strict = false, *_args, img_math: nil)
       @strict = strict
       @output = nil
       @logger = ReVIEW.logger
-      @doc_status = {}
       @dictionary = {}
       @img_math = img_math
     end
@@ -88,7 +86,6 @@ module ReVIEW
 
     def builder_init_file
       @sec_counter = SecCounter.new(5, @chapter)
-      @doc_status = {}
     end
     private :builder_init_file
 
@@ -552,32 +549,30 @@ module ReVIEW
     CAPTION_TITLES.each do |name|
       class_eval %Q(
         def #{name}(lines, caption = nil)
-          check_nested_minicolumn
           captionblock("#{name}", lines, caption)
         end
 
         def #{name}_begin(caption = nil)
-          check_nested_minicolumn
-          @doc_status[:minicolumn] = '#{name}'
           if caption
             puts compile_inline(caption)
           end
         end
 
         def #{name}_end
-          @doc_status[:minicolumn] = nil
         end
-      ), __FILE__, __LINE__ - 17
-    end
-
-    def check_nested_minicolumn
-      if @doc_status[:minicolumn]
-        app_error "#{@location}: nested mini-column is not allowed"
-      end
+      ), __FILE__, __LINE__ - 13
     end
 
     def in_minicolumn?
-      @doc_status[:minicolumn]
+      @compiler.in_minicolumn?
+    end
+
+    def in_column?
+      @compiler.in_minicolumn?
+    end
+
+    def in_dt?
+      @compiler.in_dt?
     end
 
     def minicolumn_block_name?(name)

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -246,7 +246,6 @@ module ReVIEW
     end
 
     def captionblock(type, lines, caption)
-      check_nested_minicolumn
       puts %Q(<div class="#{type}">)
       if caption.present?
         puts %Q(<p class="caption">#{compile_inline(caption)}</p>)
@@ -334,8 +333,6 @@ module ReVIEW
     CAPTION_TITLES.each do |name|
       class_eval %Q(
         def #{name}_begin(caption = nil)
-          check_nested_minicolumn
-          @doc_status[:minicolumn] = '#{name}'
           puts %Q(<div class="#{name}">)
           if caption.present?
             puts %Q(<p class="caption">\#{compile_inline(caption)}</p>)
@@ -344,9 +341,8 @@ module ReVIEW
 
         def #{name}_end
           puts '</div>'
-          @doc_status[:minicolumn] = nil
         end
-      ), __FILE__, __LINE__ - 14
+      ), __FILE__, __LINE__ - 11
     end
 
     def ul_begin

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -65,6 +65,7 @@ module ReVIEW
       print %Q(<?xml version="1.0" encoding="UTF-8"?>\n)
       print %Q(<#{@rootelement} xmlns:aid="http://ns.adobe.com/AdobeInDesign/4.0/">)
       @secttags = @book.config['structuredxml']
+      @minicolumn_with_caption = nil
     end
     private :builder_init_file
 
@@ -955,22 +956,18 @@ module ReVIEW
     end
 
     def note(lines, caption = nil)
-      check_nested_minicolumn
       captionblock('note', lines, caption)
     end
 
     def memo(lines, caption = nil)
-      check_nested_minicolumn
       captionblock('memo', lines, caption)
     end
 
     def tip(lines, caption = nil)
-      check_nested_minicolumn
       captionblock('tip', lines, caption)
     end
 
     def info(lines, caption = nil)
-      check_nested_minicolumn
       captionblock('info', lines, caption)
     end
 
@@ -983,7 +980,6 @@ module ReVIEW
     end
 
     def important(lines, caption = nil)
-      check_nested_minicolumn
       captionblock('important', lines, caption)
     end
 
@@ -992,12 +988,10 @@ module ReVIEW
     end
 
     def caution(lines, caption = nil)
-      check_nested_minicolumn
       captionblock('caution', lines, caption)
     end
 
     def warning(lines, caption = nil)
-      check_nested_minicolumn
       captionblock('warning', lines, caption)
     end
 
@@ -1010,7 +1004,6 @@ module ReVIEW
     end
 
     def notice(lines, caption = nil)
-      check_nested_minicolumn
       if caption
         captionblock('notice-t', lines, caption, 'notice-title')
       else
@@ -1049,12 +1042,10 @@ module ReVIEW
     CAPTION_TITLES.each do |name|
       class_eval %Q(
         def #{name}_begin(caption = nil)
-          check_nested_minicolumn
           if '#{name}' == 'notice' && caption.present?
-            @doc_status[:minicolumn] = '#{name}-t'
+            @minicolumn_with_caption = true
             print "<#{name}-t>"
           else
-            @doc_status[:minicolumn] = '#{name}'
             print "<#{name}>"
           end
           if caption.present?
@@ -1063,14 +1054,14 @@ module ReVIEW
         end
 
         def #{name}_end
-          if '#{name}' == 'notice' && @doc_status[:minicolumn] == 'notice-t'
+          if '#{name}' == 'notice' && @minicolumn_with_caption
             print "</#{name}-t>"
+            @minicolumn_with_caption = nil
           else
             print "</#{name}>"
           end
-          @doc_status[:minicolumn] = nil
         end
-      ), __FILE__, __LINE__ - 23
+      ), __FILE__, __LINE__ - 21
     end
 
     def syntaxblock(type, lines, caption)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -143,9 +143,7 @@ module ReVIEW
         prefix = '*'
       end
       blank unless @output.pos == 0
-      @doc_status[:caption] = true
-      puts macro(headline_name + prefix, compile_inline(caption))
-      @doc_status[:caption] = nil
+      puts macro(headline_name + prefix, compile_caption_text(caption))
       if prefix == '*' && level <= @book.config['toclevel'].to_i
         puts "\\addcontentsline{toc}{#{headline_name}}{#{compile_inline(caption)}}"
       end
@@ -161,9 +159,7 @@ module ReVIEW
 
     def nonum_begin(level, _label, caption)
       blank unless @output.pos == 0
-      @doc_status[:caption] = true
-      puts macro(HEADLINE[level] + '*', compile_inline(caption))
-      @doc_status[:caption] = nil
+      puts macro(HEADLINE[level] + '*', compile_caption_text(caption))
       puts macro('addcontentsline', 'toc', HEADLINE[level], compile_inline(caption))
     end
 
@@ -172,9 +168,7 @@ module ReVIEW
 
     def notoc_begin(level, _label, caption)
       blank unless @output.pos == 0
-      @doc_status[:caption] = true
-      puts macro(HEADLINE[level] + '*', compile_inline(caption))
-      @doc_status[:caption] = nil
+      puts macro(HEADLINE[level] + '*', compile_caption_text(caption))
     end
 
     def notoc_end(level)
@@ -203,17 +197,15 @@ module ReVIEW
         target = "\\hypertarget{#{column_label(caption)}}{}"
       end
 
-      @doc_status[:caption] = true
       if @book.config.check_version('2', exception: false)
         puts '\\begin{reviewcolumn}'
         puts target
-        puts macro('reviewcolumnhead', nil, compile_inline(caption))
+        puts macro('reviewcolumnhead', nil, compile_caption_text(caption))
       else
         # ver.3
         print '\\begin{reviewcolumn}'
-        puts "[#{compile_inline(caption)}#{target}]"
+        puts "[#{compile_caption_text(caption)}#{target}]"
       end
-      @doc_status[:caption] = nil
 
       if level <= @book.config['toclevel'].to_i
         puts "\\addcontentsline{toc}{#{HEADLINE[level]}}{#{compile_inline(caption)}}"
@@ -234,19 +226,17 @@ module ReVIEW
 
       print "\\begin{#{command_name}}"
 
-      @doc_status[:caption] = true
       if @book.config.check_version('2', exception: false)
         puts
         if caption.present?
-          puts "\\reviewminicolumntitle{#{compile_inline(caption)}}"
+          puts "\\reviewminicolumntitle{#{compile_caption_text(caption)}}"
         end
       else
         if caption.present?
-          print "[#{compile_inline(caption)}]"
+          print "[#{compile_caption_text(caption)}]"
         end
         puts
       end
-      @doc_status[:caption] = nil
     end
 
     def common_block_end(type)
@@ -280,20 +270,18 @@ module ReVIEW
 
       print "\\begin{#{command_name}}"
 
-      @doc_status[:caption] = true
       if @book.config.check_version('2', exception: false)
         puts
         if caption.present?
-          puts "\\reviewminicolumntitle{#{compile_inline(caption)}}"
+          puts "\\reviewminicolumntitle{#{compile_caption_text(caption)}}"
         end
       else
         if caption.present?
-          print "[#{compile_inline(caption)}]"
+          print "[#{compile_caption_text(caption)}]"
         end
         puts
       end
 
-      @doc_status[:caption] = nil
       blocked_lines = split_paragraph(lines)
       puts blocked_lines.join("\n\n")
 
@@ -464,27 +452,25 @@ module ReVIEW
     end
 
     def common_code_block(id, lines, command, caption, _lang)
-      @doc_status[:caption] = true
       captionstr = nil
       unless @book.config.check_version('2', exception: false)
         puts '\\begin{reviewlistblock}'
       end
       if caption.present?
         if command =~ /emlist/ || command =~ /cmd/ || command =~ /source/
-          captionstr = macro(command + 'caption', compile_inline(caption))
+          captionstr = macro(command + 'caption', compile_caption_text(caption))
         else
           begin
             if get_chap.nil?
-              captionstr = macro('reviewlistcaption', "#{I18n.t('list')}#{I18n.t('format_number_header_without_chapter', [@chapter.list(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}")
+              captionstr = macro('reviewlistcaption', "#{I18n.t('list')}#{I18n.t('format_number_header_without_chapter', [@chapter.list(id).number])}#{I18n.t('caption_prefix')}#{compile_caption_text(caption)}")
             else
-              captionstr = macro('reviewlistcaption', "#{I18n.t('list')}#{I18n.t('format_number_header', [get_chap, @chapter.list(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}")
+              captionstr = macro('reviewlistcaption', "#{I18n.t('list')}#{I18n.t('format_number_header', [get_chap, @chapter.list(id).number])}#{I18n.t('caption_prefix')}#{compile_caption_text(caption)}")
             end
           rescue KeyError
             app_error "no such list: #{id}"
           end
         end
       end
-      @doc_status[:caption] = nil
 
       if caption_top?('list') && captionstr
         puts captionstr
@@ -577,14 +563,12 @@ module ReVIEW
 
     def image_image(id, caption = '', metric = nil)
       captionstr = nil
-      @doc_status[:caption] = true
       if @book.config.check_version('2', exception: false)
-        captionstr = macro('caption', compile_inline(caption)) + "\n"
+        captionstr = macro('caption', compile_caption_text(caption)) + "\n"
       else
-        captionstr = macro('reviewimagecaption', compile_inline(caption)) + "\n"
+        captionstr = macro('reviewimagecaption', compile_caption_text(caption)) + "\n"
       end
       captionstr << macro('label', image_label(id))
-      @doc_status[:caption] = nil
 
       metrics = parse_metric('latex', metric)
       # image is always bound here
@@ -621,13 +605,11 @@ module ReVIEW
         puts detab(line.rstrip)
       end
       puts macro('label', image_label(id))
-      @doc_status[:caption] = true
       if @book.config.check_version('2', exception: false)
-        puts macro('caption', compile_inline(caption)) if caption.present?
+        puts macro('caption', compile_caption_text(caption)) if caption.present?
       elsif caption.present?
-        puts macro('reviewimagecaption', compile_inline(caption))
+        puts macro('reviewimagecaption', compile_caption_text(caption))
       end
-      @doc_status[:caption] = nil
       puts '\end{reviewdummyimage}'
     end
 
@@ -676,10 +658,8 @@ module ReVIEW
 
       captionstr = nil
       if caption.present?
-        @doc_status[:caption] = true
         captionstr = macro('reviewindepimagecaption',
-                           %Q(#{I18n.t('numberless_image')}#{I18n.t('caption_prefix')}#{compile_inline(caption)}))
-        @doc_status[:caption] = nil
+                           %Q(#{I18n.t('numberless_image')}#{I18n.t('caption_prefix')}#{compile_caption_text(caption)}))
       end
 
       if @chapter.image(id).path
@@ -782,15 +762,11 @@ module ReVIEW
     def table_header(id, caption)
       if id.nil?
         if caption.present?
-          @doc_status[:caption] = true
-          puts macro('reviewtablecaption*', compile_inline(caption))
-          @doc_status[:caption] = nil
+          puts macro('reviewtablecaption*', compile_caption_text(caption))
         end
       else
         if caption.present?
-          @doc_status[:caption] = true
-          puts macro('reviewtablecaption', compile_inline(caption))
-          @doc_status[:caption] = nil
+          puts macro('reviewtablecaption', compile_caption_text(caption))
         end
         puts macro('label', table_label(id))
       end
@@ -907,9 +883,7 @@ module ReVIEW
       begin
         if caption.present?
           puts "\\begin{table}[h]%%#{id}"
-          @doc_status[:caption] = true
-          captionstr = macro('reviewimgtablecaption', compile_inline(caption))
-          @doc_status[:caption] = nil
+          captionstr = macro('reviewimgtablecaption', compile_caption_text(caption))
           if caption_top?('table')
             puts captionstr
           end
@@ -1140,7 +1114,7 @@ module ReVIEW
     def inline_fn(id)
       if @book.config['footnotetext']
         macro("footnotemark[#{@chapter.footnote(id).number}]", '')
-      elsif @doc_status[:caption] || @doc_status[:table] || in_column? || in_dt?
+      elsif in_caption? || in_column? || in_dt?
         @foottext[id] = @chapter.footnote(id).number
         macro('protect\\footnotemark', '')
       else
@@ -1419,6 +1393,17 @@ module ReVIEW
 
     def olnum(num)
       @ol_num = num.to_i
+    end
+
+    def in_caption?
+      @in_caption
+    end
+
+    def compile_caption_text(caption)
+      @in_caption = true
+      caption_text = @compiler.text(caption)
+      @in_caption = nil
+      return caption_text
     end
   end
 end

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -162,8 +162,6 @@ module ReVIEW
     CAPTION_TITLES.each do |name|
       class_eval %Q(
         def #{name}_begin(caption = nil)
-          check_nested_minicolumn
-          @doc_status[:minicolumn] = '#{name}'
           puts %Q(<div class="#{name}">)
           if caption.present?
             puts %Q(<p class="caption">\#{compile_inline(caption)}</p>)
@@ -172,9 +170,8 @@ module ReVIEW
 
         def #{name}_end
           puts '</div>'
-          @doc_status[:minicolumn] = nil
         end
-      ), __FILE__, __LINE__ - 14
+      ), __FILE__, __LINE__ - 11
     end
 
     def hr

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -19,7 +19,7 @@ module ReVIEW
 
     Compiler.defblock(:insn, 1)
     Compiler.defblock(:planning, 0..1)
-    Compiler.defblock(:best, 0..1)
+    Compiler.defminicolumn(:best, 0..1)
     Compiler.defblock(:securty, 0..1)
     Compiler.defblock(:point, 0..1)
     Compiler.defblock(:reference, 0)
@@ -520,22 +520,18 @@ module ReVIEW
     end
 
     def note(lines, caption = nil)
-      check_nested_minicolumn
       base_parablock('note', lines, caption)
     end
 
     def memo(lines, caption = nil)
-      check_nested_minicolumn
       base_parablock('memo', lines, caption)
     end
 
     def tip(lines, caption = nil)
-      check_nested_minicolumn
       base_parablock('tip', lines, caption)
     end
 
     def info(lines, caption = nil)
-      check_nested_minicolumn
       base_parablock('info', lines, caption)
     end
 
@@ -544,12 +540,10 @@ module ReVIEW
     end
 
     def best(lines, caption = nil)
-      check_nested_minicolumn
       base_parablock('best', lines, caption)
     end
 
     def important(lines, caption = nil)
-      check_nested_minicolumn
       base_parablock('important', lines, caption)
     end
 
@@ -558,7 +552,6 @@ module ReVIEW
     end
 
     def caution(lines, caption = nil)
-      check_nested_minicolumn
       base_parablock('caution', lines, caption)
     end
 
@@ -571,7 +564,6 @@ module ReVIEW
     end
 
     def notice(lines, caption = nil)
-      check_nested_minicolumn
       base_parablock('notice', lines, caption)
     end
 
@@ -600,7 +592,6 @@ module ReVIEW
     end
 
     def warning(lines, caption = nil)
-      check_nested_minicolumn
       base_parablock('warning', lines, caption)
     end
 
@@ -609,8 +600,6 @@ module ReVIEW
     CAPTION_TITLES.each do |name|
       class_eval %Q(
         def #{name}_begin(caption = nil)
-          check_nested_minicolumn
-          @doc_status[:minicolumn] = '#{name}'
           blank
           if caption.present?
             puts compile_inline(caption)
@@ -619,9 +608,8 @@ module ReVIEW
 
         def #{name}_end
           blank
-          @doc_status[:minicolumn] = nil
         end
-      ), __FILE__, __LINE__ - 14
+      ), __FILE__, __LINE__ - 11
     end
 
     def indepimage(_lines, _id, caption = nil, _metric = nil)

--- a/lib/review/rstbuilder.rb
+++ b/lib/review/rstbuilder.rb
@@ -586,8 +586,6 @@ module ReVIEW
     CAPTION_TITLES.each do |name|
       class_eval %Q(
         def #{name}_begin(caption = nil)
-          check_nested_minicolumn
-          @doc_status[:minicolumn] = '#{name}'
           puts ".. #{name}::"
           blank
           puts "   " + compile_inline(caption).to_s unless caption.nil?
@@ -596,9 +594,8 @@ module ReVIEW
 
         def #{name}_end
           blank
-          @doc_status[:minicolumn] = nil
         end
-      ), __FILE__, __LINE__ - 14
+      ), __FILE__, __LINE__ - 11
     end
 
     def note(lines, caption = nil)

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -465,16 +465,13 @@ module ReVIEW
     CAPTION_TITLES.each do |name|
       class_eval %Q(
         def #{name}_begin(caption = nil)
-          check_nested_minicolumn
-          @doc_status[:minicolumn] = '#{name}'
           common_block_begin('#{name}', nil, nil, caption)
         end
 
         def #{name}_end
           common_block_end('#{name}', nil)
-          @doc_status[:minicolumn] = nil
         end
-      ), __FILE__, __LINE__ - 11
+      ), __FILE__, __LINE__ - 8
     end
 
     def indepimage(_lines, id, caption = nil, metric = nil)

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -2729,7 +2729,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error1
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 
@@ -2745,7 +2744,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error2
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 
@@ -2762,7 +2760,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error3
     %w[memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -429,7 +429,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error1
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 
@@ -445,7 +444,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error2
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 
@@ -462,7 +460,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error3
     %w[memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -2245,7 +2245,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error1
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 
@@ -2261,7 +2260,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error2
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 
@@ -2278,7 +2276,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error3
     %w[memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -592,7 +592,6 @@ EOS
 
   def test_minicolumn_blocks
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}[#{type}1]{
 
@@ -684,7 +683,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error1
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 
@@ -700,7 +698,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error2
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 
@@ -717,7 +714,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error3
     %w[memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -755,7 +755,6 @@ EOS
     }
 
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}[#{type}1]{
 
@@ -872,7 +871,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error1
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 
@@ -888,7 +886,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error2
     %w[note memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 
@@ -905,7 +902,6 @@ EOS
 
   def test_minicolumn_blocks_nest_error3
     %w[memo tip info warning important caution notice].each do |type|
-      @builder.doc_status.clear
       src = <<-EOS
 //#{type}{
 


### PR DESCRIPTION
#1698 と同じような課題ですが、`@doc_status`や`check_nested_minicolumn`などがbuilderのあちこちに分散しているのを避けるべく、compiler側に移動してみました。