### PR TITLE
HTMLパーツのlayoutsでの上書きの許可

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -315,20 +315,23 @@ module ReVIEW
       File.open(File.join(basetmpdir, htmlfile), 'w') do |f|
         @part_number = part.number
         @part_title = part.name.strip
-        @body = ReVIEW::Template.generate(path: 'html/_part_body.html.erb', binding: binding)
-
+        @body = ReVIEW::Template.generate(path: template_name(localfile: '_part_body.html.erb', systemfile: 'html/_part_body.html.erb'), binding: binding)
         @language = @producer.config['language']
         @stylesheets = @producer.config['stylesheet']
         f.write ReVIEW::Template.generate(path: template_name, binding: binding)
       end
     end
 
-    def template_name
+    def template_name(localfile: 'layout.html.erb', systemfile: nil)
       if @basedir
-        layoutfile = File.join(@basedir, 'layouts', 'layout.html.erb')
+        layoutfile = File.join(@basedir, 'layouts', localfile)
         if File.exist?(layoutfile)
           return layoutfile
         end
+      end
+
+      if systemfile
+        return systemfile
       end
 
       if @producer.config['htmlversion'].to_i == 5
@@ -552,25 +555,12 @@ module ReVIEW
     end
 
     def build_titlepage(basetmpdir, htmlfile)
-      # TODO: should be created via epubcommon
       @title = h(@config.name_of('booktitle'))
       File.open(File.join(basetmpdir, htmlfile), 'w') do |f|
