### PR TITLE
textmaker: 表見出し行と通常行の間に線を引く。後方互換にtextmaker/th_boldパラメータを追加

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -442,3 +442,9 @@ pdfmaker:
   #     options_with_caption: "colbacktitle=black!25!white"
   #
   # pdfmaker:階層を使うものはここまで
+# textmaker:
+  # 表見出しの表現の設定
+  # nullの場合は区切り線（------------）で見出し行と通常の行を分ける。
+  # trueの場合は見出しを★〜☆で囲み（太字と同様）、区切り線を入れない。
+  # th_bold: null
+  # textmaker:階層を使うものはここまで

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012-2021 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
+# Copyright (c) 2012-2022 Masanori Kado, Masayoshi Takahashi, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -141,6 +141,9 @@ module ReVIEW
           'force_include_images' => [],
           'cover_linear' => nil,
           'back_footnote' => nil
+        },
+        'textmaker' => {
+          'th_bold' => nil
         }
       ]
       conf.maker = nil

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2021 Minero Aoki, Kenshi Muto
+# Copyright (c) 2008-2022 Minero Aoki, Kenshi Muto
 #               2002-2006 Minero Aoki
 #
 # This program is free software.
@@ -262,8 +262,31 @@ module ReVIEW
       blank
     end
 
+    def table_rows(sepidx, rows)
+      if sepidx
+        sepidx.times do
+          tr(rows.shift.map { |s| th(s) })
+        end
+        if !@book.config['textmaker'] || !@book.config['textmaker']['th_bold']
+          puts '-' * 12
+        end
+        rows.each do |cols|
+          tr(cols.map { |s| td(s) })
+        end
+      else
+        rows.each do |cols|
+          h, *cs = *cols
+          tr([th(h)] + cs.map { |s| td(s) })
+        end
+      end
+    end
+
     def th(str)
-      "★#{str}☆"
+      if @book.config['textmaker'] && @book.config['textmaker']['th_bold']
+        "★#{str}☆"
+      else
+        str
+      end
     end
 
     def table_end

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -151,7 +151,8 @@ class TOPBuidlerTest < Test::Unit::TestCase
     actual = compile_block("//table{\n★1☆\t▲2☆\n------------\n★3☆\t▲4☆<>&\n//}\n")
     expected = <<-EOS
 ◆→開始:表←◆
-★★1☆☆\t★▲2☆☆
+★1☆\t▲2☆
+------------
 ★3☆\t▲4☆<>&
 ◆→終了:表←◆
 
@@ -506,7 +507,8 @@ EOS
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     expected = <<-EOS
 ◆→開始:表←◆
-★aaa☆\t★bbb☆
+aaa\tbbb
+------------
 ccc\tddd<>&
 ◆→終了:表←◆
 
@@ -518,7 +520,8 @@ EOS
 ◆→開始:表←◆
 表1.1　FOO
 
-★aaa☆\t★bbb☆
+aaa\tbbb
+------------
 ccc\tddd<>&
 ◆→終了:表←◆
 
@@ -529,10 +532,34 @@ EOS
     actual = compile_block("//table[foo][FOO]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     expected = <<-EOS
 ◆→開始:表←◆
-★aaa☆\t★bbb☆
+aaa\tbbb
+------------
 ccc\tddd<>&
 
 表1.1　FOO
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
+  end
+
+  def test_table_th_bold
+    @config['textmaker']['th_bold'] = true
+    actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+◆→開始:表←◆
+★aaa☆\t★bbb☆
+ccc\tddd<>&
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
+
+    actual = compile_block("//table{\naaa\tbbb\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+◆→開始:表←◆
+★aaa☆\tbbb
+★ccc☆\tddd<>&
 ◆→終了:表←◆
 
 EOS
@@ -561,6 +588,28 @@ EOS
 ◆→開始:表←◆
 foo
 
+aaa\tbbb
+------------
+ccc\tddd<>&
+◆→終了:表←◆
+
+◆→開始:表←◆
+aaa\tbbb
+------------
+ccc\tddd<>&
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
+  end
+
+  def test_emtable_thbold
+    @config['textmaker']['th_bold'] = true
+    actual = compile_block("//emtable[foo]{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n//emtable{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
+    expected = <<-EOS
+◆→開始:表←◆
+foo
+
 ★aaa☆\t★bbb☆
 ccc\tddd<>&
 ◆→終了:表←◆
@@ -578,7 +627,8 @@ EOS
     src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS
 ◆→開始:表←◆
-★1☆	★2☆	★3  4| 5☆
+1	2	3  4| 5
+------------
 a b	c  d   |e	
 ◆→終了:表←◆
 
@@ -590,7 +640,8 @@ EOS
     actual = compile_block(src)
     expected = <<-EOS
 ◆→開始:表←◆
-★1☆	★2☆	★☆	★3  4| 5☆
+1	2		3  4| 5
+------------
 a b	c  d   |e		
 ◆→終了:表←◆
 
@@ -601,7 +652,8 @@ EOS
     actual = compile_block(src)
     expected = <<-EOS
 ◆→開始:表←◆
-★1☆	★2☆	★3☆	★4|☆	★5☆
+1	2	3	4|	5
+------------
 a	b	c	d	|e
 ◆→終了:表←◆
 
@@ -612,7 +664,8 @@ EOS
     actual = compile_block(src)
     expected = <<-EOS
 ◆→開始:表←◆
-★1	2		3  4☆	★5☆
+1	2		3  4	5
+------------
 a b	c  d	e
 ◆→終了:表←◆
 


### PR DESCRIPTION
#1789 の修正

textmakerにおいて、th/td行の間に`------------` を引くようにします。
`textmaker/th_bold` パラメータをtrueにすると従来の挙動(thに★〜☆を付け、区切り線を入れない)に戻ります。
