### PR TITLE
check and use everypage-1x for TL20 or higher

### DIFF
--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -22,7 +22,7 @@
 \IfFileExists{plautopatch.sty}{\RequirePackage{plautopatch}}{}
 \NeedsTeXFormat{pLaTeX2e}
 \ProvidesClass{review-jsbook}
-  [2021/01/12 v5.1 Re:VIEW pLaTeX class modified for jsbook.cls]
+  [2021/08/23 v5.2 Re:VIEW pLaTeX class modified for jsbook.cls]
 
 \def\recls@error{\ClassError{review-jsbook}}
 \def\recls@warning{\ClassWarning{review-jsbook}}
@@ -44,7 +44,10 @@
 \PassOptionsToPackage{nosetpagesize}{graphicx}%%for TL16 or higher version
 }{}
 
-\RequirePackage{xkeyval,everypage}%%,etoolbox
+\RequirePackage{xkeyval}%%,etoolbox
+\IfFileExists{everypage-1x.sty}{% is bundled in TL20 or higher
+\RequirePackage{everypage-1x}
+}{\RequirePackage{everypage}}
 
 %% useful helpers
 \newcommand\recls@get@p@[2]{%

--- a/templates/latex/review-jsbook/review-jsbook.cls
+++ b/templates/latex/review-jsbook/review-jsbook.cls
@@ -22,7 +22,7 @@
 \IfFileExists{plautopatch.sty}{\RequirePackage{plautopatch}}{}
 \NeedsTeXFormat{pLaTeX2e}
 \ProvidesClass{review-jsbook}
-  [2021/08/23 v5.2 Re:VIEW pLaTeX class modified for jsbook.cls]
+  [2021/08/23 v5.3 Re:VIEW pLaTeX class modified for jsbook.cls]
 
 \def\recls@error{\ClassError{review-jsbook}}
 \def\recls@warning{\ClassWarning{review-jsbook}}


### PR DESCRIPTION
#1720 の対応。
カーネルバージョンを見るかわりに、単純にeverypage-1x.styがあれば(あえて古い環境にそれを入れることは考えにくいので)それを使うようにしました。
いずれ使えなくなる可能性がある前提に立っておいたほうがよさそうですね…
