### PR TITLE
IDGXML: force closing chapter for preface/postface

### DIFF
--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -86,7 +86,7 @@ module ReVIEW
         s += '</sect3>' if @subsubsection > 0
         s += '</sect2>' if @subsection > 0
         s += '</sect>' if @section > 0
-        s += '</chapter>' if @chapter.number > 0
+        s += '</chapter>'
       end
       solve_nest(@output.string) + s + "</#{@rootelement}>\n"
     end


### PR DESCRIPTION
IDGXMLのsecttagsモードを有効にしている(この時点でレアケース…)において、かつ前付後付の採番なしのものがあるとエラーになるのを修正します。
本質的には`<chapter>`を使ったかどうかでcloseするか決めたほうがいい気はしますが、もともとレアケースなので怠惰に対処します。
