### PR TITLE
textmaker: //indepimageの出力の仕方を//imageに合わせる

### DIFF
--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -519,26 +519,36 @@ module ReVIEW
       ), __FILE__, __LINE__ - 11
     end
 
-    def indepimage(_lines, id, caption = nil, metric = nil)
+    def indepimage(lines, id, caption = nil, metric = nil)
       metrics = parse_metric('top', metric)
       metrics = " #{metrics}" if metrics.present?
       blank
+      puts "◆→開始:#{@titles['image']}←◆"
       if caption_top?('image') && caption.present?
-        puts "図　#{compile_inline(caption)}"
+        indepimage_header(id, caption)
+        blank
       end
       begin
-        puts "◆→画像 #{@chapter.image(id).path.sub(%r{\A\./}, '')}#{metrics}←◆"
+        puts "◆→#{@chapter.image(id).path}#{metrics}←◆"
       rescue StandardError
         warn "image not bound: #{id}", location: location
-        puts "◆→画像 #{id}←◆"
+        lines.each do |line|
+          puts line
+        end
       end
       if !caption_top?('image') && caption.present?
-        puts "図　#{compile_inline(caption)}"
+        blank
+        indepimage_header(id, caption)
       end
+      puts "◆→終了:#{@titles['image']}←◆"
       blank
     end
 
     alias_method :numberlessimage, :indepimage
+
+    def indepimage_header(_id, caption)
+      puts "図#{I18n.t('caption_prefix_idgxml')}#{compile_inline(caption)}"
+    end
 
     def inline_code(str)
       "△#{str}☆"

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -528,9 +528,9 @@ module ReVIEW
         indepimage_header(id, caption)
         blank
       end
-      begin
+      if @chapter.image_bound?(id)
         puts "◆→#{@chapter.image(id).path}#{metrics}←◆"
-      rescue StandardError
+      else
         warn "image not bound: #{id}", location: location
         lines.each do |line|
           puts line

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -1022,6 +1022,63 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_image_dummy
+    actual = compile_block("//image[dummy][sample photo]{\nDUMMY\n//}\n")
+    expected = <<-EOS
+◆→開始:図←◆
+DUMMY
+
+図1.1　sample photo
+◆→終了:図←◆
+
+EOS
+    assert_equal expected, actual
+  end
+
+  def test_indepimage
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('sampleimg', 1)
+      item.instance_eval { @path = './images/chap1-sampleimg.png' }
+      item
+    end
+
+    actual = compile_block("//indepimage[sampleimg][sample photo]{\nfoo\n//}\n")
+    expected = <<-EOS
+◆→開始:図←◆
+◆→./images/chap1-sampleimg.png←◆
+
+図　sample photo
+◆→終了:図←◆
+
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['image'] = 'top'
+    actual = compile_block("//indepimage[sampleimg][sample photo]{\nfoo\n//}\n")
+    expected = <<-EOS
+◆→開始:図←◆
+図　sample photo
+
+◆→./images/chap1-sampleimg.png←◆
+◆→終了:図←◆
+
+EOS
+    assert_equal expected, actual
+  end
+
+  def test_indepimage_dummy
+    actual = compile_block("//indepimage[dummy][sample photo]{\nDUMMY\n//}\n")
+    expected = <<-EOS
+◆→開始:図←◆
+DUMMY
+
+図　sample photo
+◆→終了:図←◆
+
+EOS
+    assert_equal expected, actual
+  end
+
   def test_texequation
     actual = compile_block("//texequation{\n\\sin\n1^{2}\n//}\n")
     expected = <<-EOS


### PR DESCRIPTION
#1790 の修正です。

//indepimageについて◆→開始:図←◆〜◆→終了:図←◆で囲み、画像がないときにはコメント部を出力します。
キャプションについては上書きしやすいようにメソッド`indepimage_header`に切り出しました。