-        @body = ''
-        @body << %Q(<div class="titlepage">\n)
-        @body << %Q(<h1 class="tp-title">#{h(@config.name_of('booktitle'))}</h1>\n)
-        if @config['subtitle']
-          @body << %Q(<h2 class="tp-subtitle">#{h(@config.name_of('subtitle'))}</h2>\n)
-        end
-        if @config['aut']
-          @body << %Q(<h2 class="tp-author">#{h(@config.names_of('aut').join(ReVIEW::I18n.t('names_splitter')))}</h2>\n)
-        end
-        if @config['pbl']
-          @body << %Q(<h3 class="tp-publisher">#{h(@config.names_of('pbl').join(ReVIEW::I18n.t('names_splitter')))}</h3>\n)
-        end
-        @body << '</div>'
-
+        @body = ReVIEW::Template.generate(path: template_name(localfile: '_titlepage.html.erb', systemfile: 'html/_titlepage.html.erb'), binding: binding)
         @language = @producer.config['language']
         @stylesheets = @producer.config['stylesheet']
+
         f.write ReVIEW::Template.generate(path: template_name, binding: binding)
       end
     end

--- a/lib/review/epubmaker/epubcommon.rb
+++ b/lib/review/epubmaker/epubcommon.rb
@@ -101,12 +101,16 @@ module ReVIEW
         end
       end
 
-      def template_name
+      def template_name(localfile: 'layout.html.erb', systemfile: nil)
         if @workdir
-          layoutfile = File.join(@workdir, 'layouts', 'layout.html.erb')
+          layoutfile = File.join(@workdir, 'layouts', localfile)
           if File.exist?(layoutfile)
             return layoutfile
           end
+        end
+
+        if systemfile
+          return systemfile
         end
 
         if config['htmlversion'].to_i == 5
@@ -126,7 +130,7 @@ module ReVIEW
           @coverimage_src = coverimage
           raise ApplicationError, "coverimage #{config['coverimage']} not found. Abort." unless @coverimage_src
         end
-        @body = ReVIEW::Template.generate(path: './html/_cover.html.erb', binding: binding)
+        @body = ReVIEW::Template.generate(path: template_name(localfile: '_cover.html.erb', systemfile: 'html/_cover.html.erb'), binding: binding)
 
         @title = h(config.name_of('title'))
         @language = config['language']
@@ -152,7 +156,7 @@ module ReVIEW
         if config.names_of('pbl')
           @publisher_str = join_with_separator(config.names_of('pbl'), ReVIEW::I18n.t('names_splitter'))
         end
-        @body = ReVIEW::Template.generate(path: './html/_titlepage.html.erb', binding: binding)
+        @body = ReVIEW::Template.generate(path: template_name(localfile: '_titlepage.html.erb', systemfile: './html/_titlepage.html.erb'), binding: binding)
 
         @language = config['language']
         @stylesheets = config['stylesheet']
@@ -164,7 +168,7 @@ module ReVIEW
         @title = h(ReVIEW::I18n.t('colophontitle'))
         @isbn_hyphen = isbn_hyphen
 
-        @body = ReVIEW::Template.generate(path: './html/_colophon.html.erb', binding: binding)
+        @body = ReVIEW::Template.generate(path: template_name(localfile: '_colophon.html.erb', systemfile: './html/_colophon.html.erb'), binding: binding)
 
         @language = config['language']
         @stylesheets = config['stylesheet']
@@ -203,7 +207,7 @@ module ReVIEW
           end
         end
 
-        ReVIEW::Template.generate(path: './html/_colophon_history.html.erb', binding: binding)
+        ReVIEW::Template.generate(path: template_name(localfile: '_colophon_history.html.erb', systemfile: './html/_colophon_history.html.erb'), binding: binding)
       end
 
       def date_to_s(date)

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -146,24 +146,25 @@ module ReVIEW
     def build_part(part, basetmpdir, htmlfile)
       @title = h("#{ReVIEW::I18n.t('part', part.number)} #{part.name.strip}")
       File.open("#{basetmpdir}/#{htmlfile}", 'w') do |f|
-        @body = ''
-        @body << %Q(<div class="part">\n)
-        @body << %Q(<h1 class="part-number">#{ReVIEW::I18n.t('part', part.number)}</h1>\n)
-        @body << %Q(<h2 class="part-title">#{part.name.strip}</h2>\n) if part.name.strip.present?
-        @body << "</div>\n"
-
+        @part_number = part.number
+        @part_title = part.name.strip
+        @body = ReVIEW::Template.generate(path: template_name(localfile: '_part_body.html.erb', systemfile: 'html/_part_body.html.erb'), binding: binding)
         @language = @config['language']
         @stylesheets = @config['stylesheet']
         f.write ReVIEW::Template.generate(path: template_name, binding: binding)
       end
     end
 
-    def template_name
+    def template_name(localfile: 'layout-web.html.erb', systemfile: nil)
       if @basedir
-        layoutfile = File.join(@basedir, 'layouts', 'layout-web.html.erb')
+        layoutfile = File.join(@basedir, 'layouts', localfile)
         if File.exist?(layoutfile)
           return layoutfile
         end
+      end
+
+      if systemfile
+        return systemfile
       end
 
       if @config['htmlversion'].to_i == 5
@@ -281,18 +282,8 @@ module ReVIEW
 
     def build_titlepage(basetmpdir, htmlfile)
       @title = h('titlepage')
-      File.open("#{basetmpdir}/#{htmlfile}", 'w') do |f|
-        @body = ''
-        @body << %Q(<div class="titlepage">)
-        @body << %Q(<h1 class="tp-title">#{h(@config.name_of('booktitle'))}</h1>)
-        if @config['aut']
-          @body << %Q(<h2 class="tp-author">#{join_with_separator(@config.names_of('aut'), ReVIEW::I18n.t('names_splitter'))}</h2>)
-        end
-        if @config['pbl']
-          @body << %Q(<h3 class="tp-publisher">#{join_with_separator(@config.names_of('pbl'), ReVIEW::I18n.t('names_splitter'))}</h3>)
-        end
-        @body << '</div>'
-
+      File.open(File.join(basetmpdir, htmlfile), 'w') do |f|
+        @body = ReVIEW::Template.generate(path: template_name(localfile: '_titlepage.html.erb', systemfile: 'html/_titlepage.html.erb'), binding: binding)
         @language = @config['language']
         @stylesheets = @config['stylesheet']
         f.write ReVIEW::Template.generate(path: template_name, binding: binding)

--- a/templates/html/_titlepage.html.erb
+++ b/templates/html/_titlepage.html.erb
@@ -1,20 +1,12 @@
-  <h1 class="tp-title"><%= @title_str %></h1>
-<% if @subtitle_str %>
-  <h2 class="tp-subtitle"><%= h(@subtitle_str) %></h2>
+<div class="titlepage">
+<h1 class="tp-title"><%= h(@config.name_of('booktitle')) %></h1>
+<% if @config['subtitle'] %>
+<h2 class="tp-subtitle"><%= h(@config.name_of('subtitle')) %></h2>
 <% end %>
-<% if @author_str %>
-  <p>
-    <br />
-    <br />
-  </p>
-  <h2 class="tp-author"><%= h(@author_str) %></h2>
+<% if @config['aut'] %>
+<h2 class="tp-author"><%= h(@config.names_of('aut').join(ReVIEW::I18n.t('names_splitter'))) %></h2>
 <% end %>
-<% if @publisher_str %>
-  <p>
-    <br />
-    <br />
-    <br />
-    <br />
-  </p>
-  <h3 class="tp-publisher"><%= h(@publisher_str) %></h3>
+<% if @config['pbl'] %>
+<h3 class="tp-publisher"><%= h(@config.names_of('pbl').join(ReVIEW::I18n.t('names_splitter'))) %></h3>
 <% end %>
+</div>

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -6,6 +6,7 @@ class EPUBMakerTest < Test::Unit::TestCase
     config = ReVIEW::Configure.values
     config.merge!(
       'bookname' => 'sample',
+      'booktitle' => 'Sample Book',
       'title' => 'Sample Book',
       'epubversion' => 2,
       'urnid' => 'http://example.jp/',
@@ -806,19 +807,11 @@ EOT
   <title>Sample Book</title>
 </head>
 <body>
-  <h1 class="tp-title">Sample Book</h1>
-  <p>
-    <br />
-    <br />
-  </p>
-  <h2 class="tp-author">Mr.Smith</h2>
-  <p>
-    <br />
-    <br />
-    <br />
-    <br />
-  </p>
-  <h3 class="tp-publisher">BLUEPRINT</h3>
+<div class="titlepage">
+<h1 class="tp-title">Sample Book</h1>
+<h2 class="tp-author">Mr.Smith</h2>
+<h3 class="tp-publisher">BLUEPRINT</h3>
+</div>
 </body>
 </html>
 EOT
@@ -842,19 +835,11 @@ EOT
   <title>Sample Book</title>
 </head>
 <body>
-  <h1 class="tp-title">Sample Book</h1>
-  <p>
-    <br />
-    <br />
-  </p>
-  <h2 class="tp-author">Mr.Smith</h2>
-  <p>
-    <br />
-    <br />
-    <br />
-    <br />
-  </p>
-  <h3 class="tp-publisher">BLUEPRINT</h3>
+<div class="titlepage">
+<h1 class="tp-title">Sample Book</h1>
+<h2 class="tp-author">Mr.Smith</h2>
+<h3 class="tp-publisher">BLUEPRINT</h3>
+</div>
 </body>
 </html>
 EOT


### PR DESCRIPTION
#1777 の修正第二弾です。

```
_colophon.html.erb
_colophon_history.html.erb
_cover.html.erb
_part_body.html.erb
_titlepage.html.erb
```

をlayoutsで上書きできるようにします。
epubmaker, webmakerでそれぞれに持っていたpartとtitlepageの書き換えはどちらもテンプレート側を使うように変更しました。