### PR TITLE
Update rubocop 1.27.0

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,4 +1,4 @@
-name: Test
+name: Lint by RuboCop
 
 on:
   push:
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.4', '2.5', '2.6', '2.7', '3.0', '3.1']
-        os: [ubuntu-latest, macOS-latest]
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby
@@ -28,4 +28,4 @@ jobs:
       run: |
         gem install bundler --no-document
         bundle install --retry 3
-        bundle exec rake test
+        bundle exec rubocop -P

--- a/lib/review/epubmaker/epubv2.rb
+++ b/lib/review/epubmaker/epubv2.rb
@@ -22,11 +22,6 @@ module ReVIEW
       CREATOR_ATTRIBUTES = %w[aut a-adp a-ann a-arr a-art a-asn a-aqt a-aft a-aui a-ant a-bkp a-clb a-cmm a-dsr a-edt a-ill a-lyr a-mdc a-mus a-nrt a-oth a-pht a-prt a-red a-rev a-spn a-ths a-trc a-trl]
       CONTRIBUTER_ATTRIBUTES = %w[adp ann arr art asn aqt aft aui ant bkp clb cmm dsr edt ill lyr mdc mus nrt oth pht prt red rev spn ths trc trl]
 
-      # Construct object with parameter hash +config+ and message resource hash +res+.
-      def initialize(producer) # rubocop:disable Lint/UselessMethodDefinition
-        super
-      end
-
       # Return opf file content.
       def opf
         @opf_metainfo = opf_metainfo

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -136,7 +136,8 @@ module ReVIEW
       when 5
         @subsubsubsection += 1
         print %Q(<sect4 id="sect:#{@chapter.number}.#{@section}.#{@subsection}.#{@subsubsection}.#{@subsubsubsection}">) if @secttags
-      when 6 # rubocop:disable Lint/EmptyWhen
+      when 6
+        # ignore
       else
         raise "caption level too deep or unsupported: #{level}"
       end

--- a/lib/review/yamlloader.rb
+++ b/lib/review/yamlloader.rb
@@ -36,9 +36,6 @@ module ReVIEW
       end
     end
 
-    def initialize
-    end
-
     # load YAML files
     #
     # `inherit: [3.yml, 6.yml]` in 7.yml; `inherit: [1.yml, 2.yml]` in 3.yml; `inherit: [4.yml, 5.yml]` in 6.yml

--- a/review.gemspec
+++ b/review.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('mini_magick')
   gem.add_development_dependency('pygments.rb')
   gem.add_development_dependency('rake')
-  gem.add_development_dependency('rubocop', '~> 1.12.0')
+  gem.add_development_dependency('rubocop', '~> 1.27.0')
   gem.add_development_dependency('rubocop-performance')
   gem.add_development_dependency('rubocop-rake')
   gem.add_development_dependency('simplecov')


### PR DESCRIPTION
RuboCopをアップデートしておきます。
`Style/RedundantInitialize`と`Lint/RedundantCopDisableDirective`の警告が出ていたため、それの対応も追加しました。