### PR TITLE
rubocop: remove enabled cops in .rubocop.yml

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,9 +13,6 @@ require:
 
 #### Lint
 
-Lint/EmptyWhen:
-  Enabled: true
-
 Lint/NestedMethodDefinition:
   Exclude:
     - 'test/*'
@@ -23,35 +20,8 @@ Lint/NestedMethodDefinition:
 Lint/AssignmentInCondition:
   Enabled: false
 
-Lint/ParenthesesAsGroupedExpression:
-  Enabled: true
-
-Lint/UnderscorePrefixedVariableName:
-  Enabled: true
-
-Lint/UnusedBlockArgument:
-  Enabled: true
-
-Lint/UnusedMethodArgument:
-  Enabled: true
-
-Lint/UselessAssignment:
-  Enabled: true
-
 Lint/ErbNewArguments:
   Enabled: false
-
-Lint/DeprecatedOpenSSLConstant:
-  Enabled: true
-
-Lint/MixedRegexpCaptureTypes:
-  Enabled: true
-
-Lint/RaiseException:
-  Enabled: true
-
-Lint/StructNewOverride:
-  Enabled: true
 
 # make it enable when supporting only Ruby 3.0 and higher.
 Lint/RedundantDirGlobSort:
@@ -59,42 +29,8 @@ Lint/RedundantDirGlobSort:
 
 #### Performance
 
-Performance/ReverseEach:
-  Enabled: true
-
-# Use tr instead of gsub.
-Performance/StringReplacement:
-  Enabled: true
-
-Performance/RangeInclude:
-  Enabled: true
-
 Performance/DeletePrefix:
   Enabled: false
-
-Performance/RedundantMerge:
-  Enabled: true
-
-Performance/AncestorsInclude:
-  Enabled: true
-
-Performance/BigDecimalWithNumericArgument:
-  Enabled: true
-
-Performance/RedundantSortBlock:
-  Enabled: true
-
-Performance/RedundantStringChars:
-  Enabled: true
-
-Performance/ReverseFirst:
-  Enabled: true
-
-Performance/SortReverse:
-  Enabled: true
-
-Performance/Squeeze:
-  Enabled: true
 
 Performance/StringInclude:
   Enabled: false
@@ -112,20 +48,8 @@ Style/Alias:
   EnforcedStyle: prefer_alias_method
   Enabled: true
 
-Style/AndOr:
-  Enabled: true
-
 Style/BarePercentLiterals:
   EnforcedStyle: percent_q
-  Enabled: true
-
-Style/BlockDelimiters:
-  Enabled: true
-
-Style/ClassCheck:
-  Enabled: true
-
-Style/ClassMethods:
   Enabled: true
 
 Style/CommentedKeyword:
@@ -134,25 +58,8 @@ Style/CommentedKeyword:
 Style/DocumentDynamicEvalDefinition:
   Enabled: false
 
-# Do not introduce global variables.
-Style/GlobalVars:
-  Enabled: true
-
-# Use self-assignment shorthand +=.
-Style/SelfAssignment:
-  Enabled: true
-
 Style/Documentation:
   Enabled: false
-
-Style/Encoding:
-  Enabled: true
-
-Style/EmptyElse:
-  Enabled: true
-
-Style/EvalWithLocation:
-  Enabled: true
 
 Style/FormatString:
   EnforcedStyle: sprintf
@@ -164,20 +71,11 @@ Style/FormatStringToken:
 Style/GuardClause:
   Enabled: false
 
-Style/IfInsideElse:
-  Enabled: true
-
 Style/IfUnlessModifier:
   Enabled: false
 
 Style/MutableConstant:
   Enabled: false
-
-Style/MultipleComparison:
-  Enabled: true
-
-Style/RedundantInterpolation:
-  Enabled: true
 
 Style/ZeroLengthPredicate:
   Enabled: false
@@ -200,9 +98,6 @@ Style/EmptyMethod:
   EnforcedStyle: expanded
   Enabled: true
 
-Style/HashSyntax:
-  Enabled: true
-
 Style/RescueModifier:
   Enabled: false
 
@@ -210,20 +105,8 @@ Style/ClassAndModuleChildren:
   EnforcedStyle: nested
   Enabled: true
 
-Style/ColonMethodCall:
-  Enabled: true
-
-Style/For:
-  Enabled: true
-
-Style/InfiniteLoop:
-  Enabled: true
-
 Style/LineEndConcatenation:
   Enabled: false
-
-Style/MethodCallWithoutArgsParentheses:
-  Enabled: true
 
 Style/MethodCallWithArgsParentheses:
   IgnoredMethods:
@@ -258,23 +141,8 @@ Style/MethodCallWithArgsParentheses:
 Style/MixinUsage:
   Enabled: false
 
-Style/MultilineBlockChain:
-  Enabled: true
-
-Style/NegatedIf:
-  Enabled: true
-
-Style/Next:
-  Enabled: true
-
-Style/Not:
-  Enabled: true
-
 Style/NumericLiterals:
   MinDigits: 6
-
-Style/PercentLiteralDelimiters:
-  Enabled: true
 
 Style/PercentQLiterals:
   EnforcedStyle: upper_case_q
@@ -290,47 +158,14 @@ Style/RaiseArgs:
 Style/RedundantBegin:
   Enabled: false
 
