### PR TITLE
config.ymlサンプルのurnidの例更新

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -87,7 +87,7 @@ aut: ["青木峰郎", "武藤健志", "高橋征義", "角征典"]
 debug: null
 
 # 固有IDに使用するドメイン。指定しない場合には、時刻に基づくランダムUUIDが入る
-# urnid: urn:uuid:http://example.com/book-title/
+# urnid: urn:uuid:ffffffff-ffff-ffff-ffff-ffffffffffff
 #
 # ISBN。省略した場合はurnidが入る
 # isbn: null

--- a/doc/config.yml.sample-simple
+++ b/doc/config.yml.sample-simple
@@ -25,7 +25,7 @@ date: 2018-11-11
 history: [["2012-01-30"],["2016-04-20","2016-05-03"],["2018-11-11"]]
 rights: (C) 2016-2020 Re:VIEW Commiters, some rights reserved.
 description: sample config.yml file for Re:VIEW book
-urnid: urn:uuid:http://reviewml.org/review-sample-book
+# urnid: urn:uuid:ffffffff-ffff-ffff-ffff-ffffffffffff
 # isbn: null
 
 ## Book Structure


### PR DESCRIPTION
#1779 でsampleから消していましたが、review-initで作るもののほうに無効なurnidの例が残っていました。
固有UUIDを指定したいという可能性がないとはいえないのでばっさり削除とはせず、一応epubcheckが通るサンプルUUIDに変更します。
