### PR TITLE
suggested by RuboCop 1.22.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,6 +57,9 @@ Lint/StructNewOverride:
 Lint/RedundantDirGlobSort:
   Enabled: false
 
+Lint/ElseLayout:
+  Enabled: false
+
 #### Performance
 
 Performance/RegexpMatch:

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -98,7 +98,7 @@ module ReVIEW
     end
 
     def ul_item_begin(lines)
-      puts '  ' * (@ul_indent - 1) + '* ' + join_lines_to_paragraph(lines)
+      puts ('  ' * (@ul_indent - 1)) + '* ' + join_lines_to_paragraph(lines)
     end
 
     def ul_item_end

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2020 Kenshi Muto
+# Copyright (c) 2018-2021 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -90,7 +90,7 @@ module ReVIEW
           clevel.pop
           lines.push("\x01→END←\x01")
         else
-          lines.push("\t" * clevel.size + l)
+          lines.push(("\t" * clevel.size) + l)
         end
       end
 

--- a/lib/review/rstbuilder.rb
+++ b/lib/review/rstbuilder.rb
@@ -125,7 +125,7 @@ module ReVIEW
     end
 
     def ul_item(lines)
-      puts '  ' * (@ul_indent - 1) + "* #{join_lines_to_paragraph(lines)}"
+      puts ('  ' * (@ul_indent - 1)) + "* #{join_lines_to_paragraph(lines)}"
     end
 
     def ul_end
@@ -139,7 +139,7 @@ module ReVIEW
     end
 
     def ol_item(lines, _num)
-      puts '  ' * (@ol_indent - 1) + "#. #{join_lines_to_paragraph(lines)}"
+      puts ('  ' * (@ol_indent - 1)) + "#. #{join_lines_to_paragraph(lines)}"
     end
 
     def ol_end

--- a/lib/review/textutils.rb
+++ b/lib/review/textutils.rb
@@ -15,7 +15,7 @@ module ReVIEW
       add = 0
       len = nil
       str.gsub("\t") do
-        len = ts - ($`.size + add) % ts
+        len = ts - (($`.size + add) % ts)
         add += len - 1
         ' ' * len
       end
@@ -72,12 +72,13 @@ module ReVIEW
         end
 
         # lazy than rule 3, but it looks better
-        if lazy &&
-           (%i[F W H].include?(Unicode::Eaw.property(tail)) &&
-            tail !~ /\p{Hangul}/) ||
-           (%i[F W H].include?(Unicode::Eaw.property(head)) &&
-            head !~ /\p{Hangul}/)
-          space = nil
+        if lazy
+          if (%i[F W H].include?(Unicode::Eaw.property(tail)) &&
+              tail !~ /\p{Hangul}/) ||
+             (%i[F W H].include?(Unicode::Eaw.property(head)) &&
+              head !~ /\p{Hangul}/)
+            space = nil
+          end
         end
       end
       space

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -231,9 +231,9 @@ module ReVIEW
 
       case mode
       when :list
-        (calc_linesize(line) - 1) / @book.page_metric.list.n_columns + 1
+        ((calc_linesize(line) - 1) / @book.page_metric.list.n_columns) + 1
       else # mode == :text
-        (calc_linesize(line) - 1) / @book.page_metric.text.n_columns + 1
+        ((calc_linesize(line) - 1) / @book.page_metric.text.n_columns) + 1
       end
     end
 

--- a/test/test_book_chapter.rb
+++ b/test/test_book_chapter.rb
@@ -42,12 +42,12 @@ class ChapterTest < Test::Unit::TestCase
 
   def test_size
     ch = Book::Chapter.new(nil, nil, nil, __FILE__, :io)
-    filesize = IO.read(__FILE__, mode: 'rt:BOM|utf-8').size
+    filesize = File.read(__FILE__, mode: 'rt:BOM|utf-8').size
     assert_equal filesize, ch.size
 
     File.open(__FILE__, 'r') do |i|
       ch = Book::Chapter.new(nil, nil, nil, nil, i)
-      filesize = IO.read(__FILE__, mode: 'rt:BOM|utf-8').size
+      filesize = File.read(__FILE__, mode: 'rt:BOM|utf-8').size
       assert_equal filesize, ch.size
     end
   end


### PR DESCRIPTION
RuboCop 1.22.1で警告が出たので対処しています。

Lint/ElseLayoutはちょっと直す範囲が大きいのでdisable。
