### PR TITLE
custompageが存在しないときにエラーではなく警告にする

### DIFF
--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -326,7 +326,7 @@ module ReVIEW
       if File.exist?(file_sty)
         File.read(file_sty)
       else
-        raise ReVIEW::ConfigError, "File #{file} is not found."
+        warn "File #{file_sty} is not found."
       end
     end
 


### PR DESCRIPTION
昔の実装の名残りで拡張子が.htmlなどだったら.texにするというのが残っていて、#1727 のコードで入れたエラーにすると手元の業務のもの大半が怒られるようになってしまいました。
メジャーアップデート時にでもこの置換は切ったほうがよさそうではありますが、当面はWARNにします。
