### PR TITLE
layouts/layout.html.erbおよびlayouts/layout-web.html.erbを表紙ファイル等にも適用する

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2021 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2022 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -324,6 +324,13 @@ module ReVIEW
     end
 
     def template_name
+      if @basedir
+        layoutfile = File.join(@basedir, 'layouts', 'layout.html.erb')
+        if File.exist?(layoutfile)
+          return layoutfile
+        end
+      end
+
       if @producer.config['htmlversion'].to_i == 5
         './html/layout-html5.html.erb'
       else

--- a/lib/review/epubmaker/epubcommon.rb
+++ b/lib/review/epubmaker/epubcommon.rb
@@ -27,6 +27,7 @@ module ReVIEW
         @contents = producer.contents
         @body_ext = nil
         @logger = ReVIEW.logger
+        @workdir = nil
       end
 
       attr_reader :config
@@ -36,7 +37,8 @@ module ReVIEW
         CGI.escapeHTML(str)
       end
 
-      def produce(epubfile, basedir, tmpdir)
+      def produce(_epubfile, _basedir, _tmpdir, base_dir:)
+        @workdir = base_dir
         raise NotImplementedError # should be overridden
       end
 
@@ -99,6 +101,21 @@ module ReVIEW
         end
       end
 
+      def template_name
+        if @workdir
+          layoutfile = File.join(@workdir, 'layouts', 'layout.html.erb')
+          if File.exist?(layoutfile)
+            return layoutfile
+          end
+        end
+
+        if config['htmlversion'].to_i == 5
+          './html/layout-html5.html.erb'
+        else
+          './html/layout-xhtml1.html.erb'
+        end
+      end
+
       # Return cover content.
       # If Producer#config["coverimage"] is defined, it will be used for
       # the cover image.
@@ -114,12 +131,7 @@ module ReVIEW
         @title = h(config.name_of('title'))
         @language = config['language']
         @stylesheets = config['stylesheet']
-        template_path = if config['htmlversion'].to_i == 5
-                          './html/layout-html5.html.erb'
-                        else
-                          './html/layout-xhtml1.html.erb'
-                        end
-        ret = ReVIEW::Template.generate(path: template_path, binding: binding)
+        ret = ReVIEW::Template.generate(path: template_name, binding: binding)
         @body_ext = nil
         ret
       end
@@ -144,12 +156,7 @@ module ReVIEW
 
         @language = config['language']
         @stylesheets = config['stylesheet']
-        template_path = if config['htmlversion'].to_i == 5
-                          './html/layout-html5.html.erb'
-                        else
-                          './html/layout-xhtml1.html.erb'
-                        end
-        ReVIEW::Template.generate(path: template_path, binding: binding)
+        ReVIEW::Template.generate(path: template_name, binding: binding)
       end
 
       # Return colophon content.
@@ -161,12 +168,7 @@ module ReVIEW
 
         @language = config['language']
         @stylesheets = config['stylesheet']
-        template_path = if config['htmlversion'].to_i == 5
-                          './html/layout-html5.html.erb'
-                        else
-                          './html/layout-xhtml1.html.erb'
-                        end
-        ReVIEW::Template.generate(path: template_path, binding: binding)
+        ReVIEW::Template.generate(path: template_name, binding: binding)
       end
 
       def isbn_hyphen
@@ -222,12 +224,7 @@ module ReVIEW
 
         @language = config['language']
         @stylesheets = config['stylesheet']
-        template_path = if config['htmlversion'].to_i == 5
-                          './html/layout-html5.html.erb'
-                        else
-                          './html/layout-xhtml1.html.erb'
-                        end
-        ReVIEW::Template.generate(path: template_path, binding: binding)
+        ReVIEW::Template.generate(path: template_name, binding: binding)
       end
 
       def hierarchy_ncx(type)

--- a/lib/review/epubmaker/epubv2.rb
+++ b/lib/review/epubmaker/epubv2.rb
@@ -1,6 +1,6 @@
 # = epubv2.rb -- EPUB version 2 producer.
 #
-# Copyright (c) 2010-2017 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2022 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -159,6 +159,7 @@ EOT
       # +basedir+ points the directory has contents.
       # +tmpdir+ defines temporary directory.
       def produce(epubfile, work_dir, tmpdir, base_dir:)
+        @workdir = base_dir
         produce_write_common(work_dir, tmpdir)
 
         ncx_file = "#{tmpdir}/OEBPS/#{config['bookname']}.ncx"

--- a/lib/review/epubmaker/epubv3.rb
+++ b/lib/review/epubmaker/epubv3.rb
@@ -210,19 +210,20 @@ module ReVIEW
         @title = h(ReVIEW::I18n.t('toctitle'))
         @language = config['language']
         @stylesheets = config['stylesheet']
-        ReVIEW::Template.generate(path: './html/layout-html5.html.erb', binding: binding)
+        ReVIEW::Template.generate(path: template_name, binding: binding)
       end
 
       # Produce EPUB file +epubfile+.
       # +work_dir+ points the directory has contents.
       # +tmpdir+ defines temporary directory.
       def produce(epubfile, work_dir, tmpdir, base_dir:)
+        @workdir = base_dir
         produce_write_common(work_dir, tmpdir)
 
         toc_file = "#{tmpdir}/OEBPS/#{config['bookname']}-toc.#{config['htmlext']}"
         File.write(toc_file, ncx(config['epubmaker']['ncxindent']))
 
-        call_hook('hook_prepack', tmpdir, base_dir: base_dir)
+        call_hook('hook_prepack', tmpdir, base_dir: @workdir)
         expoter = ReVIEW::EPUBMaker::ZipExporter.new(tmpdir, config)
         expoter.export_zip(epubfile)
       end

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2016-2021 Masayoshi Takahashi, Masanori Kado, Kenshi Muto
+# Copyright (c) 2016-2022 Masayoshi Takahashi, Masanori Kado, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -97,7 +97,7 @@ module ReVIEW
     end
 
     def generate_html_files(yamlfile)
-      @basedir = File.dirname(yamlfile)
+      @basedir = File.absolute_path(File.dirname(yamlfile))
       @path = build_path
       remove_old_files(@path)
       Dir.mkdir(@path)
@@ -159,6 +159,13 @@ module ReVIEW
     end
 
     def template_name
+      if @basedir
+        layoutfile = File.join(@basedir, 'layouts', 'layout-web.html.erb')
+        if File.exist?(layoutfile)
+          return layoutfile
+        end
+      end
+
       if @config['htmlversion'].to_i == 5
         'web/html/layout-html5.html.erb'
       else


### PR DESCRIPTION
#1777 の修正第一弾です。

epubmaker, webmakerにおいて本文章を構築するhtmlbuilderではカスタムテンプレートのlayouts/layout.html.erb, layouts/layout-web.html.erbを採用するようにしていますが、cover, titlepage, colophon, partなどの自動生成するファイルにおいてはシステムデフォルトのものしか参照できていなかったので、カスタムテンプレートが存在すればそれを使うように修正します。
