### PR TITLE
remove invalid urnid from sample config.yml

### DIFF
--- a/samples/sample-book/src/config.yml
+++ b/samples/sample-book/src/config.yml
@@ -3,7 +3,6 @@ review_version: 5.0
 bookname: book
 language: ja
 booktitle: Re:VIEWサンプル書籍
-urnid: urn:uuid:http://reviewml.com/books/review-sample-book/
 # isbn: null
 aut: Re:VIEW Writers
 pbl: Re:VIEW Publishers


### PR DESCRIPTION
sample-bookのconfig.ymlで無用なurnidを設定しているため、EPUBcheckで警告が出ます。
sample-bookをユーザーが使う可能性は低そうですがリファレンスとなるサンプルが間違っているのは気持ちが悪いのでurnid定義を消します(これでランダム割り当てが行われるようになります)。
