### PR TITLE
rubocop: resolve some cops

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -57,9 +57,6 @@ Lint/StructNewOverride:
 Lint/RedundantDirGlobSort:
   Enabled: false
 
-Lint/ElseLayout:
-  Enabled: false
-
 #### Performance
 
 Performance/RegexpMatch:
@@ -109,9 +106,6 @@ Performance/CollectionLiteralInLoop:
   Enabled: false
 
 #### Style
-
-Style/AccessModifierDeclarations:
-  Enabled: false
 
 Style/AsciiComments:
   Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -148,9 +148,6 @@ Style/GlobalVars:
 Style/SelfAssignment:
   Enabled: true
 
-Style/ConditionalAssignment:
-  Enabled: false
-
 Style/Documentation:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -320,9 +320,6 @@ Style/RedundantSelf:
 Style/RegexpLiteral:
   Enabled: true
 
-Style/RescueStandardError:
-  Enabled: false
-
 Style/Semicolon:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -140,9 +140,6 @@ Style/CommentedKeyword:
 Style/DocumentDynamicEvalDefinition:
   Enabled: false
 
-Style/FloatDivision:
-  Enabled: false
-
 # Do not introduce global variables.
 Style/GlobalVars:
   Enabled: true

--- a/bin/review-catalog-converter
+++ b/bin/review-catalog-converter
@@ -55,21 +55,21 @@ def main
       end
       # chaps and parts
       if File.exist?("#{dir}/CHAPS")
-        if File.exist?("#{dir}/PART")
-          catalog << parse_parts(File.read("#{dir}/PART"),
+        catalog << if File.exist?("#{dir}/PART")
+                     parse_parts(File.read("#{dir}/PART"),
                                  File.read("#{dir}/CHAPS"))
-        else
-          catalog << parse_chaps(File.read("#{dir}/CHAPS"))
-        end
+                   else
+                     parse_chaps(File.read("#{dir}/CHAPS"))
+                   end
       end
       # postdef
       if File.exist?("#{dir}/POSTDEF")
         postdef = File.read("#{dir}/POSTDEF")
-        if ask_yes?('Do you want to convert POSTDEF into APPENDIX? [y/n]')
-          catalog << parse_postdef(postdef, true)
-        else
-          catalog << parse_postdef(postdef)
-        end
+        catalog << if ask_yes?('Do you want to convert POSTDEF into APPENDIX? [y/n]')
+                     parse_postdef(postdef, true)
+                   else
+                     parse_postdef(postdef)
+                   end
       end
     end
   end
@@ -99,11 +99,11 @@ def parse_chaps(str)
 end
 
 def parse_postdef(str, to_appendix = false)
-  if to_appendix
-    header = "APPENDIX:\n"
-  else
-    header = "POSTDEF:\n"
-  end
+  header = if to_appendix
+             "APPENDIX:\n"
+           else
+             "POSTDEF:\n"
+           end
   parse_internal(str, header) + "\n"
 end
 

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -52,13 +52,13 @@ def _main
       error! "#{@config['yaml']} not found." unless File.exist?(@config['yaml'])
       begin
         @config.deep_merge!(loader.load_file(@config['yaml']))
-      rescue => e
+      rescue StandardError => e
         error! "yaml error #{e.message}"
       end
     elsif File.exist?(DEFAULT_CONFIG_FILENAME)
       begin
         @config.deep_merge!(loader.load_file(DEFAULT_CONFIG_FILENAME))
-      rescue => e
+      rescue StandardError => e
         error! "yaml error #{e.message}"
       end
     end

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -34,11 +34,9 @@ def _main
   @logger = ReVIEW.logger
   @mode = :files
   @basedir = nil
-  if File.basename($PROGRAM_NAME).start_with?('review2')
-    @target = File.basename($PROGRAM_NAME, '.rb').sub('review2', '')
-  else
-    @target = nil
-  end
+  @target = if File.basename($PROGRAM_NAME).start_with?('review2')
+              File.basename($PROGRAM_NAME, '.rb').sub('review2', '')
+            end
   @check_only = false
   @output_filename = nil
 

--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -42,7 +42,7 @@ module ReVIEW
         if @io
           begin
             @content = @io.read
-          rescue
+          rescue StandardError
             @content = nil
           end
         else

--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -45,7 +45,7 @@ module ReVIEW
 
       def [](id)
         @index.fetch(id)
-      rescue
+      rescue StandardError
         index_keys = @index.keys.map { |i| i.split('|').last }.flatten # unfold all ids
         if index_keys.each_with_object(Hash.new(0)) { |i, h| h[i] += 1 }. # number of occurrences
            select { |k, v| k == id && v > 1 }.present? # detect duplicated
@@ -84,14 +84,14 @@ module ReVIEW
         begin
           chapter = chapter_item.content
           chapter.format_number
-        rescue # part
+        rescue StandardError # part
           I18n.t('part', chapter.number)
         end
       end
 
       def title(id)
         @index.fetch(id).content.title
-      rescue # non-file part
+      rescue StandardError # non-file part
         @index.fetch(id).content.name
       end
 

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -14,11 +14,11 @@ module ReVIEW
       def self.mkpart_from_namelistfile(book, path)
         chaps = []
         File.read(path, mode: 'rt:BOM|utf-8').split.each_with_index do |name, number|
-          if path =~ /PREDEF/
-            chaps << Chapter.mkchap(book, name)
-          else
-            chaps << Chapter.mkchap(book, name, number + 1)
-          end
+          chaps << if path =~ /PREDEF/
+                     Chapter.mkchap(book, name)
+                   else
+                     Chapter.mkchap(book, name, number + 1)
+                   end
         end
         Part.mkpart(chaps)
       end
@@ -47,11 +47,11 @@ module ReVIEW
         else
           @content = ''
         end
-        if file?
-          @title = nil
-        else
-          @title = name
-        end
+        @title = if file?
+                   nil
+                 else
+                   name
+                 end
         @volume = nil
 
         super()
@@ -78,11 +78,10 @@ module ReVIEW
 
       def volume
         if @number && file?
-          vol = Volume.count_file(File.join(@book.config['contentdir'], @path))
+          Volume.count_file(File.join(@book.config['contentdir'], @path))
         else
-          vol = Volume.new(0, 0, 0)
+          Volume.new(0, 0, 0)
         end
-        vol
       end
 
       def file?

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -62,11 +62,11 @@ module ReVIEW
       if @book && @book.config
         @img_math ||= ReVIEW::ImgMath.new(@book.config)
         if words_file_path = @book.config['words_file']
-          if words_file_path.is_a?(String)
-            words_files = [words_file_path]
-          else
-            words_files = words_file_path
-          end
+          words_files = if words_file_path.is_a?(String)
+                          [words_file_path]
+                        else
+                          words_file_path
+                        end
           words_files.each do |f|
             load_words(f)
           end

--- a/lib/review/catalog.rb
+++ b/lib/review/catalog.rb
@@ -4,11 +4,11 @@ require 'date'
 module ReVIEW
   class Catalog
     def initialize(file)
-      if file.respond_to?(:read)
-        @yaml = YAMLLoader.safe_load(file.read)
-      else ## as Object
-        @yaml = file
-      end
+      @yaml = if file.respond_to?(:read)
+                YAMLLoader.safe_load(file.read)
+              else ## as Object
+                file
+              end
       @yaml ||= {}
     end
 

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -681,7 +681,7 @@ module ReVIEW
         result << compile_inline(revert_replace_fence(words.shift.gsub(/\\\}/, '}').gsub(/\\\\/, '\\')))
       end
       result
