### PR TITLE
Support Ruby 3.1; use YAML.safe_load(_file)

### DIFF
--- a/.github/workflows/ruby-tex.yml
+++ b/.github/workflows/ruby-tex.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5', '3.0']
+        ruby: ['2.5', '3.0', '3.1']
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby-tex.yml
+++ b/.github/workflows/ruby-tex.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.5, 3.0]
+        ruby: ['2.5', '3.0']
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby-win.yml
+++ b/.github/workflows/ruby-win.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.1', '3.0', '2.7', '2.6', '2.5', '2.4' ]
+        ruby: [ '3.0', '2.7', '2.6', '2.5', '2.4' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby-win.yml
+++ b/.github/workflows/ruby-win.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.0', '2.7', '2.6', '2.5', '2.4' ]
+        ruby: [ '3.1', '3.0', '2.7', '2.6', '2.5', '2.4' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
         os: [ubuntu-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0']
         os: [ubuntu-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -410,7 +410,7 @@ Style/CombinableLoops:
 ### Layout
 
 Layout/BlockAlignment:
-  Enabled: true
+  Enabled: false
 
 Layout/EndAlignment:
   Enabled: true

--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -214,7 +214,7 @@ module ReVIEW
       end
 
       def load_config(filename)
-        new_conf = YAML.load_file(filename)
+        new_conf = YAML.safe_load_file(filename, aliases: true, permitted_classes: [Date])
         @config.merge!(new_conf)
       end
 

--- a/lib/review/catalog.rb
+++ b/lib/review/catalog.rb
@@ -5,7 +5,7 @@ module ReVIEW
   class Catalog
     def initialize(file)
       if file.respond_to?(:read)
-        @yaml = YAML.safe_load(file.read, [Date])
+        @yaml = YAML.safe_load(file.read, aliases: true, permitted_classes: [Date])
       else ## as Object
         @yaml = file
       end

--- a/lib/review/extentions/string.rb
+++ b/lib/review/extentions/string.rb
@@ -1,4 +1,4 @@
-if defined?(Encoding) && Encoding.respond_to?('default_external') &&
+if defined?(Encoding) && Encoding.respond_to?(:default_external) &&
    Encoding.default_external != Encoding::UTF_8
   Encoding.default_external = 'UTF-8'
 end

--- a/lib/review/i18n.rb
+++ b/lib/review/i18n.rb
@@ -75,11 +75,11 @@ module ReVIEW
     end
 
     def load_file(path)
-      @store = YAML.load_file(path)
+      @store = YAML.safe_load_file(path, aliases: true, permitted_classes: [Date])
     end
 
     def update_localefile(path)
-      user_i18n = YAML.load_file(path)
+      user_i18n = YAML.safe_load_file(path, aliases: true, permitted_classes: [Date])
       locale = user_i18n['locale']
       if locale
         user_i18n.delete('locale')

--- a/lib/review/update.rb
+++ b/lib/review/update.rb
@@ -165,7 +165,7 @@ module ReVIEW
 
       Dir.glob(File.join(dir, '*.yml')).sort.each do |yml|
         begin
-          config = YAML.load_file(yml)
+          config = YAML.safe_load_file(yml, aliases: true, permitted_classes: [Date])
           if config['language'].present?
             language = config['language']
           end
@@ -238,7 +238,7 @@ module ReVIEW
 
     def update_version
       @config_ymls.each do |yml|
-        config = YAML.load_file(yml)
+        config = YAML.safe_load_file(yml, aliases: true, permitted_classes: [Date])
         if config['review_version'].to_f.round(1) == TARGET_VERSION.to_f.round(1)
           next
         end
@@ -292,7 +292,7 @@ module ReVIEW
 
     def update_epub_version
       @epub_ymls.each do |yml|
-        config = YAML.load_file(yml)
+        config = YAML.safe_load_file(yml, aliases: true, permitted_classes: [Date])
         if config['epubversion'].present? && config['epubversion'].to_f < EPUB_VERSION.to_f
           if confirm("%s: Update '%s' to '%s' from '%s'?", [File.basename(yml), 'epubversion', EPUB_VERSION, config['epubversion']])
             rewrite_yml(yml, 'epubversion', EPUB_VERSION)
@@ -310,7 +310,7 @@ module ReVIEW
 
     def update_locale
       @locale_ymls.each do |yml|
-        config = YAML.load_file(yml)
+        config = YAML.safe_load_file(yml, aliases: true, permitted_classes: [Date])
         if !config['chapter_quote'].present? || config['chapter_quote'].scan('%s').size != 1
           next
         end
@@ -324,7 +324,7 @@ module ReVIEW
 
     def update_tex_parameters
       @tex_ymls.each do |yml|
-        config = YAML.load_file(yml)
+        config = YAML.safe_load_file(yml, aliases: true, permitted_classes: [Date])
         unless config['texdocumentclass']
           next
         end
@@ -510,7 +510,7 @@ module ReVIEW
 
     def update_tex_command
       @tex_ymls.each do |yml|
-        config = YAML.load_file(yml)
+        config = YAML.safe_load_file(yml, aliases: true, permitted_classes: [Date])
         if !config['texcommand'] || config['texcommand'] !~ /\s+-/
           next
         end
@@ -535,7 +535,7 @@ module ReVIEW
 
     def update_dvi_command
       @tex_ymls.each do |yml|
-        config = YAML.load_file(yml)
+        config = YAML.safe_load_file(yml, aliases: true, permitted_classes: [Date])
         if !config['dvicommand'] || config['dvicommand'] !~ /\s+-/
           next
         end

--- a/lib/review/yamlloader.rb
+++ b/lib/review/yamlloader.rb
@@ -17,8 +17,8 @@ module ReVIEW
 
       while file_queue.present?
         current_file = file_queue.shift
-        current_yaml = YAML.load_file(current_file)
-        if current_yaml.instance_of?(FalseClass)
+        current_yaml = YAML.safe_load_file(current_file, aliases: true, permitted_classes: [Date])
+        if current_yaml.instance_of?(FalseClass) || current_yaml.nil?
           raise "#{File.basename(current_file)} is malformed."
         end
 

--- a/review.gemspec
+++ b/review.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency('image_size')
+  gem.add_dependency('psych', '>= 3.3.2')
   gem.add_dependency('rouge')
   gem.add_dependency('rubyzip')
   gem.add_dependency('tty-logger')

--- a/review.gemspec
+++ b/review.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
 
   gem.add_dependency('image_size')
-  gem.add_dependency('psych', '>= 3.3.2')
+  gem.add_dependency('psych', '3.3.2')
   gem.add_dependency('rouge')
   gem.add_dependency('rubyzip')
   gem.add_dependency('tty-logger')


### PR DESCRIPTION
Psych should be >= 3.3.2 (see ttps://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/ )

#1766 の対応です。

* Pyschを3.3.2に固定(4.xだと古い環境のツールが動かなくなるようなので。具体的には`gem`コマンドでエラーが出るようになった)
* `YAML.load_file(path)`を`YAML.safe_load_file(path, aliases: true, permitted_classes: [Date])`に変更
* Rubocopでエラーが出るところがあったので一部修正したりRubocopのルールを変更したりした