### PR TITLE
textmaker: //imgtableの出力に画像ファイル名やコメントが含まれるようにする

### DIFF
--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -292,6 +292,31 @@ module ReVIEW
     def table_end
     end
 
+    def imgtable(lines, id, caption = nil, metric = nil)
+      metrics = parse_metric('top', metric)
+      metrics = " #{metrics}" if metrics.present?
+      blank
+      puts "◆→開始:#{@titles['table']}←◆"
+      if caption_top?('table') && caption.present?
+        table_header(id, caption)
+      end
+
+      if @chapter.image_bound?(id)
+        puts "◆→#{@chapter.image(id).path}#{metrics}←◆"
+      else
+        warn "image not bound: #{id}", location: location
+        lines.each do |line|
+          puts line
+        end
+      end
+
+      if !caption_top?('table') && caption.present?
+        table_header(id, caption)
+      end
+      puts "◆→終了:#{@titles['table']}←◆"
+      blank
+    end
+
     def comment(lines, comment = nil)
       return unless @book.config['draft']
 

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -623,6 +623,37 @@ EOS
     assert_equal expected, actual
   end
 
+  def test_imgtable
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('sampleimg', 1)
+      item.instance_eval { @path = './images/chap1-sampleimg.png' }
+      item
+    end
+
+    actual = compile_block("//imgtable[sampleimg][sample photo]{\nfoo\n//}\n")
+    expected = <<-EOS
+◆→開始:表←◆
+表1.1　sample photo
+
+◆→./images/chap1-sampleimg.png←◆
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
+
+    @config['caption_position']['table'] = 'bottom'
+    actual = compile_block("//imgtable[sampleimg][sample photo]{\nfoo\n//}\n")
+    expected = <<-EOS
+◆→開始:表←◆
+◆→./images/chap1-sampleimg.png←◆
+
+表1.1　sample photo
+◆→終了:表←◆
+
+EOS
+    assert_equal expected, actual
+  end
+
   def test_table_row_separator
     src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS


### PR DESCRIPTION
#1791 の修正
textmakerにおいて、//imgtableで図版が存在すればそのファイル名、なければコメント部を出力するようにします(//image同様の挙動にする)。
