### PR TITLE
縦中横マクロ抽象化の追加

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -1360,7 +1360,7 @@ module ReVIEW
     end
 
     def inline_tcy(str)
-      macro('rensuji', escape(str))
+      macro('reviewtcy', escape(str))
     end
 
     def inline_balloon(str)

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -124,6 +124,9 @@
   \ifdefined\reviewchapref\else% for 5.1.0 compatibility
     \newcommand{\reviewchapref}[2]{\hyperref[##2]{##1}}
   \fi
+  \ifdefined\reviewtcy\else% for 5.3.0 compatibility
+    \DeclareRobustCommand{\reviewtcy}[1]{\rensuji{##1}}
+  \fi
 }
 
 \makeatother

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2021/06/28]
+\ProvidesClass{review-base}[2021/09/06]
 % jlreq用基本設定
 \def\recls@tmp{luatex}\ifx\recls@tmp\recls@driver
   \hypersetup{
@@ -186,6 +186,7 @@
 \DeclareRobustCommand{\reviewunderline}[1]{\underline{#1}}% ulemかjumolineで上書き。デフォルトはulemにしている
 \DeclareRobustCommand{\reviewit}[1]{\textit{#1}}
 \DeclareRobustCommand{\reviewbold}[1]{\textbf{#1}}
+\DeclareRobustCommand{\reviewtcy}[1]{\tatechuyoko{#1}}
 
 % allow break line in tt
 % contributed by @zr_tex8r

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2021/09/04]
+\ProvidesClass{review-base}[2021/09/06]
 \RequirePackage{ifthen}
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}
@@ -68,9 +68,12 @@
 \rubysetup{J}}{%
 \rubysetup{g}}
 
+\DeclareRobustCommand{\reviewtcy}[1]{\PackageError{review-base}{\reviewtcy is not allowed in yoko mode}{}}
+
 \ifthenelse{\equal{\review@documentclass}{utbook} \OR \equal{\review@documentclass}{tbook}}{%
 \newcommand{\headfont}{\gtfamily\sffamily\bfseries}
 \RequirePackage{plext}
+\DeclareRobustCommand{\reviewtcy}[1]{\rensuji{#1}}
 }{%
 }
 

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -1,6 +1,6 @@
 \documentclass[dvipdfmx]{review-jsbook}
 \makeatletter
-\def\review@reviewversion{5.1.0}
+\def\review@reviewversion{5.3.0}
 \def\review@texcompiler{uplatex}
 \def\review@documentclass{review-jsbook}
 
@@ -60,6 +60,9 @@
   \fi
   \ifdefined\reviewchapref\else% for 5.1.0 compatibility
     \newcommand{\reviewchapref}[2]{\hyperref[##2]{##1}}
+  \fi
+  \ifdefined\reviewtcy\else% for 5.3.0 compatibility
+    \DeclareRobustCommand{\reviewtcy}[1]{\rensuji{##1}}
   \fi
 }
 

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -1,6 +1,6 @@
 \documentclass[dvipdfmx]{review-jsbook}
 \makeatletter
-\def\review@reviewversion{5.1.0}
+\def\review@reviewversion{5.3.0}
 \def\review@texcompiler{uplatex}
 \def\review@documentclass{review-jsbook}
 
@@ -71,6 +71,9 @@ some ad content
   \fi
   \ifdefined\reviewchapref\else% for 5.1.0 compatibility
     \newcommand{\reviewchapref}[2]{\hyperref[##2]{##1}}
+  \fi
+  \ifdefined\reviewtcy\else% for 5.3.0 compatibility
+    \DeclareRobustCommand{\reviewtcy}[1]{\rensuji{##1}}
   \fi
 }
 


### PR DESCRIPTION
#1733 の修正
- `@<tcy>` を `\rensuji` にlatexbuilderから直接変換していたのを、抽象化として`\reviewtcy` 置換に変更
- review-jsbook/review-base.sty: デフォルトの`\reviewtcy`は横書きモードでは動作しないエラーにする。plextがロードされたら `\rensuji` に展開する。(ただしplextロードするのはclassnameがutbookなどのときだけというロジックに今はなっているので、現状では結局来ることはない…)
- review-jlreq/review-base.sty: jlreqで`\tatechuyoko` を提供してくれているので単にこれに任せる。yoko modeでのエラーについてもjlreq側でやってくれる。
- (そもそもtcyはreview-jsbook, review-jlreqはこれまで動いていなかったはずではあるが、)styを更新していないRe:VIEWプロジェクトにおいて `\reviewtcy` が定義のないときに一応後方互換に `\rensuji` に展開するように
