### PR TITLE
begin/endchildエラーでの位置出力

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -104,13 +104,13 @@ module ReVIEW
 
     def check_nest
       if @children && !@children.empty?
-        app_error "//beginchild of #{@children.reverse.join(',')} misses //endchild"
+        app_error "#{@location}: //beginchild of #{@children.reverse.join(',')} misses //endchild"
       end
     end
 
     def check_printendnotes
       if @shown_endnotes.nil?
-        app_error '//endnote is found but //printendnotes is not found.'
+        app_error "#{@location}: //endnote is found but //printendnotes is not found."
       end
     end
 
@@ -754,7 +754,7 @@ EOTGNUPLOT
     def beginchild
       @children ||= []
       unless previous_list_type
-        app_error "//beginchild is shown, but previous element isn't ul, ol, or dl"
+        app_error "#{@location}: //beginchild is shown, but previous element isn't ul, ol, or dl"
       end
       puts "\x01→#{previous_list_type}←\x01"
       @children.push(previous_list_type)
@@ -762,7 +762,7 @@ EOTGNUPLOT
 
     def endchild
       if @children.nil? || @children.empty?
-        app_error "//endchild is shown, but any opened //beginchild doesn't exist"
+        app_error "#{@location}: //endchild is shown, but any opened //beginchild doesn't exist"
       else
         puts "\x01→/#{@children.pop}←\x01"
       end

--- a/test/test_builder.rb
+++ b/test/test_builder.rb
@@ -104,16 +104,16 @@ class BuidlerTest < Test::Unit::TestCase
     assert_equal '', b.solve_nest('')
     b.children = ['dl']
     e = assert_raises(ReVIEW::ApplicationError) { b.solve_nest('') }
-    assert_equal '//beginchild of dl misses //endchild', e.message
+    assert_equal ': //beginchild of dl misses //endchild', e.message
     b.children = ['ul', 'dl', 'ol']
     e = assert_raises(ReVIEW::ApplicationError) { b.solve_nest('') }
-    assert_equal '//beginchild of ol,dl,ul misses //endchild', e.message
+    assert_equal ': //beginchild of ol,dl,ul misses //endchild', e.message
 
     assert_equal "\u0001→/ol←\u0001", b.endchild
     assert_equal "\u0001→/dl←\u0001", b.endchild
     assert_equal "\u0001→/ul←\u0001", b.endchild
     e = assert_raises(ReVIEW::ApplicationError) { b.endchild }
-    assert_equal "//endchild is shown, but any opened //beginchild doesn't exist", e.message
+    assert_equal ": //endchild is shown, but any opened //beginchild doesn't exist", e.message
   end
 
   class XBuilder < Builder

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -2324,7 +2324,7 @@ EOS
 
   def test_endnote
     e = assert_raises(ReVIEW::ApplicationError) { compile_block("//endnote[foo][bar]\n\n@<endnote>{foo}\n") }
-    assert_equal '//endnote is found but //printendnotes is not found.', e.message
+    assert_equal ':4: //endnote is found but //printendnotes is not found.', e.message
 
     actual = compile_block("@<endnote>{foo}\n//endnote[foo][bar]\n//printendnotes\n")
     expected = <<-'EOS'
@@ -2990,7 +2990,7 @@ EOS
 //beginchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal "//beginchild is shown, but previous element isn't ul, ol, or dl", e.message
+    assert_equal ":1: //beginchild is shown, but previous element isn't ul, ol, or dl", e.message
   end
 
   def test_nest_error_close2
@@ -3008,7 +3008,7 @@ EOS
 //beginchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal '//beginchild of dl,ol,ul misses //endchild', e.message
+    assert_equal ':12: //beginchild of dl,ol,ul misses //endchild', e.message
   end
 
   def test_nest_error_close3
@@ -3028,7 +3028,7 @@ EOS
 //endchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal '//beginchild of ol,ul misses //endchild', e.message
+    assert_equal ':14: //beginchild of ol,ul misses //endchild', e.message
   end
 
   def test_nest_ul

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -1291,7 +1291,7 @@ EOS
 //beginchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal "//beginchild is shown, but previous element isn't ul, ol, or dl", e.message
+    assert_equal ":1: //beginchild is shown, but previous element isn't ul, ol, or dl", e.message
   end
 
   def test_nest_error_close2
@@ -1309,7 +1309,7 @@ EOS
 //beginchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal '//beginchild of dl,ol,ul misses //endchild', e.message
+    assert_equal ':12: //beginchild of dl,ol,ul misses //endchild', e.message
   end
 
   def test_nest_error_close3
@@ -1329,7 +1329,7 @@ EOS
 //endchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal '//beginchild of ol,ul misses //endchild', e.message
+    assert_equal ':14: //beginchild of ol,ul misses //endchild', e.message
   end
 
   def test_nest_ul

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -78,7 +78,7 @@ class IndexTest < Test::Unit::TestCase
     e = assert_raises(ReVIEW::ApplicationError) do
       compile_block("@<endnote>{foo}\n//endnote[foo][bar]\n")
     end
