### PR TITLE
rubocop: resolve `Performance/RegexpMatch`, `Style/SoleNestedConditional`, and `Style/CaseEquality`

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -122,9 +122,6 @@ Style/BarePercentLiterals:
 Style/BlockDelimiters:
   Enabled: true
 
-Style/CaseEquality:
-  Enabled: false
-
 Style/ClassCheck:
   Enabled: true
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -383,9 +383,6 @@ Style/StringConcatenation:
 Style/OptionalBooleanParameter:
   Enabled: false
 
-Style/SoleNestedConditional:
-  Enabled: false
-
 Style/CombinableLoops:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -59,9 +59,6 @@ Lint/RedundantDirGlobSort:
 
 #### Performance
 
-Performance/RegexpMatch:
-  Enabled: false
-
 Performance/ReverseEach:
   Enabled: true
 

--- a/bin/review
+++ b/bin/review
@@ -58,7 +58,7 @@ unless File.exist?(command_path)
   usage
 end
 
-if RUBY_PLATFORM =~ /mswin|bccwin|mingw/
+if RUBY_PLATFORM.match?(/mswin|bccwin|mingw/)
   cmd = File.join(RbConfig::CONFIG['bindir'],
                   RbConfig::CONFIG['ruby_install_name'])
   cmd << RbConfig::CONFIG['EXEEXT']

--- a/bin/review-check
+++ b/bin/review-check
@@ -18,7 +18,7 @@ include ReVIEW::TextUtils
 
 def sigmain
   Signal.trap(:INT) { exit 1 }
-  if RUBY_PLATFORM !~ /mswin(?!ce)|mingw|cygwin|bccwin/
+  unless RUBY_PLATFORM.match?(/mswin(?!ce)|mingw|cygwin|bccwin/)
     Signal.trap(:PIPE, 'IGNORE')
   end
   main
@@ -95,7 +95,7 @@ end
 def find_line(lines, re)
   # single line?
   lines.each_with_index do |line, idx|
-    if re =~ line
+    if re&.match?(line)
       return line.gsub(re, '<<<\&>>>'), idx
     end
   end
@@ -104,7 +104,7 @@ def find_line(lines, re)
   i = 0
   while i < lines.size - 1
     str = lines[i] + lines[i + 1]
-    return str.gsub(re, '<<<\&>>>'), i if re =~ str
+    return str.gsub(re, '<<<\&>>>'), i if re&.match?(str)
 
     i += 1
   end
@@ -118,7 +118,7 @@ def words_re(rc)
   File.foreach(rc) do |line|
     next if line[0, 1] == '#'
 
-    if / !/ =~ line
+    if / !/.match?(line)
       line, n = *line.split('!', 2)
       nega.push(n.strip)
     end
@@ -141,7 +141,7 @@ def each_paragraph(f)
       yield [$1], f.filename, f.lineno
     when %r<\A//\w.*\{\s*\z>
       while line = f.gets
