### PR TITLE
add ifthen package for newer jlreq.cls

### DIFF
--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -21,7 +21,7 @@
 
 \IfFileExists{plautopatch.sty}{\RequirePackage{plautopatch}}{}
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{review-jlreq}[2021/06/28 Re:VIEW 5.2 upLaTeX/LuaLaTeX class modified for jlreq.cls]
+\ProvidesClass{review-jlreq}[2021/07/24 Re:VIEW 5.3 upLaTeX/LuaLaTeX class modified for jlreq.cls]
 
 %% hook at end of reviewmacro
 \let\@endofreviewmacrohook\@empty
@@ -37,7 +37,7 @@
 \PassOptionsToPackage{nosetpagesize}{graphicx}%%for TL16 or higher version
 }{}
 
-\RequirePackage{xkeyval,everypage}
+\RequirePackage{xkeyval,everypage,ifthen}
 
 %% useful helpers
 \newcommand\recls@get@p@[2]{%


### PR DESCRIPTION
#1718 の修正
jlreq.cls側で今後読み込まなくなるため、ifthenパッケージを明示で読み込むようにします。