-    assert_equal '//endnote is found but //printendnotes is not found.', e.message
+    assert_equal ':3: //endnote is found but //printendnotes is not found.', e.message
 
     compile_block("//endnote[foo][bar]\n//printendnotes\n")
     assert_match(/ID foo is not referred/, @log_io.string)

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -259,7 +259,7 @@ EOS
 
   def test_endnote
     e = assert_raises(ReVIEW::ApplicationError) { compile_block("//endnote[foo][bar]\n\n@<endnote>{foo}\n") }
-    assert_equal '//endnote is found but //printendnotes is not found.', e.message
+    assert_equal ':4: //endnote is found but //printendnotes is not found.', e.message
 
     actual = compile_block("@<endnote>{foo}\n//endnote[foo][bar]\n//printendnotes\n")
     expected = <<-'EOS'
@@ -2610,7 +2610,7 @@ EOS
 //beginchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal "//beginchild is shown, but previous element isn't ul, ol, or dl", e.message
+    assert_equal ":1: //beginchild is shown, but previous element isn't ul, ol, or dl", e.message
   end
 
   def test_nest_error_close2
@@ -2628,7 +2628,7 @@ EOS
 //beginchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal '//beginchild of dl,ol,ul misses //endchild', e.message
+    assert_equal ':12: //beginchild of dl,ol,ul misses //endchild', e.message
   end
 
   def test_nest_error_close3
@@ -2648,7 +2648,7 @@ EOS
 //endchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal '//beginchild of ol,ul misses //endchild', e.message
+    assert_equal ':14: //beginchild of ol,ul misses //endchild', e.message
   end
 
   def test_nest_ul

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -108,7 +108,7 @@ EOS
 
   def test_endnote
     e = assert_raises(ReVIEW::ApplicationError) { compile_block("//endnote[foo][bar]\n\n@<endnote>{foo}\n") }
-    assert_equal '//endnote is found but //printendnotes is not found.', e.message
+    assert_equal ':4: //endnote is found but //printendnotes is not found.', e.message
 
     actual = compile_block("@<endnote>{foo}\n//endnote[foo][bar]\n//printendnotes\n")
     expected = <<-'EOS'

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -764,7 +764,7 @@ EOS
 
   def test_endnote
     e = assert_raises(ReVIEW::ApplicationError) { compile_block("//endnote[foo][bar]\n\n@<endnote>{foo}\n") }
-    assert_equal '//endnote is found but //printendnotes is not found.', e.message
+    assert_equal ':4: //endnote is found but //printendnotes is not found.', e.message
 
     actual = compile_block("@<endnote>{foo}\n//endnote[foo][bar]\n//printendnotes\n")
     expected = <<-'EOS'
@@ -915,7 +915,7 @@ EOS
 //endchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal "//endchild is shown, but any opened //beginchild doesn't exist", e.message
+    assert_equal ":1: //endchild is shown, but any opened //beginchild doesn't exist", e.message
   end
 
   def test_nest_error_close1
@@ -923,7 +923,7 @@ EOS
 //beginchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal "//beginchild is shown, but previous element isn't ul, ol, or dl", e.message
+    assert_equal ":1: //beginchild is shown, but previous element isn't ul, ol, or dl", e.message
   end
 
   def test_nest_error_close2
@@ -941,7 +941,7 @@ EOS
 //beginchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal '//beginchild of dl,ol,ul misses //endchild', e.message
+    assert_equal ':12: //beginchild of dl,ol,ul misses //endchild', e.message
   end
 
   def test_nest_error_close3
@@ -961,7 +961,7 @@ EOS
 //endchild
 EOS
     e = assert_raises(ReVIEW::ApplicationError) { compile_block(src) }
-    assert_equal '//beginchild of ol,ul misses //endchild', e.message
+    assert_equal ':14: //beginchild of ol,ul misses //endchild', e.message
   end
 
   def test_nest_ul

--- a/test/test_rstbuilder.rb
+++ b/test/test_rstbuilder.rb
@@ -519,7 +519,7 @@ EOS
 
   def test_endnote
     e = assert_raises(ReVIEW::ApplicationError) { compile_block("//endnote[foo][bar]\n\n@<endnote>{foo}\n") }
-    assert_equal '//endnote is found but //printendnotes is not found.', e.message
+    assert_equal ':4: //endnote is found but //printendnotes is not found.', e.message
 
     actual = compile_block("@<endnote>{foo}\n//endnote[foo][bar]\n//printendnotes\n")
     expected = <<-'EOS'

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -1001,7 +1001,7 @@ EOB
 
   def test_endnote
     e = assert_raises(ReVIEW::ApplicationError) { compile_block("//endnote[foo][bar]\n\n@<endnote>{foo}\n") }
-    assert_equal '//endnote is found but //printendnotes is not found.', e.message
+    assert_equal ':4: //endnote is found but //printendnotes is not found.', e.message
 
     actual = compile_block("@<endnote>{foo}\n//endnote[foo][bar]\n//printendnotes\n")
     expected = <<-'EOS'


### PR DESCRIPTION
builderの `app_error` を使っている場合はlocationを明示指定する必要があるみたいなので、いくつかlocation明示を追加します。
