### PR TITLE
manifest/itemをitem idでソートする

### DIFF
--- a/templates/opf/opf_manifest_epubv2.opf.erb
+++ b/templates/opf/opf_manifest_epubv2.opf.erb
@@ -4,7 +4,7 @@
 <% if @config['toc'] && @config['mytoc'] %>
     <item id="toc" href="<%= @config['bookname'] %>-toc.<%= @config['htmlext'] %>" media-type="application/xhtml+xml"/>
 <% end %>
-<% @items.sort { |a, b| a.id <=> b.id }.each do |item| %>
+<% @items.sort_by { |x| x.id }.each do |item| %>
     <item id="<%= item.id %>" href="<%= item.file %>" media-type="<%= item.media %>"/>
 <% end %>
   </manifest>

--- a/templates/opf/opf_manifest_epubv2.opf.erb
+++ b/templates/opf/opf_manifest_epubv2.opf.erb
@@ -4,7 +4,7 @@
 <% if @config['toc'] && @config['mytoc'] %>
     <item id="toc" href="<%= @config['bookname'] %>-toc.<%= @config['htmlext'] %>" media-type="application/xhtml+xml"/>
 <% end %>
-<% @items.each do |item| %>
+<% @items.sort { |a, b| a.id <=> b.id }.each do |item| %>
     <item id="<%= item.id %>" href="<%= item.file %>" media-type="<%= item.media %>"/>
 <% end %>
   </manifest>

--- a/templates/opf/opf_manifest_epubv3.opf.erb
+++ b/templates/opf/opf_manifest_epubv3.opf.erb
@@ -4,7 +4,7 @@
 <% if @coverimage %>
     <item properties="cover-image" id="cover-<%= @coverimage.id %>" href="<%= @coverimage.file %>" media-type="<%= @coverimage.media %>"/>
 <% end %>
-<% @items.each do |item| %>
+<% @items.sort { |a, b| a.id <=> b.id }.each do |item| %>
     <item id="<%= item.id %>" href="<%= item.file %>" media-type="<%= item.media %>"<%= item.properties_attribute %>/>
 <% end %>
   </manifest>

--- a/templates/opf/opf_manifest_epubv3.opf.erb
+++ b/templates/opf/opf_manifest_epubv3.opf.erb
@@ -4,7 +4,7 @@
 <% if @coverimage %>
     <item properties="cover-image" id="cover-<%= @coverimage.id %>" href="<%= @coverimage.file %>" media-type="<%= @coverimage.media %>"/>
 <% end %>
-<% @items.sort { |a, b| a.id <=> b.id }.each do |item| %>
+<% @items.sort_by { |x| x.id }.each do |item| %>
     <item id="<%= item.id %>" href="<%= item.file %>" media-type="<%= item.media %>"<%= item.properties_attribute %>/>
 <% end %>
   </manifest>

--- a/test/test_epub3maker.rb
+++ b/test/test_epub3maker.rb
@@ -321,12 +321,12 @@ EOT
     <item id="ch02-html" href="ch02.html" media-type="application/xhtml+xml"/>
     <item id="ch03-html" href="ch03.html" media-type="application/xhtml+xml" properties="mathml"/>
     <item id="ch04-html" href="ch04.html" media-type="application/xhtml+xml"/>
-    <item id="sample-png" href="sample.png" media-type="image/png"/>
-    <item id="sample-jpg" href="sample.jpg" media-type="image/jpeg"/>
+    <item id="sample-GIF" href="sample.GIF" media-type="image/gif"/>
     <item id="sample-JPEG" href="sample.JPEG" media-type="image/jpeg"/>
     <item id="sample-SvG" href="sample.SvG" media-type="image/svg+xml"/>
-    <item id="sample-GIF" href="sample.GIF" media-type="image/gif"/>
     <item id="sample-css" href="sample.css" media-type="text/css"/>
+    <item id="sample-jpg" href="sample.jpg" media-type="image/jpeg"/>
+    <item id="sample-png" href="sample.png" media-type="image/png"/>
   </manifest>
   <spine page-progression-direction="ltr">
     <itemref idref="sample" linear="no"/>

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -318,12 +318,12 @@ EOT
     <item id="ch02-html" href="ch02.html" media-type="application/xhtml+xml"/>
     <item id="ch03-html" href="ch03.html" media-type="application/xhtml+xml"/>
     <item id="ch04-html" href="ch04.html" media-type="application/xhtml+xml"/>
-    <item id="sample-png" href="sample.png" media-type="image/png"/>
-    <item id="sample-jpg" href="sample.jpg" media-type="image/jpeg"/>
+    <item id="sample-GIF" href="sample.GIF" media-type="image/gif"/>
     <item id="sample-JPEG" href="sample.JPEG" media-type="image/jpeg"/>
     <item id="sample-SvG" href="sample.SvG" media-type="image/svg+xml"/>
-    <item id="sample-GIF" href="sample.GIF" media-type="image/gif"/>
     <item id="sample-css" href="sample.css" media-type="text/css"/>
+    <item id="sample-jpg" href="sample.jpg" media-type="image/jpeg"/>
+    <item id="sample-png" href="sample.png" media-type="image/png"/>
   </manifest>
   <spine toc="ncx">
     <itemref idref="sample" linear="no"/>


### PR DESCRIPTION
EPUB用の内部アイテム情報格納時に画像類がどの順序で入るかは実行時のファイルシステムに依存していました。書き出すたびに順序が微妙に違ったりして不便なので、ID文字列でソートするようにしてみます。