-    rescue => e
+    rescue StandardError => e
       error e.message, location: location
     end
     public :text # called from builder
@@ -696,7 +696,7 @@ module ReVIEW
       end
 
       @builder.__send__("inline_#{op}", arg)
-    rescue => e
+    rescue StandardError => e
       error e.message, location: location
       @builder.nofunc_text(str)
     end

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -671,11 +671,11 @@ module ReVIEW
       end
       result = ''
       until words.empty?
-        if in_non_escaped_command? && block_mode
-          result << revert_replace_fence(words.shift)
-        else
-          result << @builder.nofunc_text(revert_replace_fence(words.shift))
-        end
+        result << if in_non_escaped_command? && block_mode
+                    revert_replace_fence(words.shift)
+                  else
+                    @builder.nofunc_text(revert_replace_fence(words.shift))
+                  end
         break if words.empty?
 
         result << compile_inline(revert_replace_fence(words.shift.gsub(/\\\}/, '}').gsub(/\\\\/, '\\')))

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -155,7 +155,7 @@ module ReVIEW
         begin
           loader = ReVIEW::YAMLLoader.new
           conf.deep_merge!(loader.load_file(yamlfile))
-        rescue => e
+        rescue StandardError => e
           raise ReVIEW::ConfigError, "yaml error #{e.message}"
         end
       end

--- a/lib/review/epub2html.rb
+++ b/lib/review/epub2html.rb
@@ -13,7 +13,7 @@ require 'review/version'
 
 begin
   require 'cgi/escape'
-rescue
+rescue StandardError
   require 'cgi/util'
 end
 

--- a/lib/review/epub2html.rb
+++ b/lib/review/epub2html.rb
@@ -107,15 +107,15 @@ EOT
         end
 
         file, anc = href.split('#', 2)
-        if anc
-          if file.empty?
-            anc = "#{sanitize(fname)}_#{sanitize(anc)}"
-          else
-            anc = "#{sanitize(file)}_#{sanitize(anc)}"
-          end
-        else
-          anc = sanitize(file)
-        end
+        anc = if anc
+                if file.empty?
+                  "#{sanitize(fname)}_#{sanitize(anc)}"
+                else
+                  "#{sanitize(file)}_#{sanitize(anc)}"
+                end
+              else
+                sanitize(file)
+              end
 
         e.attributes['href'] = "##{anc}"
       end

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -446,11 +446,11 @@ module ReVIEW
       end
 
       properties = detect_properties(path)
-      if properties.present?
-        prop_str = ',properties=' + properties.join(' ')
-      else
-        prop_str = ''
-      end
+      prop_str = if properties.present?
+                   ',properties=' + properties.join(' ')
+                 else
+                   ''
+                 end
       first = true
       headlines.each do |headline|
         if ispart.present? && headline['level'] == 1

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -394,7 +394,7 @@ module ReVIEW
         @converter.convert(filename, File.join(basetmpdir, htmlfile))
         write_info_body(basetmpdir, id, htmlfile, ispart, chaptype)
         remove_hidden_title(basetmpdir, htmlfile)
