### PR TITLE
review-jlreq: serial_pagination + openanyの挙動に対処

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2021/06/04]
+\ProvidesClass{review-base}[2021/06/28]
 % jlreq用基本設定
 \def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
   \hypersetup{
@@ -385,6 +385,7 @@
 \ifdefined\review@toc
   \def\reviewtableofcontents{%
 \setcounter{tocdepth}{\review@tocdepth}
+\pagestyle{headings}
 \tableofcontents
 }
 \fi

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -21,7 +21,7 @@
 
 \IfFileExists{plautopatch.sty}{\RequirePackage{plautopatch}}{}
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{review-jlreq}[2021/01/12 Re:VIEW 5.1 upLaTeX/LuaLaTeX class modified for jlreq.cls]
+\ProvidesClass{review-jlreq}[2021/06/28 Re:VIEW 5.2 upLaTeX/LuaLaTeX class modified for jlreq.cls]
 
 %% hook at end of reviewmacro
 \let\@endofreviewmacrohook\@empty
@@ -82,7 +82,7 @@
 
 %% hiddenfolio=nikko-pc
 \@namedef{@makehiddenfolio@nikko-pc}{%
-  \jlreqtrimmarkssetup{banner = { center-gutter = { in = {\hiddenfolio@font\selectfont \thepage} } } } }
+  \jlreqtrimmarkssetup{banner = { center-gutter= { \hiddenfolio@font\selectfont \thepage} } } }
 
 %% hiddenfolio=shippo
 \@namedef{@makehiddenfolio@shippo}{%
@@ -282,6 +282,7 @@
 % シンプルな通しノンブル
 \ifrecls@serialpage
   \jlreqsetup{frontmatter_pagination=continuous}
+  \if@openright\else\jlreqsetup{mainmatter_pagebreak=clearpage}\fi
 \fi
 
 % 開始ページを変更

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -82,7 +82,7 @@
 
 %% hiddenfolio=nikko-pc
 \@namedef{@makehiddenfolio@nikko-pc}{%
-  \jlreqtrimmarkssetup{banner = { center-gutter= { \hiddenfolio@font\selectfont \thepage} } } }
+  \jlreqtrimmarkssetup{banner = { center-gutter= { in = { \hiddenfolio@font\selectfont \thepage} } } } }
 
 %% hiddenfolio=shippo
 \@namedef{@makehiddenfolio@shippo}{%


### PR DESCRIPTION
- `serial_pagination=true, openany` (アラビア数字ノンブル通し + 右改丁強制しない)が指定されているときには、前付の偶数改ページではなく単なる改ページにします。(`serial_pagination`を指定していない場合はローマ数字前付で、これは偶数改ページしないと左右がおかしくなるのでそのまま。電子版などでこの挙動も無視したいんだという人は適宜`\jlreqsetup`で設定していただく)
- 欄外ノンブルのhiddenfolioの記述指定がまちがっていたので修正
- 目次だけページスタイルが違っているのが気持ち悪いので、章と同じheadingsページスタイルに。

jlreq.clsの改訂がけっこうドラスティックなのですが、TeXLive 2018・2019・2020・2021 HEADでコンパイル確認済みです。
