### PR TITLE
check unreferred footnote/endnote

### DIFF
--- a/test/test_book_chapter.rb
+++ b/test/test_book_chapter.rb
@@ -1,4 +1,5 @@
 require 'book_test_helper'
+
 class ChapterTest < Test::Unit::TestCase
   include BookTestHelper
 
@@ -174,6 +175,7 @@ E
 
   def test_footnote_index
     content = <<E
+@<fn>{abc}@<fn>{def}@<fn>{xyz}
 //footnote[abc][textabc...]
 //footnote[def][textdef...]
 //footnote[xyz][textxyz...]
@@ -191,6 +193,7 @@ E
 
   def test_endnote_index
     content = <<E
+@<fn>{abc}@<fn>{def}@<fn>{xyz}@<endnote>{abc}@<endnote>{def}@<endnote>{xyz}
 //footnote[abc][textabc...]
 //footnote[def][textdef...]
 //footnote[xyz][textxyz...]


### PR DESCRIPTION
#1725 の対応

footnote/endnoteの参照漏れチェック用に、IndexBuilderに実装を入れてみました。
キャプションや内容に含まれていることがあるので、軽量だったIndexBuilder内で `compile_inline` を各所で使わざるを得なくなっています。
