### PR TITLE
ファイル存在チェックの強化

### DIFF
--- a/lib/review/epubmaker/epubcommon.rb
+++ b/lib/review/epubmaker/epubcommon.rb
@@ -1,6 +1,6 @@
 # = epubcommon.rb -- super class for EPUBv2 and EPUBv3
 #
-# Copyright (c) 2010-2019 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2021 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -70,7 +70,7 @@ module ReVIEW
           item = contents.find { |content| content.coverimage?(config['coverimage']) }
 
           unless item
-            raise "coverimage #{config['coverimage']} not found. Abort."
+            raise ApplicationError, "coverimage #{config['coverimage']} not found. Abort."
           end
 
           %Q(    <meta name="cover" content="#{item.id}"/>\n)
@@ -107,7 +107,7 @@ module ReVIEW
 
         if config['coverimage']
           @coverimage_src = coverimage
-          raise "coverimage #{config['coverimage']} not found. Abort." unless @coverimage_src
+          raise ApplicationError, "coverimage #{config['coverimage']} not found. Abort." unless @coverimage_src
         end
         @body = ReVIEW::Template.generate(path: './html/_cover.html.erb', binding: binding)
 
@@ -338,7 +338,7 @@ module ReVIEW
 
           fname = "#{basedir}/#{item.file}"
           unless File.exist?(fname)
-            raise "#{fname} is not found."
+            raise ApplicationError, "#{fname} is not found."
           end
 
           FileUtils.mkdir_p(File.dirname("#{tmpdir}/OEBPS/#{item.file}"))

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -495,7 +495,12 @@ module ReVIEW
       end
       ReVIEW::Template.generate(path: template_path, mode: '-', binding: binding, template_dir: template_dir)
     rescue => e
-      error! "template or configuration error: #{e.full_message(highlight: false)}"
+      if defined?(e.full_message)
+        error! "template or configuration error: #{e.full_message(highlight: false)}"
+      else
+        # <= Ruby 2.4
+        error! "template or configuration error: #{e.message}"
+      end
     end
 
     def copy_sty(dirname, copybase, extname = 'sty')

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -479,8 +479,6 @@ module ReVIEW
         result << "%% END: config-local.tex.erb\n"
       end
       result
-    rescue StandardError => e
-      error! "template or configuration error: #{e.message}"
     end
 
     def template_content
@@ -496,6 +494,8 @@ module ReVIEW
         template_path = 'layouts/layout.tex.erb'
       end
       ReVIEW::Template.generate(path: template_path, mode: '-', binding: binding, template_dir: template_dir)
+    rescue => e
+      error! "template or configuration error: #{e.full_message}"
     end
 
     def copy_sty(dirname, copybase, extname = 'sty')

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -446,6 +446,10 @@ module ReVIEW
           end
       end
 
+      if @config['coverimage'] && !File.exist?(File.join(@config['imagedir'], @config['coverimage']))
+        raise ReVIEW::ConfigError, "coverimage #{@config['coverimage']} is not found."
+      end
+
       @locale_latex = {}
       part_tuple = I18n.get('part').split(/%[A-Za-z]{1,3}/, 2)
       chapter_tuple = I18n.get('chapter').split(/%[A-Za-z]{1,3}/, 2)

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -318,12 +318,16 @@ module ReVIEW
     end
 
     def make_custom_page(file)
-      file_sty = file.to_s.sub(/\.[^.]+\Z/, '.tex')
-      if File.exist?(file_sty)
-        return File.read(file_sty)
+      if file.nil?
+        return nil
       end
 
-      nil
+      file_sty = file.to_s.sub(/\.[^.]+\Z/, '.tex')
+      if File.exist?(file_sty)
+        File.read(file_sty)
+      else
+        raise ReVIEW::ConfigError, "File #{file} is not found."
+      end
     end
 
     def join_with_separator(value, sep)
@@ -471,6 +475,8 @@ module ReVIEW
         result << "%% END: config-local.tex.erb\n"
       end
       result
+    rescue StandardError => e
+      error! "template or configuration error: #{e.message}"
     end
 
     def template_content

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -495,7 +495,7 @@ module ReVIEW
       end
       ReVIEW::Template.generate(path: template_path, mode: '-', binding: binding, template_dir: template_dir)
     rescue => e
-      error! "template or configuration error: #{e.full_message}"
+      error! "template or configuration error: #{e.full_message(highlight: false)}"
     end
 
     def copy_sty(dirname, copybase, extname = 'sty')

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -167,6 +167,25 @@ class PDFMakerTest < Test::Unit::TestCase
     end
   end
 
+  def test_template_content_with_invalid_localconfig
+    Dir.mktmpdir do |dir|
+      Dir.chdir(dir) do
+        Dir.mkdir('layouts')
+        File.write(File.join('layouts', 'config-local.tex.erb'), %q(<%= not_existed_method %>\n))
+        @maker.basedir = Dir.pwd
+        @maker.erb_config
+        @maker.instance_eval do
+          def error!(msg)
+            msg
+          end
+        end
+        error_msg = @maker.template_content
+        assert_match(/template or configuration error:/, error_msg)
+        assert_match(/undefined local variable or method `not_existed_method'/, error_msg)
+      end
+    end
+  end
+
   def test_gettemplate_with_backmatter
     @config.merge!(
       'backcover' => 'backcover.tex',


### PR DESCRIPTION
#1726 のEPUB coverimage対応と、PDFMakerの外部ファイル取り込み部のチェック強化です。

- EPUBMaker: coverimage指定時に実ファイルがないときにバックトレースではなくエラーメッセージで終了させる(ApplicationErrorを明示raiseするようにしました)。
- PDFMaker: coverimage指定時に実ファイルがないときにコンパイル前に即エラーするようにしました。
- PDFMaker: titlefile, creditfile, profileなどで外部ファイルをインポートするよう設定しているときにファイルの存在チェックをするようにしました(`pdfmaker.rb#make_custom_page` 内)。

実ファイルが絡むのでテストを作りづらい…。