### PR TITLE
PDFMaker: コピーの代わりにシンボリックリンクを使う機能の提供

### DIFF
--- a/lib/review/makerhelper.rb
+++ b/lib/review/makerhelper.rb
@@ -61,7 +61,11 @@ module ReVIEW
             exts = options[:exts] || %w[png gif jpg jpeg svg pdf eps ai tif psd]
             exts_str = exts.join('|')
             if !is_converted && fname =~ /\.(#{exts_str})$/i
-              FileUtils.cp("#{from_dir}/#{fname}", to_dir)
+              if options[:use_symlink]
+                FileUtils.ln_s(File.realpath("#{from_dir}/#{fname}"), to_dir)
+              else
+                FileUtils.cp("#{from_dir}/#{fname}", to_dir)
+              end
               image_files << "#{from_dir}/#{fname}"
             end
           end

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -307,7 +307,11 @@ module ReVIEW
       return unless File.exist?(from)
 
       Dir.mkdir(to)
-      ReVIEW::MakerHelper.copy_images_to_dir(from, to)
+      if @config['pdfmaker']['use_symlink']
+        ReVIEW::MakerHelper.copy_images_to_dir(from, to, { use_symlink: true })
+      else
+        ReVIEW::MakerHelper.copy_images_to_dir(from, to)
+      end
     end
 
     def make_custom_page(file)
@@ -496,6 +500,8 @@ module ReVIEW
             File.open(File.join(copybase, fname.sub(/\.erb\Z/, '')), 'w') do |f|
               f.print erb_content(File.join(dirname, fname))
             end
+          elsif @config['pdfmaker']['use_symlink']
+            FileUtils.ln_s(File.join(dirname, fname), copybase)
           else
             FileUtils.cp(File.join(dirname, fname), copybase)
           end

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -273,6 +273,9 @@ module ReVIEW
         @config['usepackage'] = ''
         @config['usepackage'] = "\\usepackage{#{@config['texstyle']}}" if @config['texstyle']
 
+        if @config['pdfmaker']['use_symlink']
+          logger.info 'use symlink'
+        end
         copy_images(@config['imagedir'], File.join(@path, @config['imagedir']))
         copy_sty(File.join(Dir.pwd, 'sty'), @path)
         copy_sty(File.join(Dir.pwd, 'sty'), @path, 'fd')
@@ -308,7 +311,7 @@ module ReVIEW
 
       Dir.mkdir(to)
       if @config['pdfmaker']['use_symlink']
-        ReVIEW::MakerHelper.copy_images_to_dir(from, to, { use_symlink: true })
+        ReVIEW::MakerHelper.copy_images_to_dir(from, to, use_symlink: true)
       else
         ReVIEW::MakerHelper.copy_images_to_dir(from, to)
       end


### PR DESCRIPTION
#1696 の対応

`@config["pdfmaker"]["use_symlink"] = true` のときに、styとimagesのコピーをsymlinkで実行します。

OS非互換になりそうなので隠し機能扱いにしたいですが、仕事で使う(2GBオーバのimagesがある)ときに現状必須で内容的にextで対応もしづらいので、コードを入れさせていただきたいです。
