### PR TITLE
Implement imgmath for IDGXML maker 

### DIFF
--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -854,6 +854,7 @@ module ReVIEW
       else
         %Q(<replace idref="texinline-#{@texinlineequation}"><pre>#{escape(str)}</pre></replace>)
       end
+    end
 
     def noindent
       @noindent = true

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -465,11 +465,22 @@ module ReVIEW
         puts caption_str if caption_top?('equation')
       end
 
-      puts %Q(<replace idref="texblock-#{@texblockequation}">)
-      puts '<pre>'
-      print lines.join("\n")
-      puts '</pre>'
-      puts '</replace>'
+      if @book.config['math_format'] == 'imgmath'
+        fontsize = @book.config['imgmath_options']['fontsize'].to_f
+        lineheight = @book.config['imgmath_options']['lineheight'].to_f
+        math_str = "\\begin{equation*}\n\\fontsize{#{fontsize}}{#{lineheight}}\\selectfont\n#{lines.join("\n")}\n\\end{equation*}\n"
+        key = Digest::SHA256.hexdigest(math_str)
+        img_path = @img_math.defer_math_image(math_str, key)
+        puts '<img>'
+        puts %Q(<Image href="file://#{img_path}" />)
+        puts '</img>'
+      else
+        puts %Q(<replace idref="texblock-#{@texblockequation}">)
+        puts '<pre>'
+        puts lines.join("\n")
+        puts '</pre>'
+        puts '</replace>'
+      end
 
       if id
         puts caption_str unless caption_top?('equation')
@@ -835,8 +846,14 @@ module ReVIEW
 
     def inline_m(str)
       @texinlineequation += 1
-      %Q(<replace idref="texinline-#{@texinlineequation}"><pre>#{escape(str)}</pre></replace>)
-    end
+      if @book.config['math_format'] == 'imgmath'
+        math_str = '$' + str + '$'
+        key = Digest::SHA256.hexdigest(str)
+        img_path = @img_math.defer_math_image(math_str, key)
+        %Q(<Image href="file://#{img_path}" type="inline" />)
+      else
+        %Q(<replace idref="texinline-#{@texinlineequation}"><pre>#{escape(str)}</pre></replace>)
+      end
 
     def noindent
       @noindent = true

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -471,9 +471,9 @@ module ReVIEW
         math_str = "\\begin{equation*}\n\\fontsize{#{fontsize}}{#{lineheight}}\\selectfont\n#{lines.join("\n")}\n\\end{equation*}\n"
         key = Digest::SHA256.hexdigest(math_str)
         img_path = @img_math.defer_math_image(math_str, key)
-        puts '<img>'
+        puts '<equationimage>'
         puts %Q(<Image href="file://#{img_path}" />)
-        puts '</img>'
+        puts '</equationimage>'
       else
         puts %Q(<replace idref="texblock-#{@texblockequation}">)
         puts '<pre>'
@@ -850,7 +850,7 @@ module ReVIEW
         math_str = '$' + str + '$'
         key = Digest::SHA256.hexdigest(str)
         img_path = @img_math.defer_math_image(math_str, key)
-        %Q(<Image href="file://#{img_path}" type="inline" />)
+        %Q(<inlineequation><Image href="file://#{img_path}" type="inline" /></inlineequation>)
       else
         %Q(<replace idref="texinline-#{@texinlineequation}"><pre>#{escape(str)}</pre></replace>)
       end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -16,7 +16,6 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     @config['tableopt'] = '10'
     @book = Book::Base.new
     @book.config = @config
-    img_math = ReVIEW::ImgMath.new(@config)
     @log_io = StringIO.new
     ReVIEW.logger = ReVIEW::Logger.new(@log_io)
     @compiler = ReVIEW::Compiler.new(@builder)
@@ -269,9 +268,6 @@ EOS
     actual = compile_inline('@<m>{\\sin} @<m>{\\frac{1\\}{2\\}}')
     assert_equal %Q(<inlineequation><Image href="file://images/_review_math/_gen_5fded382aa33f0f0652092d41e05c743f7453c26ca1433038a4883234975a9b0.png" type="inline" /></inlineequation> <inlineequation><Image href="file://images/_review_math/_gen_e7e9536310cdba7ff948771f791cefe32f99b73c608778c9660db79e4926e9f9.png" type="inline" /></inlineequation>), actual
   end
-
-
-  
 
   def test_dlist_beforeulol
     actual = compile_block(" : foo\n  foo.\n\npara\n\n : foo\n  foo.\n\n 1. bar\n\n : foo\n  foo.\n\n * bar\n")

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -267,7 +267,7 @@ EOS
   def test_inline_m_imgmath
     @config['math_format'] = 'imgmath'
     actual = compile_inline('@<m>{\\sin} @<m>{\\frac{1\\}{2\\}}')
-    assert_equal %Q(<Image href="file://images/_review_math/_gen_5fded382aa33f0f0652092d41e05c743f7453c26ca1433038a4883234975a9b0.png" type="inline" /> <Image href="file://images/_review_math/_gen_e7e9536310cdba7ff948771f791cefe32f99b73c608778c9660db79e4926e9f9.png" type="inline" />), actual
+    assert_equal %Q(<inlineequation><Image href="file://images/_review_math/_gen_5fded382aa33f0f0652092d41e05c743f7453c26ca1433038a4883234975a9b0.png" type="inline" /></inlineequation> <inlineequation><Image href="file://images/_review_math/_gen_e7e9536310cdba7ff948771f791cefe32f99b73c608778c9660db79e4926e9f9.png" type="inline" /></inlineequation>), actual
   end
 
 
@@ -1305,7 +1305,7 @@ EOS
 p \\land \\bm{P} q
 //}
 EOS
-    expected = %Q(<img><Image href="file://images/_review_math/_gen_84291054a12d278ea05694c20fbbc8e974ec66fc13be801c01dca764faeecccb.png" /></img>)
+    expected = %Q(<equationimage><Image href="file://images/_review_math/_gen_84291054a12d278ea05694c20fbbc8e974ec66fc13be801c01dca764faeecccb.png" /></equationimage>)
     actual = compile_block(src)
     assert_equal expected, actual
   end
@@ -1319,12 +1319,12 @@ EOS
 e=mc^2
 //}
 EOS
-    expected = %Q(<p><span type='eq'>式1.1</span></p><equationblock><caption>式1.1　The Equivalence of Mass <i>and</i> Energy</caption><img><Image href="file://images/_review_math/_gen_882e99d99b276a2118a3894895b6da815a03261f4150148c99b932bec5355f25.png" /></img></equationblock>)
+    expected = %Q(<p><span type='eq'>式1.1</span></p><equationblock><caption>式1.1　The Equivalence of Mass <i>and</i> Energy</caption><equationimage><Image href="file://images/_review_math/_gen_882e99d99b276a2118a3894895b6da815a03261f4150148c99b932bec5355f25.png" /></equationimage></equationblock>)
     actual = compile_block(src)
     assert_equal expected, actual
 
     @config['caption_position']['equation'] = 'bottom'
-    expected = %Q(<p><span type='eq'>式1.1</span></p><equationblock><img><Image href="file://images/_review_math/_gen_882e99d99b276a2118a3894895b6da815a03261f4150148c99b932bec5355f25.png" /></img><caption>式1.1　The Equivalence of Mass <i>and</i> Energy</caption></equationblock>)
+    expected = %Q(<p><span type='eq'>式1.1</span></p><equationblock><equationimage><Image href="file://images/_review_math/_gen_882e99d99b276a2118a3894895b6da815a03261f4150148c99b932bec5355f25.png" /></equationimage><caption>式1.1　The Equivalence of Mass <i>and</i> Energy</caption></equationblock>)
     actual = compile_block(src)
     assert_equal expected, actual
   end


### PR DESCRIPTION
fix #1820 

- `lib/review/idgxmlbuilder.rb` : `texequation()` と `inline_m()` に、画像化した数式を出力する動作を追加
- `lib/review/idgxmlmaker.rb` : `'review/img_math'` を使えるようにコード追加
- `test/test_idgxmlbuilder.rb` : 追加した部分についてテストコードを書きました（`texequation()` キャプションあり・なし、`inline_m()`）