### PR TITLE
handle YAML parse error in makers

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -75,9 +75,13 @@ module ReVIEW
       cmd_config, yamlfile, exportfile = parse_opts(args)
       error! "#{yamlfile} not found." unless File.exist?(yamlfile)
 
-      @config = ReVIEW::Configure.create(maker: 'epubmaker',
-                                         yamlfile: yamlfile,
-                                         config: cmd_config)
+      begin
+        @config = ReVIEW::Configure.create(maker: 'epubmaker',
+                                           yamlfile: yamlfile,
+                                           config: cmd_config)
+      rescue ReVIEW::ConfigError => e
+        error! e.message
+      end
       @producer = ReVIEW::EPUBMaker::Producer.new(@config)
       update_log_level
       debug("Loaded yaml file (#{yamlfile}).")

--- a/lib/review/idgxmlmaker.rb
+++ b/lib/review/idgxmlmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2019-2021 Kenshi Muto
+# Copyright (c) 2019-2022 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -74,9 +74,13 @@ module ReVIEW
       cmd_config, yamlfile = parse_opts(args)
       error! "#{yamlfile} not found." unless File.exist?(yamlfile)
 
-      @config = ReVIEW::Configure.create(maker: 'idgxmlmaker',
-                                         yamlfile: yamlfile,
-                                         config: cmd_config)
+      begin
+        @config = ReVIEW::Configure.create(maker: 'idgxmlmaker',
+                                           yamlfile: yamlfile,
+                                           config: cmd_config)
+      rescue ReVIEW::ConfigError => e
+        error! e.message
+      end
       I18n.setup(@config['language'])
       begin
         generate_idgxml_files(yamlfile)

--- a/lib/review/pdfmaker.rb
+++ b/lib/review/pdfmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2010-2021 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2022 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -121,9 +121,13 @@ module ReVIEW
       cmd_config, yamlfile = parse_opts(args)
       error! "#{yamlfile} not found." unless File.exist?(yamlfile)
 
-      @config = ReVIEW::Configure.create(maker: 'pdfmaker',
-                                         yamlfile: yamlfile,
-                                         config: cmd_config)
+      begin
+        @config = ReVIEW::Configure.create(maker: 'pdfmaker',
+                                           yamlfile: yamlfile,
+                                           config: cmd_config)
+      rescue ReVIEW::ConfigError => e
+        error! e.message
+      end
 
       I18n.setup(@config['language'])
       @basedir = File.absolute_path(File.dirname(yamlfile))

--- a/lib/review/textmaker.rb
+++ b/lib/review/textmaker.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2021 Kenshi Muto
+# Copyright (c) 2018-2022 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -74,9 +74,14 @@ module ReVIEW
       cmd_config, yamlfile = parse_opts(args)
       error! "#{yamlfile} not found." unless File.exist?(yamlfile)
 
-      @config = ReVIEW::Configure.create(maker: 'textmaker',
-                                         yamlfile: yamlfile,
-                                         config: cmd_config)
+      begin
+        @config = ReVIEW::Configure.create(maker: 'textmaker',
+                                           yamlfile: yamlfile,
+                                           config: cmd_config)
+      rescue ReVIEW::ConfigError => e
+        error! e.message
+      end
+
       @img_math = ReVIEW::ImgMath.new(@config, path_name: '_review_math_text')
 
       I18n.setup(@config['language'])

--- a/lib/review/webmaker.rb
+++ b/lib/review/webmaker.rb
@@ -78,9 +78,13 @@ module ReVIEW
       cmd_config, yamlfile = parse_opts(args)
       error! "#{yamlfile} not found." unless File.exist?(yamlfile)
 
-      @config = ReVIEW::Configure.create(maker: 'webmaker',
-                                         yamlfile: yamlfile,
-                                         config: cmd_config)
+      begin
+        @config = ReVIEW::Configure.create(maker: 'webmaker',
+                                           yamlfile: yamlfile,
+                                           config: cmd_config)
+      rescue ReVIEW::ConfigError => e
+        error! e.message
+      end
 
       @config['htmlext'] = 'html'
       @img_math = ReVIEW::ImgMath.new(@config)


### PR DESCRIPTION
#1797 の修正
YAMLのcreateで例外(パーサエラー)が発生したときにConfigErrorを各makerで捕捉し、error!で終了させます。
