### PR TITLE
[WIP] review-jlreqの縦書きにおける大扉・奥付の回転

### DIFF
--- a/samples/syntax-book/config-jlreq-tate.yml
+++ b/samples/syntax-book/config-jlreq-tate.yml
@@ -1,0 +1,5 @@
+# call me by 'REVIEW_TEMPLATE=review-jlreq REVIEW_CONFIG_FILE=config-jlreq-tate.yml rake pdf'
+inherit: ["config.yml"]
+# texdocumentclass: ["review-jlreq", "media=print,paper=b5"]
+texdocumentclass: ["review-jlreq", "media=ebook,paper=b5,tate"]
+# texdocumentclass: ["review-jlreq", "media=print,paper=b5,bleed_margin=3mm,cover=true,Q=14,startpage=3,serial_pagination=true,hiddenfolio=nikko-pc"]

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -352,30 +352,65 @@
 \ifdefined\review@titlepage
   \ifthenelse{\isundefined{\review@titlefile}}{%
     \def\reviewtitlepagecont{%
-       \begin{titlepage}
-       \thispagestyle{empty}
-       \begin{center}%
-       \mbox{}%
-       \vskip5\zw
-       \reviewtitlefont%
-       {\Huge\review@booktitlename\par}%
-       \ifdefined\review@subtitlename
-         \vskip 1em%
-         {\Large\review@subtitlename\par}%
-       \fi
-       \vskip 15em%
-       {\huge
-       \lineskip .75em
-       \begin{tabular}[t]{p{\textwidth}}%
-       \centering\review@titlepageauthors
-       \end{tabular}\par}%
-       \vfill
-       {\large\review@date \review@intn@edition%
-         \hspace{2\zw}%
-         \review@intn@publishedby\par}%
-       \vskip4\zw\mbox{}
-       \end{center}%
-       \end{titlepage}\clearpage
+      \ifvmode% 縦書き大扉
+        \begin{titlepage}
+        \thispagestyle{empty}
+          \begin{minipage}<y>{\textheight}
+            \begin{center}
+              \mbox{}%
+              \vskip5\zw
+              \reviewtitlefont%
+              {\Huge\review@booktitlename\par}%
+              \ifdefined\review@subtitlename
+                \vskip 1em%
+                {\Large\review@subtitlename\par}%
+              \fi
+              \vskip 15em%
+              {\huge
+                \lineskip .75em
+                \begin{tabular}[t]{p{\textwidth}}%
+                  \centering\review@titlepageauthors
+                \end{tabular}\par}%
+            \end{center}
+          \end{minipage}
+          \hfill
+          \begin{minipage}<y>{\textheight}
+            \begin{center}
+              \reviewtitlefont%
+              {\large\review@date \review@intn@edition%
+                \hspace{2\zw}%
+                \review@intn@publishedby\par}%
+              \vskip4\zw\mbox{}
+            \end{center}
+          \end{minipage}
+        \end{titlepage}
+        \clearpage
+      \else% 横書き大扉
+        \begin{titlepage}
+        \thispagestyle{empty}
+        \begin{center}%
+        \mbox{}%
+        \vskip5\zw
+        \reviewtitlefont%
+        {\Huge\review@booktitlename\par}%
+        \ifdefined\review@subtitlename
+          \vskip 1em%
+          {\Large\review@subtitlename\par}%
+        \fi
+        \vskip 15em%
+        {\huge
+        \lineskip .75em
+        \begin{tabular}[t]{p{\textwidth}}%
+        \centering\review@titlepageauthors
+        \end{tabular}\par}%
+        \vfill
+        {\large\review@date \review@intn@edition%
+          \hspace{2\zw}%
+          \review@intn@publishedby\par}%
+        \vskip4\zw\mbox{}
+        \end{center}%
+        \end{titlepage}\clearpage
+      \fi
     }
   }{%
     \def\reviewtitlepagecont{\review@titlefile}
@@ -407,24 +442,47 @@
 \ifdefined\review@colophon
   \ifthenelse{\isundefined{\review@colophonfile}}{%
     \def\reviewcolophonpagecont{%
-\reviewcolophon
-\thispagestyle{empty}
-\vspace*{\fill}
-{\noindent\reviewtitlefont\Large\review@booktitlename}\\
-\ifdefined\review@subtitlename
-{\noindent\reviewtitlefont\large\review@subtitlename} \\
-\fi
-\rule[8pt]{\textwidth}{1pt} \\
-{\noindent\review@pubhistories}
+      \reviewcolophon
+      \ifvmode% 縦書き奥付
+        \thispagestyle{empty}
+        \hfill
+        \begin{minipage}<y>{\textheight}
+          {\noindent\reviewtitlefont\Large\review@booktitlename}\\
+          \ifdefined\review@subtitlename
+            {\noindent\reviewtitlefont\large\review@subtitlename} \\
+          \fi
+          \rule[8pt]{\textwidth}{1pt} \\
+          {\noindent\review@pubhistories}
+          \vspace{.5\Cvs}
 
-\begin{tabularx}{\dimexpr\textwidth-0.5em}{lX}
-\review@colophonnames
-\end{tabularx}
-　\\
-\rule[0pt]{\textwidth}{1pt} \\
-\ifdefined\review@rights
-\review@rights
-\fi
+          \begin{tabularx}{\dimexpr\textwidth-0.5em}{lX}
+            \review@colophonnames
+          \end{tabularx}%
+          　\\
+          \rule[0pt]{\textwidth}{1pt} \\
+          \ifdefined\review@rights
+            \review@rights
+          \fi
+        \end{minipage}
+      \else% 横書き奥付
+        \thispagestyle{empty}
+        \vspace*{\fill}
+        {\noindent\reviewtitlefont\Large\review@booktitlename}\\
+        \ifdefined\review@subtitlename
+          {\noindent\reviewtitlefont\large\review@subtitlename} \\
+        \fi
+        \rule[8pt]{\textwidth}{1pt} \\
+        {\noindent\review@pubhistories}
+
+        \begin{tabularx}{\dimexpr\textwidth-0.5em}{lX}
+          \review@colophonnames
+        \end{tabularx}%
+        　\\
+        \rule[0pt]{\textwidth}{1pt} \\
+        \ifdefined\review@rights
+          \review@rights
+        \fi
+      \fi
     }%
   }{%
     \def\reviewcolophonpagecont{\review@colophonfile}

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -339,7 +339,11 @@
        \def\review@coverimageoption{width=\paperwidth,height=\paperheight}
     \fi
     \def\reviewcoverpagecont{%
-      \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
+      \if@tate
+        \expandafter\includefullpagegraphics\expandafter[angle=90,\review@coverimageoption]{\review@coverimage}
+      \else
+        \expandafter\includefullpagegraphics\expandafter[\review@coverimageoption]{\review@coverimage}
+      \fi
       \cleardoublepage
     }
   \fi
@@ -352,7 +356,7 @@
 \ifdefined\review@titlepage
   \ifthenelse{\isundefined{\review@titlefile}}{%
     \def\reviewtitlepagecont{%
-      \ifvmode% 縦書き大扉
+      \if@tate% 縦書き大扉
         \begin{titlepage}
         \thispagestyle{empty}
           \begin{minipage}<y>{\textheight}
@@ -443,7 +447,7 @@
   \ifthenelse{\isundefined{\review@colophonfile}}{%
     \def\reviewcolophonpagecont{%
       \reviewcolophon
-      \ifvmode% 縦書き奥付
+      \if@tate% 縦書き奥付
         \thispagestyle{empty}
         \hfill
         \begin{minipage}<y>{\textheight}

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -21,7 +21,7 @@
 
 \IfFileExists{plautopatch.sty}{\RequirePackage{plautopatch}}{}
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesClass{review-jlreq}[2021/09/04 Re:VIEW 5.3 upLaTeX/LuaLaTeX class modified for jlreq.cls]
+\ProvidesClass{review-jlreq}[2021/09/06 Re:VIEW 5.3 upLaTeX/LuaLaTeX class modified for jlreq.cls]
 
 %% hook at end of reviewmacro
 \let\@endofreviewmacrohook\@empty
@@ -219,6 +219,17 @@
 
 \def\recls@tmp{uplatex}\ifx\recls@tmp\recls@engine
   \RequirePackage{pxjahyper}
+\fi
+
+% 縦書き対処
+\ifvmode
+  \def\recls@tmp{uplatex}\ifx\recls@tmp\recls@engine
+    \RequirePackage{plext}
+  \fi
+  \def\recls@tmp{lualatex}\ifx\recls@tmp\recls@engine
+    \RequirePackage{lltjext}
+  \fi
+  \jlreqsetup{frontmatter_pagebreak={}}% これを入れないと大扉前に白が入る
 \fi
 
 %% include fullpage graphics

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -222,7 +222,7 @@
 \fi
 
 % 縦書き対処
-\ifvmode
+\if@tate
   \def\recls@tmp{uplatex}\ifx\recls@tmp\recls@engine
     \RequirePackage{plext}
   \fi
@@ -358,7 +358,7 @@
 \newcounter{reclsendnote}
 \setcounter{reclsendnote}{0}
 \if@tate
-  \renewcommand*{\thereclsendnote}{\jlreq@open@bracket@before@space\inhibitglue（\jlreq@rensuji{\@arabic\c@reclsendnote}）\inhibitglue}
+  \renewcommand*{\thereclsendnote}{\jlreq@open@bracket@before@space\inhibitglue（\tatechuyoko{\@arabic\c@reclsendnote}）\inhibitglue}
 \else
   \renewcommand*{\thereclsendnote}{(\arabic{reclsendnote}\hbox{}）\inhibitglue}
 \fi


### PR DESCRIPTION
#1732 の対応の検討

## 目標
- review-jlreqでtate指定時に、大扉、奥付を横書きにする (新潮なんかだと奥付縦だったりするけど)
- review-jlreq でtate指定時に、表紙を90度回転し、かつセンター合わせにする。fitpageも動くようにする

## 検討
- 縦書きかどうかは `if@tate` でわかる。`ifvmode` ではない。
- jlreq.clsのバージョンで挙動が違う気がする。新しいのだとエラーにならない、ということがままある。
- 縦内に横を貼るのがだいぶしんどいのでplext/lltjextと `minipage<y>` にすると、まぁまぁ混乱せずに作れることはわかった。

## 問題
- plextを入れるとsyntaxb-bookではreviewlistのところでMissing } insertedエラーになった。おそらく問題はここではない気がするが追跡が困難
- lltjextは手元のいくつかのTeXLive環境でやってみているのだがjlreqとの組み合わせでMissing } insertedほか奇妙なマクロエラーが出る。jlreqのバージョンによっても違ってるかんじ。(ちゃんと追跡すること)
- `minipage<y>` を使えないとなるとかなりたいへんそう。`\yoko` で書くと全然思い通りにならない…。
- 縦モードだとfrontmatterのところでノンブル1の空ページが入る。review-jlreqで `\jlreqsetup{frontmatter_pagebreak={}}` としてみたがこれで正しいか確信がない。
- 1章が偶数で始まるのは正しいのか?