### PR TITLE
copy __IMGMATH_BODY__.tex also to analyse

### DIFF
--- a/lib/review/img_math.rb
+++ b/lib/review/img_math.rb
@@ -104,6 +104,7 @@ module ReVIEW
           end
         rescue CompileError
           FileUtils.cp([tex_path,
+                        File.join(File.dirname(tex_path), '__IMGMATH_BODY__.tex'),
                         File.join(File.dirname(tex_path), '__IMGMATH__.log')],
                        math_real_dir)
           error! "LaTeX math compile error. See #{math_real_dir}/__IMGMATH__.log for details."


### PR DESCRIPTION
数式画像化の遅延ビルドにおいてエラーが発生したときに `__IMGMATH_.tex` と `__IMGMATH__.log`  をコピーしていましたが、肝心の中身である `__IMGMATH_BODY__.tex` をコピーし忘れていました。
