### PR TITLE
Windows における Ruby 2.7 チェックの追加

### DIFF
--- a/.github/workflows/ruby-win.yml
+++ b/.github/workflows/ruby-win.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', '2.6', '2.5', '2.4' ]
+        ruby: [ '3.0', '2.7', '2.6', '2.5', '2.4' ]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
特にコード本体は追加・変更を加えておりませんが、WindowsにおけるRuby 2.7のチェックを追加しました。

なお、GitHub ActionsでWindowsにおけるRuby 3.0のチェックでエラーが出ている件ですが、私がWindowsにおけるRuby 2.7のチェックを加えた際に全てのテストをパスしており、再実行してみればRuby 3.0のチェックもパスすると思います。