### PR TITLE
correct epub:type

### DIFF
--- a/lib/review/epubmaker/epubcommon.rb
+++ b/lib/review/epubmaker/epubcommon.rb
@@ -213,8 +213,6 @@ module ReVIEW
       # Return own toc content.
       def mytoc
         @title = h(ReVIEW::I18n.t('toctitle'))
-
-        @body_ext = config['epubversion'] >= 3 ? %Q( epub:type="toc") : nil
         @body = %Q(  <h1 class="toc-title">#{h(ReVIEW::I18n.t('toctitle'))}</h1>\n)
         if config['epubmaker']['flattoc'].nil?
           @body << hierarchy_ncx('ul')
@@ -229,9 +227,7 @@ module ReVIEW
                         else
                           './html/layout-xhtml1.html.erb'
                         end
-        ret = ReVIEW::Template.generate(path: template_path, binding: binding)
-        @body_ext = nil
-        ret
+        ReVIEW::Template.generate(path: template_path, binding: binding)
       end
 
       def hierarchy_ncx(type)

--- a/lib/review/epubmaker/epubcommon.rb
+++ b/lib/review/epubmaker/epubcommon.rb
@@ -1,6 +1,6 @@
 # = epubcommon.rb -- super class for EPUBv2 and EPUBv3
 #
-# Copyright (c) 2010-2021 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2022 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -103,7 +103,7 @@ module ReVIEW
       # If Producer#config["coverimage"] is defined, it will be used for
       # the cover image.
       def cover
-        @body_ext = config['epubversion'] >= 3 ? %Q( epub:type="cover") : ''
+        @body_ext = config['epubversion'] >= 3 ? %Q( epub:type="cover") : nil
 
         if config['coverimage']
           @coverimage_src = coverimage
@@ -119,7 +119,9 @@ module ReVIEW
                         else
                           './html/layout-xhtml1.html.erb'
                         end
-        ReVIEW::Template.generate(path: template_path, binding: binding)
+        ret = ReVIEW::Template.generate(path: template_path, binding: binding)
+        @body_ext = nil
+        ret
       end
 
       # Return title (copying) content.
@@ -212,6 +214,7 @@ module ReVIEW
       def mytoc
         @title = h(ReVIEW::I18n.t('toctitle'))
 
+        @body_ext = config['epubversion'] >= 3 ? %Q( epub:type="toc") : nil
         @body = %Q(  <h1 class="toc-title">#{h(ReVIEW::I18n.t('toctitle'))}</h1>\n)
         if config['epubmaker']['flattoc'].nil?
           @body << hierarchy_ncx('ul')
@@ -226,7 +229,9 @@ module ReVIEW
                         else
                           './html/layout-xhtml1.html.erb'
                         end
-        ReVIEW::Template.generate(path: template_path, binding: binding)
+        ret = ReVIEW::Template.generate(path: template_path, binding: binding)
+        @body_ext = nil
+        ret
       end
 
       def hierarchy_ncx(type)

--- a/lib/review/epubmaker/epubv3.rb
+++ b/lib/review/epubmaker/epubv3.rb
@@ -1,6 +1,6 @@
 # = epubv3.rb -- EPUB version 3 producer.
 #
-# Copyright (c) 2010-2017 Kenshi Muto
+# Copyright (c) 2010-2022 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -195,6 +195,7 @@ module ReVIEW
       end
 
       def ncx(indentarray)
+        @body_ext = %Q( epub:type="toc")
         ncx_main = if config['epubmaker']['flattoc'].nil?
                      hierarchy_ncx('ol')
                    else
@@ -210,7 +211,9 @@ module ReVIEW
         @title = h(ReVIEW::I18n.t('toctitle'))
         @language = config['language']
         @stylesheets = config['stylesheet']
-        ReVIEW::Template.generate(path: './html/layout-html5.html.erb', binding: binding)
+        ret = ReVIEW::Template.generate(path: './html/layout-html5.html.erb', binding: binding)
+        @body_ext = nil
+        ret
       end
 
       # Produce EPUB file +epubfile+.

--- a/lib/review/epubmaker/epubv3.rb
+++ b/lib/review/epubmaker/epubv3.rb
@@ -195,7 +195,6 @@ module ReVIEW
       end
 
       def ncx(indentarray)
-        @body_ext = %Q( epub:type="toc")
         ncx_main = if config['epubmaker']['flattoc'].nil?
                      hierarchy_ncx('ol')
                    else
@@ -211,9 +210,7 @@ module ReVIEW
         @title = h(ReVIEW::I18n.t('toctitle'))
         @language = config['language']
         @stylesheets = config['stylesheet']
-        ret = ReVIEW::Template.generate(path: './html/layout-html5.html.erb', binding: binding)
-        @body_ext = nil
-        ret
+        ReVIEW::Template.generate(path: './html/layout-html5.html.erb', binding: binding)
       end
 
       # Produce EPUB file +epubfile+.

--- a/test/test_epub3maker.rb
+++ b/test/test_epub3maker.rb
@@ -170,7 +170,7 @@ EOT
   <meta name="generator" content="Re:VIEW" />
   <title>Table of Contents</title>
 </head>
-<body epub:type="toc">
+<body>
   <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
   <h1 class="toc-title">Table of Contents</h1>
 
@@ -239,7 +239,7 @@ EOT
   <meta name="generator" content="Re:VIEW" />
   <title>Table of Contents</title>
 </head>
-<body epub:type="toc">
+<body>
   <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
   <h1 class="toc-title">Table of Contents</h1>
 
@@ -357,7 +357,7 @@ EOT
   <meta name="generator" content="Re:VIEW" />
   <title>Table of Contents</title>
 </head>
-<body epub:type="toc">
+<body>
   <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
   <h1 class="toc-title">Table of Contents</h1>
 
@@ -390,7 +390,7 @@ EOT
   <meta name="generator" content="Re:VIEW" />
   <title>Table of Contents</title>
 </head>
-<body epub:type="toc">
+<body>
   <h1 class="toc-title">Table of Contents</h1>
 
 <ul class="toc-h1"><li><a href="ch01.html">CH01&lt;&gt;&amp;&quot;</a></li>
@@ -425,7 +425,7 @@ EOT
   <meta name="generator" content="Re:VIEW" />
   <title>Table of Contents</title>
 </head>
-<body epub:type="toc">
+<body>
   <h1 class="toc-title">Table of Contents</h1>
 <ul class="toc-h1">
 <li><a href="ch01.html">CH01&lt;&gt;&amp;&quot;</a></li>

--- a/test/test_epub3maker.rb
+++ b/test/test_epub3maker.rb
@@ -170,7 +170,7 @@ EOT
   <meta name="generator" content="Re:VIEW" />
   <title>Table of Contents</title>
 </head>
-<body>
+<body epub:type="toc">
   <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
   <h1 class="toc-title">Table of Contents</h1>
 
@@ -239,7 +239,7 @@ EOT
   <meta name="generator" content="Re:VIEW" />
   <title>Table of Contents</title>
 </head>
-<body>
+<body epub:type="toc">
   <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
   <h1 class="toc-title">Table of Contents</h1>
 
@@ -357,7 +357,7 @@ EOT
   <meta name="generator" content="Re:VIEW" />
   <title>Table of Contents</title>
 </head>
-<body>
+<body epub:type="toc">
   <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
   <h1 class="toc-title">Table of Contents</h1>
 
@@ -390,7 +390,7 @@ EOT
   <meta name="generator" content="Re:VIEW" />
   <title>Table of Contents</title>
 </head>
-<body>
+<body epub:type="toc">
   <h1 class="toc-title">Table of Contents</h1>
 
 <ul class="toc-h1"><li><a href="ch01.html">CH01&lt;&gt;&amp;&quot;</a></li>
@@ -425,7 +425,7 @@ EOT
   <meta name="generator" content="Re:VIEW" />
   <title>Table of Contents</title>
 </head>
-<body>
+<body epub:type="toc">
   <h1 class="toc-title">Table of Contents</h1>
 <ul class="toc-h1">
 <li><a href="ch01.html">CH01&lt;&gt;&amp;&quot;</a></li>


### PR DESCRIPTION
#1776 の修正です。

- cover内でepub:typeを設定し終えたら変数をnilに戻してほかで使われないようにする
- nav系目次に`epub:type="toc"` を指定