-Style/RedundantParentheses:
-  Enabled: true
-
 Style/RedundantReturn:
   Enabled: false
 
 Style/RedundantSelf:
   Enabled: false
 
-Style/RegexpLiteral:
-  Enabled: true
-
-Style/Semicolon:
-  Enabled: true
-
-Style/SingleLineMethods:
-  Enabled: true
-
-Style/SpecialGlobalVars:
-  Enabled: true
-
 Style/StderrPuts:
   Enabled: false
-
-Style/StringLiterals:
-  Enabled: true
-
-Style/StringLiteralsInInterpolation:
-  Enabled: true
-
-Style/SymbolProc:
-  Enabled: true
-
-Style/SymbolArray:
-  Enabled: true
-
-Style/TrailingCommaInArrayLiteral:
-  Enabled: true
-
-Style/TrailingCommaInHashLiteral:
-  Enabled: true
 
 Style/WordArray:
   MinSize: 10
@@ -340,30 +175,6 @@ Style/RedundantPercentQ:
 
 Style/WhileUntilModifier:
   Enabled: false
-
-Style/YodaCondition:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: true
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Style/RedundantFetchBlock:
-  Enabled: true
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: true
 
 Style/SlicingWithRange:
   Enabled: false
@@ -388,16 +199,6 @@ Style/CombinableLoops:
 Layout/BlockAlignment:
   Enabled: false
 
-Layout/EndAlignment:
-  Enabled: true
-
-Layout/MultilineMethodCallBraceLayout:
-  Enabled: true
-
-Layout/AccessModifierIndentation:
-  EnforcedStyle: indent
-  Enabled: true
-
 Layout/ClosingHeredocIndentation:
   Enabled: false
 
@@ -405,98 +206,20 @@ Layout/DotPosition:
   EnforcedStyle: trailing
   Enabled: true
 
-Layout/EmptyLines:
-  Enabled: true
-
-Layout/EmptyLineAfterGuardClause:
-  Enabled: true
-
-Layout/EmptyLinesAroundAccessModifier:
-  Enabled: true
-
-Layout/EmptyLinesAroundClassBody:
-  Enabled: true
-
-Layout/EmptyLinesAroundMethodBody:
-  Enabled: true
-
-Layout/EmptyLinesAroundModuleBody:
-  Enabled: true
-
-Layout/EndOfLine:
-  Enabled: true
-
-Layout/ExtraSpacing:
-  Enabled: true
-
-Layout/IndentationConsistency:
-  Enabled: true
-
-Layout/IndentationWidth:
-  Enabled: true
-
-Layout/FirstHashElementIndentation:
-  Enabled: true
-
 Layout/HeredocIndentation:
   Enabled: false
 
-Layout/LeadingCommentSpace:
-  Enabled: true
-
-Layout/MultilineOperationIndentation:
-  Enabled: true
-
 Layout/SpaceAroundBlockParameters:
   EnforcedStyleInsidePipes: no_space
-  Enabled: true
-
-Layout/SpaceAfterComma:
-  Enabled: true
-
-Layout/SpaceAfterNot:
-  Enabled: true
-
-Layout/SpaceAfterSemicolon:
-  Enabled: true
-
-Layout/SpaceAroundEqualsInParameterDefault:
-  Enabled: true
-
-Layout/SpaceAroundOperators:
-  Enabled: true
-
-Layout/SpaceBeforeBlockBraces:
-  Enabled: true
-
-Layout/SpaceBeforeComma:
-  Enabled: true
-
-Layout/SpaceInsideBlockBraces:
-  Enabled: true
-
-Layout/SpaceInsideHashLiteralBraces:
-  Enabled: true
-
-Layout/SpaceInsideArrayLiteralBrackets:
   Enabled: true
 
 Layout/SpaceInsideStringInterpolation:
   EnforcedStyle: no_space
   Enabled: true
 
-Layout/TrailingEmptyLines:
-  Enabled: true
-
 Layout/TrailingWhitespace:
   Enabled: true
   AllowInHeredoc: true
-
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
 
 Layout/LineLength:
   Max: 256
@@ -552,31 +275,14 @@ Metrics/BlockLength:
 
 ## Naming
 
-Naming/AccessorMethodName:
-  Enabled: true
-
-# When defining the == operator, name its argument other.
-Naming/BinaryOperatorParameterName:
-  Enabled: true
-
 Naming/FileName:
   Enabled: false
 
 Naming/HeredocDelimiterNaming:
   Enabled: false
 
-Naming/MemoizedInstanceVariableName:
-  Enabled: true
-
-Naming/MethodName:
-  Enabled: true
-
 Naming/MethodParameterName:
   Enabled: false
-
-# Use snake_case for variable names.
-Naming/VariableName:
-  Enabled: true
 
 Naming/VariableNumber:
   EnforcedStyle: normalcase
@@ -585,9 +291,6 @@ Naming/VariableNumber:
     - test/*
 
 #### Security
-
-Security/YAMLLoad:
-  Enabled: true
 
 #### Gemspec
 


### PR DESCRIPTION
`.rubocop.yml`の項目が多いため、`Enabled: true`になっているcopsは`.rubocop.yml`から削除しました。