-      rescue => e
+      rescue StandardError => e
         @compile_errors = true
         error "compile error in #{filename} (#{e.class})"
         error e.message

--- a/lib/review/epubmaker/epubcommon.rb
+++ b/lib/review/epubmaker/epubcommon.rb
@@ -220,11 +220,11 @@ module ReVIEW
       def mytoc
         @title = h(ReVIEW::I18n.t('toctitle'))
         @body = %Q(  <h1 class="toc-title">#{h(ReVIEW::I18n.t('toctitle'))}</h1>\n)
-        if config['epubmaker']['flattoc'].nil?
-          @body << hierarchy_ncx('ul')
-        else
-          @body << flat_ncx('ul', config['epubmaker']['flattocindent'])
-        end
+        @body << if config['epubmaker']['flattoc'].nil?
+                   hierarchy_ncx('ul')
+                 else
+                   flat_ncx('ul', config['epubmaker']['flattocindent'])
+                 end
 
         @language = config['language']
         @stylesheets = config['stylesheet']

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -861,7 +861,7 @@ EOS
       end
       begin
         puts %Q(<img src="#{@chapter.image(id).path.sub(%r{\A\./}, '')}" alt="#{escape(compile_inline(caption))}"#{metrics} />)
-      rescue
+      rescue StandardError
         warn "image not bound: #{id}", location: location
         if lines
           puts %Q(<pre class="dummyimage">)
@@ -1250,7 +1250,7 @@ EOS
     def inline_icon(id)
       begin
         %Q(<img src="#{@chapter.image(id).path.sub(%r{\A\./}, '')}" alt="[#{id}]" />)
-      rescue
+      rescue StandardError
         warn "image not bound: #{id}", location: location
         %Q(<pre>missing image: #{id}</pre>)
       end

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -67,11 +67,11 @@ module ReVIEW
         htmldir = 'html'
         localfilename = 'layout.html.erb'
       end
-      if @book.htmlversion == 5
-        htmlfilename = File.join(htmldir, 'layout-html5.html.erb')
-      else
-        htmlfilename = File.join(htmldir, 'layout-xhtml1.html.erb')
-      end
+      htmlfilename = if @book.htmlversion == 5
+                       File.join(htmldir, 'layout-html5.html.erb')
+                     else
+                       File.join(htmldir, 'layout-xhtml1.html.erb')
+                     end
 
       layout_file = File.join(@book.basedir, 'layouts', localfilename)
       if !File.exist?(layout_file) && File.exist?(File.join(@book.basedir, 'layouts', 'layout.erb'))
@@ -1096,11 +1096,11 @@ EOS
 
     def inline_hd_chap(chap, id)
       n = chap.headline_index.number(id)
-      if n.present? && chap.number && over_secnolevel?(n)
-        str = I18n.t('hd_quote', [n, compile_inline(chap.headline(id).caption)])
-      else
-        str = I18n.t('hd_quote_without_number', compile_inline(chap.headline(id).caption))
-      end
+      str = if n.present? && chap.number && over_secnolevel?(n)
+              I18n.t('hd_quote', [n, compile_inline(chap.headline(id).caption)])
+            else
+              I18n.t('hd_quote_without_number', compile_inline(chap.headline(id).caption))
+            end
       if @book.config['chapterlink']
         anchor = 'h' + n.tr('.', '-')
         %Q(<a href="#{chap.id}#{extname}##{anchor}">#{str}</a>)

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -9,7 +9,7 @@
 
 begin
   require 'cgi/escape'
-rescue
+rescue StandardError
   require 'cgi/util'
 end
 

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -60,13 +60,13 @@ module ReVIEW
     def highlight_pygments(ops)
       body = ops[:body] || ''
       format = ops[:format] || ''
-      if ops[:lexer].present?
-        lexer = ops[:lexer]
-      elsif @book.config['highlight'] && @book.config['highlight']['lang']
-        lexer = @book.config['highlight']['lang'] # default setting
-      else
-        lexer = 'text'
-      end
+      lexer = if ops[:lexer].present?
+                ops[:lexer]
+              elsif @book.config['highlight'] && @book.config['highlight']['lang']
+                @book.config['highlight']['lang'] # default setting
+              else
+                'text'
+              end
       options = { nowrap: true, noclasses: true }
       if ops[:linenum]
         options[:nowrap] = false
@@ -93,13 +93,13 @@ module ReVIEW
 
     def highlight_rouge(ops)
       body = ops[:body] || ''
-      if ops[:lexer].present?
-        lexer = ops[:lexer]
-      elsif @book.config['highlight'] && @book.config['highlight']['lang']
-        lexer = @book.config['highlight']['lang'] # default setting
-      else
-        lexer = 'text'
-      end
+      lexer = if ops[:lexer].present?
+                ops[:lexer]
+              elsif @book.config['highlight'] && @book.config['highlight']['lang']
+                @book.config['highlight']['lang'] # default setting
+              else
+                'text'
+              end
       # format = ops[:format] || ''
 
       first_line_num = 1 ## default

--- a/lib/review/i18n.rb
+++ b/lib/review/i18n.rb
@@ -171,7 +171,7 @@ module ReVIEW
       args_matched = (frmt.count('%') <= args.size)
       frmt.gsub!('##', '%%')
       args_matched ? (frmt % args) : frmt
-    rescue
+    rescue StandardError
       str
     end
   end

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -457,11 +457,11 @@ module ReVIEW
       caption_str = nil
       if id
         puts '<equationblock>'
-        if get_chap.nil?
-          caption_str = %Q(<caption>#{I18n.t('equation')}#{I18n.t('format_number_without_chapter', [@chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}</caption>)
-        else
-          caption_str = %Q(<caption>#{I18n.t('equation')}#{I18n.t('format_number', [get_chap, @chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}</caption>)
-        end
+        caption_str = if get_chap.nil?
+                        %Q(<caption>#{I18n.t('equation')}#{I18n.t('format_number_without_chapter', [@chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}</caption>)
+                      else
+                        %Q(<caption>#{I18n.t('equation')}#{I18n.t('format_number', [get_chap, @chapter.equation(id).number])}#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}</caption>)
+                      end
         puts caption_str if caption_top?('equation')
       end
 

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -800,7 +800,7 @@ module ReVIEW
     def inline_icon(id)
       begin
         %Q(<Image href="file://#{@chapter.image(id).path.sub(%r{\A\./}, '')}" type="inline" />)
-      rescue
+      rescue StandardError
         warn "image not bound: #{id}", location: location
         ''
       end
@@ -1147,7 +1147,7 @@ module ReVIEW
       end
       begin
         puts %Q(<Image href="file://#{@chapter.image(id).path.sub(%r{\A\./}, '')}"#{metrics} />)
-      rescue
+      rescue StandardError
         warn %Q(image not bound: #{id}), location: location
       end
       unless caption_top?('image')

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -480,7 +480,7 @@ module ReVIEW
     def table(lines, id = nil, caption = nil)
       @tablewidth = nil
       if @book.config['tableopt']
-        @tablewidth = @book.config['tableopt'].split(',')[0].to_f / @book.config['pt_to_mm_unit'].to_f
+        @tablewidth = @book.config['tableopt'].split(',')[0].to_f / @book.config['pt_to_mm_unit'].to_f # rubocop:disable Style/FloatDivision
       end
       @col = 0
 
@@ -540,7 +540,7 @@ module ReVIEW
           cellwidth = @tsize.split(/\s*,\s*/)
           totallength = 0
           cellwidth.size.times do |n|
-            cellwidth[n] = cellwidth[n].to_f / @book.config['pt_to_mm_unit'].to_f
+            cellwidth[n] = cellwidth[n].to_f / @book.config['pt_to_mm_unit'].to_f # rubocop:disable Style/FloatDivision
             totallength += cellwidth[n]
             warn "total length exceeds limit for table: #{@table_id}", location: location if totallength > @tablewidth
           end

--- a/lib/review/idgxmlmaker.rb
+++ b/lib/review/idgxmlmaker.rb
@@ -119,7 +119,7 @@ module ReVIEW
         if s.success?
           File.write(xmlfile, o) # override
         end
-      rescue => e
+      rescue StandardError => e
         warn("filter error for #{xmlfile}: #{e.message}")
       end
     end
@@ -177,7 +177,7 @@ module ReVIEW
       begin
         @converter.convert(filename, File.join(basetmpdir, xmlfile))
         apply_filter(File.join(basetmpdir, xmlfile))
-      rescue => e
+      rescue StandardError => e
         @compile_errors = true
         error "compile error in #{filename} (#{e.class})"
         error e.message

--- a/lib/review/idgxmlmaker.rb
+++ b/lib/review/idgxmlmaker.rb
@@ -159,13 +159,11 @@ module ReVIEW
     end
 
     def build_chap(chap, base_path, basetmpdir, ispart)
-      filename = ''
-
-      if ispart.present?
-        filename = chap.path
-      else
-        filename = Pathname.new(chap.path).relative_path_from(base_path).to_s
-      end
+      filename = if ispart.present?
+                   chap.path
+                 else
+                   Pathname.new(chap.path).relative_path_from(base_path).to_s
+                 end
       id = File.basename(filename).sub(/\.re\Z/, '')
       if @buildonly && !@buildonly.include?(id)
         warn "skip #{id}.re"

--- a/lib/review/index_builder.rb
+++ b/lib/review/index_builder.rb
@@ -101,11 +101,7 @@ module ReVIEW
 
       cursor = level - 2
 
-      if label
-        @headline_stack[cursor] = label
-      else
-        @headline_stack[cursor] = caption
-      end
+      @headline_stack[cursor] = (label || caption)
       if @headline_stack.size > cursor + 1
         @headline_stack = @headline_stack.take(cursor + 1)
       end
@@ -123,11 +119,7 @@ module ReVIEW
 
       cursor = level - 2
 
-      if label
-        @headline_stack[cursor] = label
-      else
-        @headline_stack[cursor] = caption
-      end
+      @headline_stack[cursor] = (label || caption)
       if @headline_stack.size > cursor + 1
         @headline_stack = @headline_stack.take(cursor + 1)
       end
@@ -147,11 +139,7 @@ module ReVIEW
 
       cursor = level - 2
 
-      if label
-        @headline_stack[cursor] = label
-      else
-        @headline_stack[cursor] = caption
-      end
+      @headline_stack[cursor] = (label || caption)
       if @headline_stack.size > cursor + 1
         @headline_stack = @headline_stack.take(cursor + 1)
       end
@@ -171,11 +159,7 @@ module ReVIEW
 
       cursor = level - 2
 
-      if label
-        @headline_stack[cursor] = label
-      else
-        @headline_stack[cursor] = caption
-      end
+      @headline_stack[cursor] = (label || caption)
       if @headline_stack.size > cursor + 1
         @headline_stack = @headline_stack.take(cursor + 1)
       end

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -199,12 +199,11 @@ module ReVIEW
       blank
       @doc_status[:column] = true
 
-      target = nil
-      if label
-        target = "\\hypertarget{#{column_label(label)}}{}"
-      else
-        target = "\\hypertarget{#{column_label(caption)}}{}"
-      end
+      target = if label
+                 "\\hypertarget{#{column_label(label)}}{}"
+               else
+                 "\\hypertarget{#{column_label(caption)}}{}"
+               end
 
       @doc_status[:caption] = true
       if @book.config.check_version('2', exception: false)
@@ -476,11 +475,11 @@ module ReVIEW
           captionstr = macro(command + 'caption', compile_inline(caption))
         else
           begin
-            if get_chap.nil?
-              captionstr = macro('reviewlistcaption', "#{I18n.t('list')}#{I18n.t('format_number_header_without_chapter', [@chapter.list(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}")
-            else
-              captionstr = macro('reviewlistcaption', "#{I18n.t('list')}#{I18n.t('format_number_header', [get_chap, @chapter.list(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}")
-            end
+            captionstr = if get_chap.nil?
+                           macro('reviewlistcaption', "#{I18n.t('list')}#{I18n.t('format_number_header_without_chapter', [@chapter.list(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}")
+                         else
+                           macro('reviewlistcaption', "#{I18n.t('list')}#{I18n.t('format_number_header', [get_chap, @chapter.list(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}")
+                         end
           rescue KeyError
             app_error "no such list: #{id}"
           end
@@ -578,13 +577,12 @@ module ReVIEW
     end
 
     def image_image(id, caption = '', metric = nil)
-      captionstr = nil
       @doc_status[:caption] = true
-      if @book.config.check_version('2', exception: false)
-        captionstr = macro('caption', compile_inline(caption)) + "\n"
-      else
-        captionstr = macro('reviewimagecaption', compile_inline(caption)) + "\n"
-      end
+      captionstr = if @book.config.check_version('2', exception: false)
+                     macro('caption', compile_inline(caption)) + "\n"
+                   else
+                     macro('reviewimagecaption', compile_inline(caption)) + "\n"
+                   end
       captionstr << macro('label', image_label(id))
       @doc_status[:caption] = nil
 
@@ -970,11 +968,11 @@ module ReVIEW
 
       if id
         puts macro('begin', 'reviewequationblock')
-        if get_chap.nil?
-          captionstr = macro('reviewequationcaption', "#{I18n.t('equation')}#{I18n.t('format_number_header_without_chapter', [@chapter.equation(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}")
-        else
-          captionstr = macro('reviewequationcaption', "#{I18n.t('equation')}#{I18n.t('format_number_header', [get_chap, @chapter.equation(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}")
-        end
+        captionstr = if get_chap.nil?
+                       macro('reviewequationcaption', "#{I18n.t('equation')}#{I18n.t('format_number_header_without_chapter', [@chapter.equation(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}")
+                     else
+                       macro('reviewequationcaption', "#{I18n.t('equation')}#{I18n.t('format_number_header', [get_chap, @chapter.equation(id).number])}#{I18n.t('caption_prefix')}#{compile_inline(caption)}")
+                     end
       end
 
       if caption_top?('equation') && captionstr
@@ -1279,11 +1277,11 @@ module ReVIEW
 
     def inline_hd_chap(chap, id)
       n = chap.headline_index.number(id)
-      if n.present? && chap.number && over_secnolevel?(n)
-        str = I18n.t('hd_quote', [chap.headline_index.number(id), compile_inline(chap.headline(id).caption)])
-      else
-        str = I18n.t('hd_quote_without_number', compile_inline(chap.headline(id).caption))
-      end
+      str = if n.present? && chap.number && over_secnolevel?(n)
+              I18n.t('hd_quote', [chap.headline_index.number(id), compile_inline(chap.headline(id).caption)])
+            else
+              I18n.t('hd_quote_without_number', compile_inline(chap.headline(id).caption))
+            end
       if @book.config['chapterlink']
         anchor = n.tr('.', '-')
         macro('reviewsecref', str, sec_label(anchor))

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -157,7 +157,7 @@ module ReVIEW
         puts macro('label', sec_label(anchor))
         puts macro('label', label) if label
       end
-    rescue
+    rescue StandardError
       app_error "unknown level: #{level}"
     end
 

--- a/lib/review/location.rb
+++ b/lib/review/location.rb
@@ -22,7 +22,7 @@ module ReVIEW
     def string
       begin
         "#{@filename}:#{@f.lineno}"
-      rescue
+      rescue StandardError
         "#{@filename}:nil"
       end
     end

--- a/lib/review/logger.rb
+++ b/lib/review/logger.rb
@@ -76,27 +76,27 @@ module ReVIEW
   end
 
   def self.logger(level: 'info')
-    if const_defined?(:TTYLogger)
-      @logger ||= TTYLogger.new do |config|
-        config.level = level.to_sym
-        config.handlers = [
-          [:console,
-           {
-             styles: {
-               debug: { label: 'DEBUG' },
-               info: { label: 'INFO', color: :magenta },
-               success: { label: 'SUCCESS' },
-               wait: { label: 'WAIT' },
-               warn: { label: 'WARN' },
-               error: { label: 'ERROR' },
-               fatal: { label: 'FATAL' }
-             }
-           }]
-        ]
-      end
-    else
-      @logger ||= ReVIEW::Logger.new($stderr, progname: File.basename($PROGRAM_NAME, '.*'))
-    end
+    @logger ||= if const_defined?(:TTYLogger)
+                  TTYLogger.new do |config|
+                    config.level = level.to_sym
+                    config.handlers = [
+                      [:console,
+                       {
+                         styles: {
+                           debug: { label: 'DEBUG' },
+                           info: { label: 'INFO', color: :magenta },
+                           success: { label: 'SUCCESS' },
+                           wait: { label: 'WAIT' },
+                           warn: { label: 'WARN' },
+                           error: { label: 'ERROR' },
+                           fatal: { label: 'FATAL' }
+                         }
+                       }]
+                    ]
+                  end
+                else
+                  ReVIEW::Logger.new($stderr, progname: File.basename($PROGRAM_NAME, '.*'))
+                end
   end
 
   def self.logger=(logger)

--- a/lib/review/makerhelper.rb
+++ b/lib/review/makerhelper.rb
@@ -11,7 +11,7 @@ require 'yaml'
 
 begin
   require 'cgi/escape'
-rescue
+rescue StandardError
   require 'cgi/util'
 end
 

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -255,11 +255,11 @@ module ReVIEW
 
     def inline_hd_chap(chap, id)
       n = chap.headline_index.number(id)
-      if n.present? && chap.number && over_secnolevel?(n)
-        str = I18n.t('hd_quote', [n, compile_inline(chap.headline(id).caption)])
-      else
-        str = I18n.t('hd_quote_without_number', compile_inline(chap.headline(id).caption))
-      end
+      str = if n.present? && chap.number && over_secnolevel?(n)
+              I18n.t('hd_quote', [n, compile_inline(chap.headline(id).caption)])
+            else
+              I18n.t('hd_quote_without_number', compile_inline(chap.headline(id).caption))
+            end
       if @book.config['chapterlink']
         if @chapter == chap
           anchor = 'h' + n.tr('.', '-')

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -409,7 +409,7 @@ module ReVIEW
     def inline_icon(id)
       begin
         "![](#{@chapter.image(id).path.sub(%r{\A\./}, '')})"
-      rescue
+      rescue StandardError
         warn "image not bound: #{id}", location: location
         %Q(<pre>missing image: #{id}</pre>)
       end

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -297,7 +297,7 @@ module ReVIEW
       @logger.info "compiling #{filename}.tex"
       begin
         @converter.convert(filename + '.re', File.join(@path, filename + '.tex'))
-      rescue => e
+      rescue StandardError => e
         @compile_errors = true
         error "compile error in #{filename}.tex (#{e.class})"
         error e.message
@@ -494,7 +494,7 @@ module ReVIEW
         template_path = 'layouts/layout.tex.erb'
       end
       ReVIEW::Template.generate(path: template_path, mode: '-', binding: binding, template_dir: template_dir)
-    rescue => e
+    rescue StandardError => e
       if defined?(e.full_message)
         error! "template or configuration error: #{e.full_message(highlight: false)}"
       else

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -136,11 +136,11 @@ module ReVIEW
 
       # version 2 compatibility
       unless @config['texdocumentclass']
-        if @config.check_version(2, exception: false)
-          @config['texdocumentclass'] = ['jsbook', 'uplatex,oneside']
-        else
-          @config['texdocumentclass'] = @config['_texdocumentclass']
-        end
+        @config['texdocumentclass'] = if @config.check_version(2, exception: false)
+                                        ['jsbook', 'uplatex,oneside']
+                                      else
+                                        @config['_texdocumentclass']
+                                      end
       end
 
       begin
@@ -483,11 +483,11 @@ module ReVIEW
 
     def template_content
       template_dir = ReVIEW::Template::TEMPLATE_DIR
-      if @config.check_version('2', exception: false)
-        template_path = './latex-compat2/layout.tex.erb'
-      else
-        template_path = './latex/layout.tex.erb'
-      end
+      template_path = if @config.check_version('2', exception: false)
+                        './latex-compat2/layout.tex.erb'
+                      else
+                        './latex/layout.tex.erb'
+                      end
       layout_file = File.join(@basedir, 'layouts', 'layout.tex.erb')
       if File.exist?(layout_file)
         template_dir = @basedir

--- a/lib/review/preprocessor.rb
+++ b/lib/review/preprocessor.rb
@@ -70,11 +70,11 @@ module ReVIEW
             direc = parse_directive(line, 1, 'eval')
             path = expand(direc.arg)
             @leave_content = File.extname(path) == '.re'
-            if direc['eval']
-              ent = evaluate(path, ent)
-            else
-              ent = @repository.fetch_file(path)
-            end
+            ent = if direc['eval']
+                    evaluate(path, ent)
+                  else
+                    @repository.fetch_file(path)
+                  end
             replace_block(f, line, ent, false) # FIXME: turn off lineno: tmp
 
           when /\A\#@map(?:range)?/

--- a/lib/review/textmaker.rb
+++ b/lib/review/textmaker.rb
@@ -159,7 +159,7 @@ module ReVIEW
 
       begin
         @converter.convert(filename, File.join(basetmpdir, textfile))
-      rescue => e
+      rescue StandardError => e
         @compile_errors = true
         error "compile error in #{filename} (#{e.class})"
         error e.message

--- a/lib/review/textmaker.rb
+++ b/lib/review/textmaker.rb
@@ -111,12 +111,11 @@ module ReVIEW
 
     def build_body(basetmpdir, _yamlfile)
       base_path = Pathname.new(@basedir)
-      builder = nil
-      if @plaintext
-        builder = ReVIEW::PLAINTEXTBuilder.new(img_math: @img_math)
-      else
-        builder = ReVIEW::TOPBuilder.new(img_math: @img_math)
-      end
+      builder = if @plaintext
+                  ReVIEW::PLAINTEXTBuilder.new(img_math: @img_math)
+                else
+                  ReVIEW::TOPBuilder.new(img_math: @img_math)
+                end
       @converter = ReVIEW::Converter.new(@book, builder)
       @book.parts.each do |part|
         if part.name.present?
@@ -142,13 +141,11 @@ module ReVIEW
     end
 
     def build_chap(chap, base_path, basetmpdir, ispart)
-      filename = ''
-
-      if ispart.present?
-        filename = chap.path
-      else
-        filename = Pathname.new(chap.path).relative_path_from(base_path).to_s
-      end
+      filename = if ispart.present?
+                   chap.path
+                 else
+                   Pathname.new(chap.path).relative_path_from(base_path).to_s
+                 end
       id = File.basename(filename).sub(/\.re\Z/, '')
       if @buildonly && !@buildonly.include?(id)
         warn "skip #{id}.re"

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -398,7 +398,7 @@ module ReVIEW
     def inline_icon(id)
       begin
         "◆→画像 #{@chapter.image(id).path.sub(%r{\A\./}, '')}←◆"
-      rescue
+      rescue StandardError
         warn "image not bound: #{id}", location: location
         "◆→画像 #{id}←◆"
       end
@@ -504,7 +504,7 @@ module ReVIEW
       end
       begin
         puts "◆→画像 #{@chapter.image(id).path.sub(%r{\A\./}, '')}#{metrics}←◆"
-      rescue
+      rescue StandardError
         warn "image not bound: #{id}", location: location
         puts "◆→画像 #{id}←◆"
       end

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -175,13 +175,11 @@ module ReVIEW
     end
 
     def build_chap(chap, base_path, basetmpdir, ispart)
-      filename = ''
-
-      if ispart.present?
-        filename = chap.path
-      else
-        filename = Pathname.new(chap.path).relative_path_from(base_path).to_s
-      end
+      filename = if ispart.present?
+                   chap.path
+                 else
+                   Pathname.new(chap.path).relative_path_from(base_path).to_s
+                 end
       id = File.basename(filename).sub(/\.re\Z/, '')
 
       if @buildonly && !@buildonly.include?(id)

--- a/lib/review/webtocprinter.rb
+++ b/lib/review/webtocprinter.rb
@@ -41,16 +41,16 @@ EOT
           next
         end
 
-        if path.start_with?('.')
-          content << "<li>#{escape(result.headline)}"
-        else
-          content << %Q(<li><a href="#{path}">#{escape(result.headline)}</a>)
-        end
-        if result.level == 0
-          content << "\n<ul>" # part
-        else
-          content << "</li>\n"
-        end
+        content << if path.start_with?('.')
+                     "<li>#{escape(result.headline)}"
+                   else
+                     %Q(<li><a href="#{path}">#{escape(result.headline)}</a>)
+                   end
+        content << if result.level == 0
+                     "\n<ul>" # part
+                   else
+                     "</li>\n"
+                   end
       end
       content << "</ul>\n"
     end

--- a/test/book_test_helper.rb
+++ b/test/book_test_helper.rb
@@ -20,11 +20,11 @@ module BookTestHelper
           created_files[filename] = path
         end
         conf_path = File.expand_path('config.yml', dir)
-        if File.exist?(conf_path)
-          config = ReVIEW::Configure.create(yamlfile: conf_path)
-        else
-          config = ReVIEW::Configure.values
-        end
+        config = if File.exist?(conf_path)
+                   ReVIEW::Configure.create(yamlfile: conf_path)
+                 else
+                   ReVIEW::Configure.values
+                 end
         book = Book::Base.new(dir, config: config)
         yield(dir, book, created_files)
       end
@@ -34,11 +34,11 @@ module BookTestHelper
   def get_instance_variables(obj)
     obj.instance_variables.each_with_object({}) do |name, memo|
       value = obj.instance_variable_get(name)
-      if value.instance_variables.empty?
-        memo[name] = value
-      else
-        memo[name] = get_instance_variables(value)
-      end
+      memo[name] = if value.instance_variables.empty?
+                     value
+                   else
+                     get_instance_variables(value)
+                   end
     end
   end
 end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -348,15 +348,15 @@ EOS
 //}
 EOS
 
-      if type == 'notice' # exception pattern
-        expected = <<-EOS.chomp
+      expected = if type == 'notice' # exception pattern
+                   <<-EOS.chomp
 <#{type}-t><title aid:pstyle='#{type}-title'>#{type}1</title></#{type}-t><#{type}-t><title aid:pstyle='#{type}-title'>#{type}2</title></#{type}-t>
 EOS
-      else
-        expected = <<-EOS.chomp
+                 else
+                   <<-EOS.chomp
 <#{type}><title aid:pstyle='#{type}-title'>#{type}1</title></#{type}><#{type}><title aid:pstyle='#{type}-title'>#{type}2</title></#{type}>
 EOS
-      end
+                 end
       assert_equal expected, compile_block(src)
 
       src = <<-EOS
@@ -412,17 +412,17 @@ LIST
 //}
 EOS
 
-      if type == 'notice' # exception pattern
-        expected = <<-EOS.chomp
+      expected = if type == 'notice' # exception pattern
+                   <<-EOS.chomp
 <#{type}><ul><li aid:pstyle="ul-item">A</li></ul><ol><li aid:pstyle="ol-item" olnum="1" num="1">B</li></ol></#{type}><#{type}-t><title aid:pstyle='#{type}-title'>OMITEND1</title><list type='emlist'><pre>LIST
 </pre></list></#{type}-t><#{type}-t><title aid:pstyle='#{type}-title'>OMITEND2</title></#{type}-t>
 EOS
-      else
-        expected = <<-EOS.chomp
+                 else
+                   <<-EOS.chomp
 <#{type}><ul><li aid:pstyle="ul-item">A</li></ul><ol><li aid:pstyle="ol-item" olnum="1" num="1">B</li></ol></#{type}><#{type}><title aid:pstyle='#{type}-title'>OMITEND1</title><list type='emlist'><pre>LIST
 </pre></list></#{type}><#{type}><title aid:pstyle='#{type}-title'>OMITEND2</title></#{type}>
 EOS
-      end
+                 end
       assert_equal expected, compile_block(src)
     end
   end

--- a/test/test_img_math.rb
+++ b/test/test_img_math.rb
@@ -104,7 +104,7 @@ class ImgMathTest < Test::Unit::TestCase
     begin
       `uplatex -v`
       true
-    rescue
+    rescue StandardError
       false
     end
   end

--- a/test/test_pdfmaker_cmd.rb
+++ b/test/test_pdfmaker_cmd.rb
@@ -41,7 +41,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   def test_pdfmaker_cmd_sample_jsbook_print
     begin
       `uplatex -v`
-    rescue
+    rescue StandardError
       $stderr.puts 'skip test_pdfmaker_cmd_sample_jsbook_print'
       return true
     end
@@ -51,7 +51,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   def test_pdfmaker_cmd_sample_jsbook_ebook
     begin
       `uplatex -v`
-    rescue
+    rescue StandardError
       $stderr.puts 'skip test_pdfmaker_cmd_sample_jsbook_ebook'
       return true
     end
@@ -61,7 +61,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   def test_pdfmaker_cmd_sample_jlreq_print
     begin
       `uplatex -v`
-    rescue
+    rescue StandardError
       $stderr.puts 'skip test_pdfmaker_cmd_sample_jlreq_print'
       return true
     end
@@ -71,7 +71,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   def test_pdfmaker_cmd_sample_jlreq_ebook
     begin
       `uplatex -v`
-    rescue
+    rescue StandardError
       $stderr.puts 'skip test_pdfmaker_cmd_sample_jlreq_ebook'
       return true
     end
@@ -81,7 +81,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   def test_pdfmaker_cmd_syntax_jsbook_print
     begin
       `uplatex -v`
-    rescue
+    rescue StandardError
       $stderr.puts 'skip test_pdfmaker_cmd_syntax_jsbook_print'
       return true
     end
@@ -91,7 +91,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   def test_pdfmaker_cmd_syntax_jsbook_print_buildonly
     begin
       `uplatex -v`
-    rescue
+    rescue StandardError
       $stderr.puts 'skip test_pdfmaker_cmd_syntax_jsbook_print_buildonly'
       return true
     end
@@ -101,7 +101,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   def test_pdfmaker_cmd_syntax_jsbook_ebook
     begin
       `uplatex -v`
-    rescue
+    rescue StandardError
       $stderr.puts 'skip test_pdfmaker_cmd_syntax_jsbook_ebook'
       return true
     end
@@ -111,7 +111,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   def test_pdfmaker_cmd_syntax_jlreq_ebook
     begin
       `uplatex -v`
-    rescue
+    rescue StandardError
       $stderr.puts 'skip test_pdfmaker_cmd_syntax_jlreq_ebook'
       return true
     end
@@ -121,7 +121,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   def test_pdfmaker_cmd_syntax_jlreq_ebook_lualatex
     begin
       `lualatex -v`
-    rescue
+    rescue StandardError
       $stderr.puts 'skip test_pdfmaker_cmd_syntax_jlreq_ebook_lualatex'
       return true
     end


### PR DESCRIPTION
`Style/RescueStandardError`, `Style/FloatDivision`, `Style/ConditionalAssignment`のrubocopルールについて対応しました。
また、`Lint/ElseLayout`と`Style/AccessModifierDeclarations`は解決済みだったのでそのまま削除しています。