-        break if %r{//\}} === line
+        break if %r{//\}}.match?(line)
       end
     when /\A=/
       yield [line.slice(/\A=+(?:\[.*?\])?\s+(.*)/, 1).strip], f.lineno
@@ -150,8 +150,8 @@ def each_paragraph(f)
       lineno = f.lineno
       while line = f.gets
         break if line.strip.empty?
-        break if %r{\A(?:=|//[\w\}])} =~ line
-        next if /\A\#@/ =~ line
+        break if %r{\A(?:=|//[\w\}])}.match?(line)
+        next if /\A\#@/.match?(line)
 
         buf.push(line.strip)
       end

--- a/bin/review-compile
+++ b/bin/review-compile
@@ -22,7 +22,7 @@ DEFAULT_CONFIG_FILENAME = 'config.yml'.freeze
 
 def main
   Signal.trap(:INT) { exit 1 }
-  if RUBY_PLATFORM !~ /mswin(?!ce)|mingw|cygwin|bccwin/
+  unless RUBY_PLATFORM.match?(/mswin(?!ce)|mingw|cygwin|bccwin/)
     Signal.trap(:PIPE, 'IGNORE')
   end
   _main

--- a/bin/review-index
+++ b/bin/review-index
@@ -15,7 +15,7 @@ require 'review/tocprinter'
 
 begin
   Signal.trap(:INT) { exit 1 }
-  if RUBY_PLATFORM !~ /mswin(?!ce)|mingw|cygwin|bccwin/
+  unless RUBY_PLATFORM.match?(/mswin(?!ce)|mingw|cygwin|bccwin/)
     Signal.trap(:PIPE, 'IGNORE')
   end
 

--- a/bin/review-preproc
+++ b/bin/review-preproc
@@ -26,7 +26,7 @@ include ReVIEW::Loggable
 
 def sigmain
   Signal.trap(:INT) { exit 1 }
-  if RUBY_PLATFORM !~ /mswin(?!ce)|mingw|cygwin|bccwin/
+  unless RUBY_PLATFORM.match?(/mswin(?!ce)|mingw|cygwin|bccwin/)
     Signal.trap(:PIPE, 'IGNORE')
   end
   main

--- a/bin/review-validate
+++ b/bin/review-validate
@@ -41,7 +41,7 @@ ARGF.each do |line|
     unless %w[list emlist listnum emlistnum cmd image table].include?(block)
       @logger.warn "#{ln}: found '#{$1}' without the head space. Is it correct?"
     end
-  elsif line =~ /\A\*\s+/
+  elsif /\A\*\s+/.match?(line)
     # itemize
     unless %w[list emlist listnum emlistnum cmd image table].include?(block)
       @logger.warn "#{ln}: found '*' without the head space. Is it correct?"
@@ -53,7 +53,7 @@ ARGF.each do |line|
   elsif block == 'table'
     next if line.start_with?('#@')
 
-    if line !~ /\A-----/
+    unless line.start_with?('-----')
       # table
       colcount = line.split("\t").size
       if maxcolcount == 0

--- a/lib/review/book/book_unit.rb
+++ b/lib/review/book/book_unit.rb
@@ -86,7 +86,7 @@ module ReVIEW
         return @title unless content
 
         content.each_line do |line|
-          if line =~ /\A=+/
+          if /\A=+/.match?(line)
             @title = line.sub(/\A=+(\[.+?\])?(\{.+?\})?/, '').strip
             break
           end

--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -14,7 +14,7 @@ module ReVIEW
       def self.mkpart_from_namelistfile(book, path)
         chaps = []
         File.read(path, mode: 'rt:BOM|utf-8').split.each_with_index do |name, number|
-          chaps << if path =~ /PREDEF/
+          chaps << if /PREDEF/.match?(path)
                      Chapter.mkchap(book, name)
                    else
                      Chapter.mkchap(book, name, number + 1)

--- a/lib/review/book/volume.rb
+++ b/lib/review/book/volume.rb
@@ -12,7 +12,7 @@ module ReVIEW
       def self.count_file(path)
         b = c = l = 0
         File.foreach(path) do |line|
-          next if /\A\#@/ =~ line
+          next if /\A\#@/.match?(line)
 
           text = line.gsub(/\s+/, '')
           b += text.bytesize

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -134,11 +134,9 @@ module ReVIEW
     end
 
     def load_words(file)
-      if File.exist?(file)
-        if /\.csv\Z/i.match?(file)
-          CSV.foreach(file) do |row|
-            @dictionary[row[0]] = row[1]
-          end
+      if File.exist?(file) && /\.csv\Z/i.match?(file)
+        CSV.foreach(file) do |row|
+          @dictionary[row[0]] = row[1]
         end
       end
     end

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -135,7 +135,7 @@ module ReVIEW
 
     def load_words(file)
       if File.exist?(file)
-        if file =~ /\.csv\Z/i
+        if /\.csv\Z/i.match?(file)
           CSV.foreach(file) do |row|
             @dictionary[row[0]] = row[1]
           end
@@ -537,8 +537,8 @@ module ReVIEW
       params = metric.split(/,\s*/)
       results = []
       params.each do |param|
-        if param =~ /\A.+?::/
-          next unless param =~ /\A#{type}::/
+        if /\A.+?::/.match?(param)
+          next unless /\A#{type}::/.match?(param)
 
           param.sub!(/\A#{type}::/, '')
         end

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -71,7 +71,7 @@ module ReVIEW
       attr_reader :name
 
       def check_args(args)
-        unless @argc_spec === args.size
+        unless @argc_spec === args.size # rubocop:disable Style/CaseEquality
           raise CompileError, "wrong # of parameters (block command //#{@name}, expect #{@argc_spec} but #{args.size})"
         end
 

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -467,7 +467,7 @@ module ReVIEW
     def compile_ulist(f)
       level = 0
       f.while_match(/\A\s+\*|\A\#@/) do |line|
-        next if line =~ /\A\#@/
+        next if /\A\#@/.match?(line)
 
         buf = [text(line.sub(/\*+/, '').strip)]
         f.while_match(/\A\s+(?!\*)\S/) do |cont|
@@ -510,7 +510,7 @@ module ReVIEW
     def compile_olist(f)
       @builder.ol_begin
       f.while_match(/\A\s+\d+\.|\A\#@/) do |line|
-        next if line =~ /\A\#@/
+        next if /\A\#@/.match?(line)
 
         num = line.match(/(\d+)\./)[1]
         buf = [text(line.sub(/\d+\./, '').strip)]
@@ -572,7 +572,7 @@ module ReVIEW
       f.until_match(%r{\A//\}}) do |line|
         if ignore_inline
           buf.push(line.chomp)
-        elsif line !~ /\A\#@/
+        elsif !/\A\#@/.match?(line)
           buf.push(text(line.rstrip, true))
         end
       end
@@ -643,7 +643,7 @@ module ReVIEW
       str.gsub(/@<(\w+)>([$|])(.+?)(\2)/) do
         op = $1
         arg = $3
-        if arg =~ /[\x01\x02\x03\x04]/
+        if /[\x01\x02\x03\x04]/.match?(arg)
           error "invalid character in '#{str}'", location: location
         end
         replaced = arg.tr('@', "\x01").tr('\\', "\x02").tr('{', "\x03").tr('}', "\x04")

--- a/lib/review/epub2html.rb
+++ b/lib/review/epub2html.rb
@@ -62,10 +62,10 @@ EOT
     def parse_epub(epubname)
       Zip::File.open(epubname) do |zio|
         zio.each do |entry|
-          if entry.name =~ /.+\.opf\Z/
+          if /.+\.opf\Z/.match?(entry.name)
             opf = entry.get_input_stream.read
             @opfxml = REXML::Document.new(opf)
-          elsif entry.name =~ /.+\.x?html\Z/
+          elsif /.+\.x?html\Z/.match?(entry.name)
             @htmls[entry.name.sub('OEBPS/', '')] = entry.get_input_stream.read.force_encoding('utf-8')
           end
         end

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -227,7 +227,7 @@ module ReVIEW
       if @config['epubmaker']['verify_target_images'].present?
         @config['epubmaker']['force_include_images'].each do |file|
           unless File.exist?(file)
-            if file !~ /\Ahttps?:/
+            unless /\Ahttps?:/.match?(file)
               warn "#{file} is not found, skip."
             end
             next
@@ -257,7 +257,7 @@ module ReVIEW
 
           if FileTest.directory?(File.join(resdir, fname))
             recursive_copy_files(File.join(resdir, fname), File.join(destdir, fname), allow_exts)
-          elsif fname =~ /\.(#{allow_exts.join('|')})\Z/i
+          elsif /\.(#{allow_exts.join('|')})\Z/i.match?(fname)
             FileUtils.mkdir_p(destdir)
             debug("Copy #{resdir}/#{fname} to the temporary directory.")
             FileUtils.cp(File.join(resdir, fname), destdir, preserve: true)
@@ -386,7 +386,7 @@ module ReVIEW
 
       if @config['params'].present?
         warn %Q('params:' in config.yml is obsoleted.)
-        if @config['params'] =~ /stylesheet=/
+        if /stylesheet=/.match?(@config['params'])
           warn %Q(stylesheets should be defined in 'stylesheet:', not in 'params:')
         end
       end

--- a/lib/review/epubmaker/content.rb
+++ b/lib/review/epubmaker/content.rb
@@ -76,7 +76,7 @@ module ReVIEW
         if @id.nil?
           @id = @file.gsub(%r{[\\/. ]}, '-')
         end
-        if @id =~ /\A[^a-z]/i
+        if /\A[^a-z]/i.match?(@id)
           @id = "rv-#{@id}"
         end
         @id = CGI.escape(@id).gsub('%', '_25_')

--- a/lib/review/epubmaker/epubcommon.rb
+++ b/lib/review/epubmaker/epubcommon.rb
@@ -178,9 +178,9 @@ module ReVIEW
       def isbn_hyphen
         str = config['isbn'].to_s
 
-        if str =~ /\A\d{10}\Z/
+        if /\A\d{10}\Z/.match?(str)
           "#{str[0..0]}-#{str[1..5]}-#{str[6..8]}-#{str[9..9]}"
-        elsif str =~ /\A\d{13}\Z/
+        elsif /\A\d{13}\Z/.match?(str)
           "#{str[0..2]}-#{str[3..3]}-#{str[4..8]}-#{str[9..11]}-#{str[12..12]}"
         end
       end
@@ -192,9 +192,9 @@ module ReVIEW
             items.each_with_index do |item, rev|
               editstr = edit == 0 ? ReVIEW::I18n.t('first_edition') : ReVIEW::I18n.t('nth_edition', (edit + 1).to_s)
               revstr = ReVIEW::I18n.t('nth_impression', (rev + 1).to_s)
-              if item =~ /\A\d+-\d+-\d+\Z/
+              if /\A\d+-\d+-\d+\Z/.match?(item)
                 @col_history << ReVIEW::I18n.t('published_by1', [date_to_s(item), editstr + revstr])
-              elsif item =~ /\A(\d+-\d+-\d+)[\s　](.+)/
+              elsif /\A(\d+-\d+-\d+)[\s　](.+)/.match?(item)
                 # custom date with string
                 item.match(/\A(\d+-\d+-\d+)[\s　](.+)/) do |m|
                   @col_history << ReVIEW::I18n.t('published_by3', [date_to_s(m[1]), m[2]])
@@ -336,7 +336,7 @@ module ReVIEW
         end
 
         contents.each do |item|
-          next if item.file =~ /#/ # skip subgroup
+          next if /#/.match?(item.file) # skip subgroup
 
           fname = "#{basedir}/#{item.file}"
           unless File.exist?(fname)

--- a/lib/review/epubmaker/epubv3.rb
+++ b/lib/review/epubmaker/epubv3.rb
@@ -186,7 +186,7 @@ module ReVIEW
         @tocx_contents = []
         toc = nil
         contents.each do |item|
-          next if item.media !~ /xhtml\+xml/ # skip non XHTML
+          next unless /xhtml\+xml/.match?(item.media) # skip non XHTML
 
           @tocx_contents << item
         end

--- a/lib/review/epubmaker/producer.rb
+++ b/lib/review/epubmaker/producer.rb
@@ -89,8 +89,8 @@ module ReVIEW
         Dir.foreach(path) do |f|
           next if f.start_with?('.')
 
-          if f =~ /\.(#{allow_exts.join('|')})\Z/i
-            path.chop! if path =~ %r{/\Z}
+          if /\.(#{allow_exts.join('|')})\Z/i.match?(f)
+            path.chop! if %r{/\Z}.match?(path)
             if base.nil?
               @contents.push(ReVIEW::EPUBMaker::Content.new(file: "#{path}/#{f}"))
             else
@@ -115,7 +115,7 @@ module ReVIEW
 
         # use Dir to solve a path for Windows (see #1011)
         new_tmpdir = Dir[File.join(tmpdir.nil? ? Dir.mktmpdir : tmpdir)][0]
-        if epubfile !~ %r{\A/}
+        unless epubfile.start_with?('/')
           epubfile = "#{current}/#{epubfile}"
         end
 

--- a/lib/review/epubmaker/reviewheaderlistener.rb
+++ b/lib/review/epubmaker/reviewheaderlistener.rb
@@ -41,7 +41,7 @@ module ReVIEW
       end
 
       def tag_end(name)
-        if name =~ /\Ah\d+/
+        if /\Ah\d+/.match?(name)
           if @id.present?
             @headlines.push({ 'level' => @level,
                               'id' => @id,

--- a/lib/review/htmlutils.rb
+++ b/lib/review/htmlutils.rb
@@ -129,9 +129,9 @@ module ReVIEW
     end
 
     def normalize_id(id)
-      if id =~ /\A[a-z][a-z0-9_.-]*\Z/i
+      if /\A[a-z][a-z0-9_.-]*\Z/i.match?(id)
         id
-      elsif id =~ /\A[0-9_.-][a-z0-9_.-]*\Z/i
+      elsif /\A[0-9_.-][a-z0-9_.-]*\Z/i.match?(id)
         "id_#{id}" # dummy prefix
       else
         "id_#{CGI.escape(id.gsub('_', '__')).tr('%', '_').tr('+', '-')}" # escape all

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -1142,16 +1142,16 @@ module ReVIEW
     def indepimage(_lines, id, caption = nil, metric = nil)
       metrics = parse_metric('idgxml', metric)
       puts '<img>'
-      if caption_top?('image')
-        puts %Q(<caption>#{compile_inline(caption)}</caption>) if caption.present?
+      if caption_top?('image') && caption.present?
+        puts %Q(<caption>#{compile_inline(caption)}</caption>)
       end
       begin
         puts %Q(<Image href="file://#{@chapter.image(id).path.sub(%r{\A\./}, '')}"#{metrics} />)
       rescue StandardError
         warn %Q(image not bound: #{id}), location: location
       end
-      unless caption_top?('image')
-        puts %Q(<caption>#{compile_inline(caption)}</caption>) if caption.present?
+      if !caption_top?('image') && caption.present?
+        puts %Q(<caption>#{compile_inline(caption)}</caption>)
       end
       puts '</img>'
     end

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -515,7 +515,7 @@ module ReVIEW
       sepidx = nil
       rows = []
       lines.each_with_index do |line, idx|
-        if /\A[=\-]{12}/ =~ line
+        if /\A[=\-]{12}/.match?(line)
           sepidx ||= idx
           next
         end
@@ -724,15 +724,15 @@ module ReVIEW
     end
 
     def inline_maru(str)
-      if str =~ /\A\d+\Z/
+      if /\A\d+\Z/.match?(str)
         sprintf('&#x%x;', 9311 + str.to_i)
-      elsif str =~ /\A[A-Z]\Z/
+      elsif /\A[A-Z]\Z/.match?(str)
         begin
           sprintf('&#x%x;', 9398 + str.codepoints.to_a[0] - 65)
         rescue NoMethodError
           sprintf('&#x%x;', 9398 + str[0] - 65)
         end
-      elsif str =~ /\A[a-z]\Z/
+      elsif /\A[a-z]\Z/.match?(str)
         begin
           sprintf('&#x%x;', 9392 + str.codepoints.to_a[0] - 65)
         rescue NoMethodError

--- a/lib/review/init.rb
+++ b/lib/review/init.rb
@@ -257,7 +257,7 @@ EOS
         exit 1
       end
 
-      if filename =~ %r{\Ahttps?://}
+      if %r{\Ahttps?://}.match?(filename)
         begin
           @logger.info "Downloading from #{filename}"
           zipdata = Net::HTTP.get(URI.parse(filename))
@@ -334,7 +334,7 @@ EOS
       # validation
       if @web_result
         @web_result.each do |s|
-          if s !~ /\A[a-z0-9=_,.-]*\Z/i
+          unless /\A[a-z0-9=_,.-]*\Z/i.match?(s)
             @web_result = nil
             break
           end

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -803,7 +803,7 @@ module ReVIEW
       end
 
       if @tsize
-        if @tsize =~ /\A[\d., ]+\Z/
+        if /\A[\d., ]+\Z/.match?(@tsize)
           @cellwidth = @tsize.split(/\s*,\s*/)
           @cellwidth.collect! { |i| "p{#{i}mm}" }
           puts macro('begin', 'reviewtable', '|' + @cellwidth.join('|') + '|')
@@ -856,7 +856,7 @@ module ReVIEW
     end
 
     def th(s, cellwidth = 'l')
-      if /\\\\/ =~ s
+      if /\\\\/.match?(s)
         if !@book.config.check_version('2', exception: false) && cellwidth =~ /\{/
           macro('reviewth', s.gsub("\\\\\n", '\\newline{}'))
         else
@@ -869,7 +869,7 @@ module ReVIEW
     end
 
     def td(s, cellwidth = 'l')
-      if /\\\\/ =~ s
+      if /\\\\/.match?(s)
         if !@book.config.check_version('2', exception: false) && cellwidth =~ /\{/
           s.gsub("\\\\\n", '\\newline{}')
         else
@@ -1412,7 +1412,7 @@ module ReVIEW
     end
 
     def compile_href(url, label)
-      if /\A[a-z]+:/ =~ url
+      if /\A[a-z]+:/.match?(url)
         if label
           macro('href', escape_url(url), escape(label))
         else

--- a/lib/review/lineinput.rb
+++ b/lib/review/lineinput.rb
@@ -31,7 +31,7 @@ module ReVIEW
     def skip_comment_lines
       n = 0
       while line = gets
-        unless line.strip =~ /\A\#@/
+        unless /\A\#@/.match?(line.strip)
           ungets(line)
           return n
         end
@@ -88,7 +88,7 @@ module ReVIEW
 
     def while_match(re)
       while line = gets
-        unless re =~ line
+        unless re&.match?(line)
           ungets(line)
           return
         end
@@ -99,7 +99,7 @@ module ReVIEW
 
     def until_match(re)
       while line = gets
-        if re =~ line
+        if re&.match?(line)
           ungets(line)
           return
         end

--- a/lib/review/makerhelper.rb
+++ b/lib/review/makerhelper.rb
@@ -43,7 +43,7 @@ module ReVIEW
 
       Dir.open(from_dir) do |dir|
         dir.each do |fname|
-          next if fname =~ /^\./
+          next if /^\./.match?(fname)
 
           if FileTest.directory?("#{from_dir}/#{fname}")
             image_files += copy_images_to_dir("#{from_dir}/#{fname}", "#{to_dir}/#{fname}", options)
@@ -52,7 +52,7 @@ module ReVIEW
 
             is_converted = false
             (options[:convert] || {}).each do |orig_type, conv_type|
-              next unless /\.#{orig_type}$/ =~ fname
+              next unless /\.#{orig_type}$/.match?(fname)
 
               is_converted = system("convert #{from_dir}/#{fname} #{to_dir}/#{fname}.#{conv_type}")
               image_files << "#{from_dir}/#{fname}.#{conv_type}"

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -377,9 +377,9 @@ module ReVIEW
           items.each_with_index do |item, rev|
             editstr = edit == 0 ? ReVIEW::I18n.t('first_edition') : ReVIEW::I18n.t('nth_edition', (edit + 1).to_s)
             revstr = ReVIEW::I18n.t('nth_impression', (rev + 1).to_s)
-            if item =~ /\A\d+-\d+-\d+\Z/
+            if /\A\d+-\d+-\d+\Z/.match?(item)
               buf << ReVIEW::I18n.t('published_by1', [date_to_s(item), editstr + revstr])
-            elsif item =~ /\A(\d+-\d+-\d+)[\s　](.+)/
+            elsif /\A(\d+-\d+-\d+)[\s　](.+)/.match?(item)
               # custom date with string
               item.match(/\A(\d+-\d+-\d+)[\s　](.+)/) { |m| buf << ReVIEW::I18n.t('published_by3', [date_to_s(m[1]), m[2]]) }
             else

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -86,7 +86,7 @@ module ReVIEW
         if l =~ /\A\x01→(dl|ul|ol)←\x01/
           clevel.push($1)
           lines.push("\x01→END←\x01")
-        elsif l =~ %r{\A\x01→/(dl|ul|ol)←\x01}
+        elsif %r{\A\x01→/(dl|ul|ol)←\x01}.match?(l)
           clevel.pop
           lines.push("\x01→END←\x01")
         else

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -214,14 +214,14 @@ module ReVIEW
 
     def emlistnum(lines, caption = nil, _lang = nil)
       blank
-      if caption_top?('list')
-        puts compile_inline(caption) if caption.present?
+      if caption_top?('list') && caption.present?
+        puts compile_inline(caption)
       end
       lines.each_with_index do |line, i|
         puts((i + 1).to_s.rjust(2) + ": #{line}")
       end
-      unless caption_top?('list')
-        puts compile_inline(caption) if caption.present?
+      if !caption_top?('list') && caption.present?
+        puts compile_inline(caption)
       end
       blank
     end

--- a/lib/review/preprocessor/repository.rb
+++ b/lib/review/preprocessor/repository.rb
@@ -165,7 +165,7 @@ module ReVIEW
       end
 
       def check_spec(spec)
-        app_error "wrong spec: #{spec.inspect}" unless /\A\w+\z/ =~ spec
+        app_error "wrong spec: #{spec.inspect}" unless /\A\w+\z/.match?(spec)
         spec
       end
 

--- a/lib/review/textutils.rb
+++ b/lib/review/textutils.rb
@@ -72,13 +72,11 @@ module ReVIEW
         end
 
         # lazy than rule 3, but it looks better
-        if lazy
-          if (%i[F W H].include?(Unicode::Eaw.property(tail)) &&
+        if lazy && ((%i[F W H].include?(Unicode::Eaw.property(tail)) &&
               tail !~ /\p{Hangul}/) ||
              (%i[F W H].include?(Unicode::Eaw.property(head)) &&
-              head !~ /\p{Hangul}/)
-            space = nil
-          end
+              head !~ /\p{Hangul}/))
+          space = nil
         end
       end
       space

--- a/lib/review/update.rb
+++ b/lib/review/update.rb
@@ -226,9 +226,11 @@ module ReVIEW
 
     def check_own_files(dir)
       if File.exist?(File.join(dir, 'layouts/layout.tex.erb'))
+        # rubocop:disable Style/SoleNestedConditional
         unless confirm('** There is custom layouts/layout.tex.erb file. Updating may break to make PDF until you fix layout.tex.erb. Do you really proceed to update? **', [], nil)
           raise ApplicationError
         end
+        # rubocop:enable Style/SoleNestedConditional
       end
 
       if File.exist?(File.join(dir, 'review-ext.rb'))
@@ -265,10 +267,12 @@ module ReVIEW
       target_rakefile = File.join(dir, 'Rakefile')
       if File.exist?(target_rakefile)
         if Digest::SHA256.hexdigest(File.read(target_rakefile)) != Digest::SHA256.hexdigest(File.read(master_rakefile))
+          # rubocop:disable Style/SoleNestedConditional
           if confirm('%s will be overridden with Re:VIEW version (%s). Do you really proceed?', ['Rakefile', master_rakefile])
             FileUtils.mv(target_rakefile, "#{target_rakefile}-old")
             FileUtils.cp(master_rakefile, target_rakefile)
           end
+          # rubocop:enable Style/SoleNestedConditional
         end
       else
         @logger.info t('new file %s is created.', [target_rakefile]) unless @force
@@ -278,12 +282,14 @@ module ReVIEW
       master_rakefile = File.join(@review_dir, 'samples/sample-book/src/lib/tasks/review.rake')
       target_rakefile = File.join(taskdir, 'review.rake')
       if File.exist?(target_rakefile)
+        # rubocop:disable Style/SoleNestedConditional
         if Digest::SHA256.hexdigest(File.read(target_rakefile)) != Digest::SHA256.hexdigest(File.read(master_rakefile))
           if confirm('%s will be overridden with Re:VIEW version (%s). Do you really proceed?', ['lib/tasks/review.rake', master_rakefile])
             FileUtils.mv(target_rakefile, "#{target_rakefile}-old")
             FileUtils.cp(master_rakefile, target_rakefile)
           end
         end
+        # rubocop:enable Style/SoleNestedConditional
       else
         @logger.info t('new file %s is created.', [target_rakefile]) unless @force
         FileUtils.cp(master_rakefile, target_rakefile)
@@ -294,9 +300,11 @@ module ReVIEW
       @epub_ymls.each do |yml|
         config = YAMLLoader.safe_load_file(yml)
         if config['epubversion'].present? && config['epubversion'].to_f < EPUB_VERSION.to_f
+          # rubocop:disable Style/SoleNestedConditional
           if confirm("%s: Update '%s' to '%s' from '%s'?", [File.basename(yml), 'epubversion', EPUB_VERSION, config['epubversion']])
             rewrite_yml(yml, 'epubversion', EPUB_VERSION)
           end
+          # rubocop:enable Style/SoleNestedConditional
         end
         if !config['htmlversion'].present? || config['htmlversion'].to_f >= HTML_VERSION.to_f
           next

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -225,7 +225,7 @@ module ReVIEW
 
           if FileTest.directory?("#{resdir}/#{fname}")
             recursive_copy_files("#{resdir}/#{fname}", "#{destdir}/#{fname}", allow_exts)
-          elsif fname =~ /\.(#{allow_exts.join('|')})\Z/i
+          elsif /\.(#{allow_exts.join('|')})\Z/i.match?(fname)
             FileUtils.mkdir_p(destdir)
             FileUtils.cp("#{resdir}/#{fname}", destdir)
           end

--- a/test/test_epubmaker_cmd.rb
+++ b/test/test_epubmaker_cmd.rb
@@ -21,7 +21,7 @@ class EPUBMakerCmdTest < Test::Unit::TestCase
   end
 
   def common_buildepub(bookdir, configfile, targetepubfile)
-    if /mswin|mingw|cygwin/ !~ RUBY_PLATFORM
+    unless /mswin|mingw|cygwin/.match?(RUBY_PLATFORM)
       config = prepare_samplebook(@tmpdir1, bookdir, nil, configfile)
       builddir = File.join(@tmpdir1, config['bookname'] + '-epub')
       assert !File.exist?(builddir)
@@ -35,7 +35,7 @@ class EPUBMakerCmdTest < Test::Unit::TestCase
   end
 
   def check_filesize(epubfile)
-    if /mswin|mingw|cygwin/ !~ RUBY_PLATFORM
+    unless /mswin|mingw|cygwin/.match?(RUBY_PLATFORM)
       Zip::File.open(epubfile) do |zio|
         zio.each do |entry|
           assert_not_equal(0, entry.size, "#{entry.name} is 0 byte.")

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1708,7 +1708,7 @@ EOS
   end
 
   def test_texequation
-    return true if /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
+    return true if /mswin|mingw|cygwin/.match?(RUBY_PLATFORM)
     return true unless system('latex -version 1>/dev/null 2>/dev/null')
 
     mktmpbookdir('catalog.yml' => "CHAPS:\n - ch01.re\n",
@@ -1741,7 +1741,7 @@ EOS
 
   def test_texequation_fail
     # Re:VIEW 3 never fail on defer mode. This test is only for Re:VIEW 2.
-    return true if /mswin|mingw|cygwin/ =~ RUBY_PLATFORM
+    return true if /mswin|mingw|cygwin/.match?(RUBY_PLATFORM)
     return true unless system('latex -version 1>/dev/null 2>/dev/null')
 
     mktmpbookdir('catalog.yml' => "CHAPS:\n - ch01.re\n",

--- a/test/test_idgxmlmaker_cmd.rb
+++ b/test/test_idgxmlmaker_cmd.rb
@@ -21,7 +21,7 @@ class IDGXMLMakerCmdTest < Test::Unit::TestCase
   end
 
   def common_buildidgxml(bookdir, configfile, targetfile, option)
-    if /mswin|mingw|cygwin/ !~ RUBY_PLATFORM
+    unless /mswin|mingw|cygwin/.match?(RUBY_PLATFORM)
       config = prepare_samplebook(@tmpdir1, bookdir, nil, configfile)
       builddir = File.join(@tmpdir1, config['bookname'] + '-idgxml')
       assert !File.exist?(builddir)

--- a/test/test_pdfmaker_cmd.rb
+++ b/test/test_pdfmaker_cmd.rb
@@ -21,7 +21,7 @@ class PDFMakerCmdTest < Test::Unit::TestCase
   end
 
   def common_buildpdf(bookdir, templatedir, configfile, targetpdffile, option = nil)
-    if /mswin|mingw|cygwin/ !~ RUBY_PLATFORM
+    unless /mswin|mingw|cygwin/.match?(RUBY_PLATFORM)
       config = prepare_samplebook(@tmpdir1, bookdir, templatedir, configfile)
       builddir = File.join(@tmpdir1, config['bookname'] + '-pdf')
       assert !File.exist?(builddir)

--- a/test/test_textmaker_cmd.rb
+++ b/test/test_textmaker_cmd.rb
@@ -21,7 +21,7 @@ class TEXTMakerCmdTest < Test::Unit::TestCase
   end
 
   def common_buildtext(bookdir, configfile, targetfile, option)
-    if /mswin|mingw|cygwin/ !~ RUBY_PLATFORM
+    unless /mswin|mingw|cygwin/.match?(RUBY_PLATFORM)
       config = prepare_samplebook(@tmpdir1, bookdir, nil, configfile)
       builddir = File.join(@tmpdir1, config['bookname'] + '-text')
       assert !File.exist?(builddir)


### PR DESCRIPTION
rubocopの`Performance/RegexpMatch`, `Style/SoleNestedConditional`, `Style/CaseEquality`について対応します。

`Performance/RegexpMatch`は`=~`ではなく`match?`を使うと早い＆キャプチャを使わないのが明確化できる、というものです。
`Style/SoleNestedConditional`はif等のネストをflatにするものですが、`confirm`は例外的にネストにさせています。
`Style/CaseEquality`もコメントで抑制しただけです（IntegerとRangeをうまいことまとめているため）。