### PR TITLE
Add `require 'date'` to yamlloader

### DIFF
--- a/lib/review/yamlloader.rb
+++ b/lib/review/yamlloader.rb
@@ -1,4 +1,5 @@
 require 'yaml'
+require 'date'
 
 module ReVIEW
   class YAMLLoader


### PR DESCRIPTION
YAMLLoaderで使っている`Date`でエラーになることがあったので、YAMLLoader自体にrequireをつけておきます（具体的にはreview-updateでした…）。