### PR TITLE
review-jlreq: serial_pagination + openanyの挙動に対処

### DIFF
--- a/NEWS.ja.md
+++ b/NEWS.ja.md
@@ -1,4 +1,7 @@
 # Version 5.2.0
+## 新機能
+* EPUBMaker: CSS 組版向けに、見出しの存在に応じて `<section>` で階層化する機能を追加しました。config.yml で `epubmaker` セクションの `use_section` パラメータを `true` にすると有効化されます ([#1685])
+
 ## バグ修正
 * PDFMaker: Ruby 2.6 以上でテンプレートの引数についての警告が出る問題を修正しました ([#1683])
 * EPUBMaker: Docker 環境においてファイルがコピーされず空になる問題を修正しました ([#1686])
@@ -25,6 +28,7 @@
 [#1674]: https://github.com/kmuto/review/issues/1674
 [#1683]: https://github.com/kmuto/review/pulls/1683
 [#1684]: https://github.com/kmuto/review/pulls/1684
+[#1685]: https://github.com/kmuto/review/pulls/1685
 [#1686]: https://github.com/kmuto/review/issues/1686
 [#1688]: https://github.com/kmuto/review/pulls/1688
 [#1689]: https://github.com/kmuto/review/pulls/1689

--- a/NEWS.ja.md
+++ b/NEWS.ja.md
@@ -1,3 +1,45 @@
+# Version 5.2.0
+## バグ修正
+* PDFMaker: Ruby 2.6 以上でテンプレートの引数についての警告が出る問題を修正しました ([#1683])
+* EPUBMaker: Docker 環境においてファイルがコピーされず空になる問題を修正しました ([#1686])
+* 縦中横を正しく表示する CSS 設定を追加しました ([#1688])
+* PDFMaker: 新しい TeXLive との組み合わせで pxjahyper のオプション競合エラーが発生するのを修正しました ([#1690])
+* PDFMaker: 画像が見つからないときにコンパイルエラーになるのを修正しました ([#1706])
+
+## 機能強化
+* 警告とエラーを出力する際の処理を改善しました。`error!` (すぐに終了) および `app_error` (`ApplicationError` 例外を上げる) メソッドを導入しました ([#1674])
+* PDFMaker: ビルドのために画像ファイルをコピーする際、実コピーではなくシンボリックリンクを利用して処理を高速化するオプションを追加しました。`pdfmaker` セクションの `use_symlink` パラメータを `true` にすると、デフォルト挙動の実コピーの代わりにシンボリックリンクが使われます。Windows など一部の OS ではこれは動作しない可能性があります ([#1696])
+
+## その他
+* GitHub Actions まわりを修正しました ([#1684], [#1691])
+* review-preproc: リファクタリングを行いました ([#1697])
+* 入れ子の箇条書きの処理をリファクタリングしました ([#1698])
+* Rubocop 1.12 に対応しました ([#1689], [#1692], [#1699], [#1700])
+* 各ビルダの `builder_init_file` メソッドで最初に `super` で基底 builder の `builder_init_file` を実行するようにしました ([#1702])
+* PDFMaker: FileUtils ライブラリを内部で使う際に、明示記法の `FIleUtils.foobar` を使うようにしました ([#1704])
+
+## コントリビューターのみなさん
+* [@odaki](https://github.com/odaki)
+* [@imamurayusuke](https://github.com/imamurayusuke)
+
+[#1674]: https://github.com/kmuto/review/issues/1674
+[#1683]: https://github.com/kmuto/review/pulls/1683
+[#1684]: https://github.com/kmuto/review/pulls/1684
+[#1686]: https://github.com/kmuto/review/issues/1686
+[#1688]: https://github.com/kmuto/review/pulls/1688
+[#1689]: https://github.com/kmuto/review/pulls/1689
+[#1690]: https://github.com/kmuto/review/pulls/1690
+[#1691]: https://github.com/kmuto/review/pulls/1691
+[#1692]: https://github.com/kmuto/review/pulls/1692
+[#1696]: https://github.com/kmuto/review/issues/1696
+[#1697]: https://github.com/kmuto/review/pulls/1697
+[#1698]: https://github.com/kmuto/review/pulls/1698
+[#1699]: https://github.com/kmuto/review/pulls/1699
+[#1700]: https://github.com/kmuto/review/pulls/1700
+[#1702]: https://github.com/kmuto/review/pulls/1702
+[#1704]: https://github.com/kmuto/review/pulls/1704
+[#1706]: https://github.com/kmuto/review/issues/1706
+
 # Version 5.1.1
 ## バグ修正
 * `review-preproc` がエラーになるのを修正しました ([#1679])

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,7 @@
 # Version 5.2.0
+## New Features
+* EPUBMaker: added `<section>` based on heading level for CSS formatting, when the `epubmaker/use_section` parameter is set to `true` ([#1685])
+
 ## Bug Fixes
 * PDFMaker: fixed a problem that caused a warning in templates for Ruby 2.6 and above ([#1683])
 * EPUBMaker: fixed an issue that caused copied files to be empty in Docker environments ([#1686])
@@ -25,6 +28,7 @@
 [#1674]: https://github.com/kmuto/review/issues/1674
 [#1683]: https://github.com/kmuto/review/pulls/1683
 [#1684]: https://github.com/kmuto/review/pulls/1684
+[#1685]: https://github.com/kmuto/review/pulls/1685
 [#1686]: https://github.com/kmuto/review/issues/1686
 [#1688]: https://github.com/kmuto/review/pulls/1688
 [#1689]: https://github.com/kmuto/review/pulls/1689
@@ -48,7 +52,7 @@
 
 # Version 5.1.0
 ## New Features
-* added Rake rule to call [Vivliostyle-CLI](https://github.com/vivliostyle/vivliostyle-cli), CSS typesetting formatter. Create a PDF with `rake vivliostyle:build` or `rake vivliostyle`, and open a preview with `rake vivliostyle:preview` ([#1663])
+<* added Rake rule to call [Vivliostyle-CLI](https://github.com/vivliostyle/vivliostyle-cli), CSS typesetting formatter. Create a PDF with `rake vivliostyle:build` or `rake vivliostyle`, and open a preview with `rake vivliostyle:preview` ([#1663])
 * PDFMaker: introduced `boxsetting` parameter to choose and customize the decorations for column, note, memo, tip, info, warning, important, caution and notice ([#1637])
 * added inline op, `@<ins>` (indicates an insertion) and `@<del>` (indicates a deletion) ([#1630])
 * EPUBMaker, WebMaker: MathJax is now supported. Added `math_format` parameter to choose the mathematical expression method ([#1587], [#1614])

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,45 @@
+# Version 5.2.0
+## Bug Fixes
+* PDFMaker: fixed a problem that caused a warning in templates for Ruby 2.6 and above ([#1683])
+* EPUBMaker: fixed an issue that caused copied files to be empty in Docker environments ([#1686])
+* added CSS style for correct displaying horizontal characters in vertical typesetting ([#1688])
+* PDFMaker: fixed the pxjahyper option conflict error on latest TeXLive ([#1690])
+* PDFMaker: fixed compile error when image is not found ([#1706])
+
+## Enhancements
+* improve around warn and error handling ([#1674])
+* PDFMaker: introduced `pdfmaker/use_symlink` parameter to speed up the process by using symbolic links instead of actual copies. This may not work on some operating systems such as Windows ([#1696])
+
+## Others
+* fixed related to GitHub Actions ([#1684], [#1691])
+* review-preproc: refactored ([#1697])
+* refactored nested lists handling ([#1698])
+* refactor code with Rubocop 1.12 ([#1689], [#1692], [#1699], [#1700])
+* The `builder_init_file` method of each builder now executes `super` first to use base builder's `builder_init_file` ([#1702])
+* PDFMaker: Stopped implicitly including FileUtils library ([#1704])
+
+## Contributors
+* [@odaki](https://github.com/odaki)
+* [@imamurayusuke](https://github.com/imamurayusuke)
+
+[#1674]: https://github.com/kmuto/review/issues/1674
+[#1683]: https://github.com/kmuto/review/pulls/1683
+[#1684]: https://github.com/kmuto/review/pulls/1684
+[#1686]: https://github.com/kmuto/review/issues/1686
+[#1688]: https://github.com/kmuto/review/pulls/1688
+[#1689]: https://github.com/kmuto/review/pulls/1689
+[#1690]: https://github.com/kmuto/review/pulls/1690
+[#1691]: https://github.com/kmuto/review/pulls/1691
+[#1692]: https://github.com/kmuto/review/pulls/1692
+[#1696]: https://github.com/kmuto/review/issues/1696
+[#1697]: https://github.com/kmuto/review/pulls/1697
+[#1698]: https://github.com/kmuto/review/pulls/1698
+[#1699]: https://github.com/kmuto/review/pulls/1699
+[#1700]: https://github.com/kmuto/review/pulls/1700
+[#1702]: https://github.com/kmuto/review/pulls/1702
+[#1704]: https://github.com/kmuto/review/pulls/1704
+[#1706]: https://github.com/kmuto/review/issues/1706
+
 # Version 5.1.1
 ## Bug Fixes
 * Fix the runtime error of `review-preproc` ([#1679])

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2021/06/04]
+\ProvidesClass{review-base}[2021/06/28]
 % jlreq用基本設定
 \def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
   \hypersetup{
@@ -385,6 +385,7 @@
 \ifdefined\review@toc
   \def\reviewtableofcontents{%
 \setcounter{tocdepth}{\review@tocdepth}
+\pagestyle{headings}
 \tableofcontents
 }
 \fi

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -21,7 +21,7 @@
 
 \IfFileExists{plautopatch.sty}{\RequirePackage{plautopatch}}{}
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{review-jlreq}[2021/01/12 Re:VIEW 5.1 upLaTeX/LuaLaTeX class modified for jlreq.cls]
+\ProvidesClass{review-jlreq}[2021/06/28 Re:VIEW 5.2 upLaTeX/LuaLaTeX class modified for jlreq.cls]
 
 %% hook at end of reviewmacro
 \let\@endofreviewmacrohook\@empty
@@ -82,7 +82,7 @@
 
 %% hiddenfolio=nikko-pc
 \@namedef{@makehiddenfolio@nikko-pc}{%
-  \jlreqtrimmarkssetup{banner = { center-gutter = { in = {\hiddenfolio@font\selectfont \thepage} } } } }
+  \jlreqtrimmarkssetup{banner = { center-gutter= { \hiddenfolio@font\selectfont \thepage} } } }
 
 %% hiddenfolio=shippo
 \@namedef{@makehiddenfolio@shippo}{%
@@ -282,6 +282,7 @@
 % シンプルな通しノンブル
 \ifrecls@serialpage
   \jlreqsetup{frontmatter_pagination=continuous}
+  \if@openright\else\jlreqsetup{mainmatter_pagebreak=clearpage}\fi
 \fi
 
 % 開始ページを変更


### PR DESCRIPTION
- `serial_pagination=true, openany` (アラビア数字ノンブル通し + 右改丁強制しない)が指定されているときには、前付の偶数改ページではなく単なる改ページにします。(`serial_pagination`を指定していない場合はローマ数字前付で、これは偶数改ページしないと左右がおかしくなるのでそのまま。電子版などでこの挙動も無視したいんだという人は適宜`\jlreqsetup`で設定していただく)
- 欄外ノンブルのhiddenfolioの記述指定がまちがっていたので修正
- 目次だけページスタイルが違っているのが気持ち悪いので、章と同じheadingsページスタイルに。

jlreq.clsの改訂がけっこうドラスティックなのですが、TeXLive 2018・2019・2020・2021 HEADでコンパイル確認済みです。
