### PR TITLE
compile headline in IndexBuilder to check crossref

### DIFF
--- a/lib/review/index_builder.rb
+++ b/lib/review/index_builder.rb
@@ -114,6 +114,7 @@ module ReVIEW
 
       item = ReVIEW::Book::Index::Item.new(item_id, @sec_counter.number_list, caption)
       @headline_index.add_item(item)
+      compile_inline(caption)
     end
 
     def nonum_begin(level, label, caption)


### PR DESCRIPTION
footnote/endnoteのcrossrefチェックからheadlineが漏れていたので、compile_inline実行対象に。