### PR TITLE
fix instruction to build svg math

### DIFF
--- a/doc/format.ja.md
+++ b/doc/format.ja.md
@@ -712,7 +712,7 @@ imgmath_options:
 math_format: imgmath
 imgmath_options:
   format: svg
-  pdfcrop_pixelize_cmd: "pdftocairo -svg -r 90 -f %p -l %p -singlefile %i %o"
+  pdfcrop_pixelize_cmd: "pdftocairo -%t -r 90 -f %p -l %p %i %o"
 ```
 
 デフォルトでは、pdfcrop_pixelize_cmd に指定するコマンドは、1ページあたり1数式からなる複数ページの PDF のファイル名を `%i` プレースホルダで受け取り、`%p` プレースホルダのページ数に基づいて `%o`（拡張子あり）または `%O`（拡張子なし）の画像ファイルに書き出す、という仕組みになっています。

--- a/doc/format.md
+++ b/doc/format.md
@@ -748,7 +748,7 @@ For example, to make SVG:
 math_format: imgmath
 imgmath_options:
   format: svg
-  pdfcrop_pixelize_cmd: "pdftocairo -svg -r 90 -f %p -l %p -singlefile %i %o"
+  pdfcrop_pixelize_cmd: "pdftocairo -%t -r 90 -f %p -l %p %i %o"
 ```
 
 By default, the command specified in `pdfcrop_pixelize_cmd` takes the filename of multi-page PDF consisting of one formula per page.


### PR DESCRIPTION
SVG数式の作成のコマンドラインに間違いがありました。

- `-singlefile` は pdftocairoでSVGを作るときには逆に入れてはだめ
- `-svg` は `-%t` のままでもOKなのでそのように
