### PR TITLE
PDFMaker: 画像が見つからないときのコンパイルエラーの回避

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -615,9 +615,9 @@ module ReVIEW
     def image_dummy(id, caption, lines)
       warn "image not bound: #{id}", location: location
       puts '\begin{reviewdummyimage}'
-      # path = @chapter.image(id).path
-      puts "--[[path = #{id} (#{existence(id)})]]--"
+      puts escape("--[[path = #{id} (#{existence(id)})]]--")
       lines.each do |line|
+        puts "\n"
         puts detab(line.rstrip)
       end
       puts macro('label', image_label(id))
@@ -702,8 +702,9 @@ module ReVIEW
       else
         warn "image not bound: #{id}", location: location
         puts '\begin{reviewdummyimage}'
-        puts "--[[path = #{escape(id)} (#{existence(id)})]]--"
+        puts escape("--[[path = #{escape(id)} (#{existence(id)})]]--")
         lines.each do |line|
+          puts "\n"
           puts detab(line.rstrip)
         end
       end

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2020/12/31]
+\ProvidesClass{review-base}[2021/06/04]
 % jlreq用基本設定
 \def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
   \hypersetup{
@@ -61,10 +61,7 @@
   \begin{figure}\begin{center}}{\end{center}\end{figure}}
 
 \newenvironment{reviewdummyimage}{%
-  \begin{figure}
-    \begin{center}\begin{alltt}}{%
-    \end{alltt}\end{center}
-  \end{figure}}
+  \begin{figure}\begin{center}}{\end{center}\end{figure}}
 
 \newcommand{\reviewindepimagecaption[2]}{\@makecaption{}{#2}}
 

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2020/12/31]
+\ProvidesClass{review-base}[2021/06/04]
 \RequirePackage{ifthen}
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}
@@ -112,8 +112,8 @@
 
 \newenvironment{reviewdummyimage}{%
   \begin{figure}
-    \begin{center}\begin{alltt}}{%
-    \end{alltt}\end{center}
+    \begin{center}}{%
+    \end{center}
   \end{figure}}
 
 \DeclareRobustCommand{\reviewincludegraphics}[2][]{%

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1374,7 +1374,7 @@ EOS
     actual = compile_block("//indepimage[sample_img_nofile_][sample photo]\n")
     expected = <<-EOS
 \\begin{reviewdummyimage}
---[[path = sample\\textunderscore{}img\\textunderscore{}nofile\\textunderscore{} (not exist)]]--
+{-}{-}[[path = sample\\reviewbackslash{}textunderscore\\{\\}img\\reviewbackslash{}textunderscore\\{\\}nofile\\reviewbackslash{}textunderscore\\{\\} (not exist)]]{-}{-}
 \\reviewindepimagecaption{図: sample photo}
 \\end{reviewdummyimage}
 EOS


### PR DESCRIPTION
#1706 の修正

表示文字のエスケープを行い、等幅表示はやめます。
