### PR TITLE
PDFMaker: `@<icon>` の展開をreviewincludegraphicsではなくreviewiconに抽象化する

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -1350,7 +1350,7 @@ module ReVIEW
 
     def inline_icon(id)
       if @chapter.image(id).path
-        command = 'reviewincludegraphics'
+        command = 'reviewicon'
         if @book.config.check_version('2', exception: false)
           command = 'includegraphics'
         end

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -127,6 +127,9 @@
   \ifdefined\reviewtcy\else% for 5.3.0 compatibility
     \DeclareRobustCommand{\reviewtcy}[1]{\rensuji{##1}}
   \fi
+  \ifdefined\reviewicon\else% for 5.6.0 compatibility
+    \DeclareRobustCommand{\reviewicon}[1]{\reviewincludegraphics{##1}}
+  \fi
 }
 
 \makeatother

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -187,6 +187,9 @@
 \DeclareRobustCommand{\reviewit}[1]{\textit{#1}}
 \DeclareRobustCommand{\reviewbold}[1]{\textbf{#1}}
 \DeclareRobustCommand{\reviewtcy}[1]{\tatechuyoko{#1}}
+\DeclareRobustCommand{\reviewicon}[1]{\includegraphics[]{#1}}
+% アイコンの高さを文字の高さに合わせたいときには、以下をreview-custom.styに記述してください:
+% \DeclareRobustCommand{\reviewicon}[1]{\includegraphics[height=0.9\zw]{#1}}
 
 % allow break line in tt
 % contributed by @zr_tex8r

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -1,4 +1,4 @@
-\ProvidesClass{review-base}[2021/09/06]
+\ProvidesClass{review-base}[2022/07/25]
 \RequirePackage{ifthen}
 \@ifundefined{Hy@Info}{% for jsbook.cls
   \RequirePackage[dvipdfmx,bookmarks=true,bookmarksnumbered=true]{hyperref}
@@ -331,6 +331,10 @@
 
 \DeclareRobustCommand{\reviewinsert}[1]{\Underline{#1}}
 \DeclareRobustCommand{\reviewstrike}[1]{\Midline{#1}}
+\DeclareRobustCommand{\reviewicon}[1]{\includegraphics[]{#1}}
+% アイコンの高さを文字の高さに合わせたいときには、以下をreview-custom.styに記述してください:
+% \DeclareRobustCommand{\reviewicon}[1]{\includegraphics[height=0.9zw]{#1}}
+
 %%%% for ulem.sty:
 %%\renewcommand{\reviewstrike}[1]{\sout{#1}}
 

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -1,6 +1,6 @@
 \documentclass[dvipdfmx]{review-jsbook}
 \makeatletter
-\def\review@reviewversion{5.3.0}
+\def\review@reviewversion{5.6.0}
 \def\review@texcompiler{uplatex}
 \def\review@documentclass{review-jsbook}
 
@@ -63,6 +63,9 @@
   \fi
   \ifdefined\reviewtcy\else% for 5.3.0 compatibility
     \DeclareRobustCommand{\reviewtcy}[1]{\rensuji{##1}}
+  \fi
+  \ifdefined\reviewicon\else% for 5.6.0 compatibility
+    \DeclareRobustCommand{\reviewicon}[1]{\reviewincludegraphics{##1}}
   \fi
 }
 

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -1,6 +1,6 @@
 \documentclass[dvipdfmx]{review-jsbook}
 \makeatletter
-\def\review@reviewversion{5.3.0}
+\def\review@reviewversion{5.6.0}
 \def\review@texcompiler{uplatex}
 \def\review@documentclass{review-jsbook}
 
@@ -74,6 +74,9 @@ some ad content
   \fi
   \ifdefined\reviewtcy\else% for 5.3.0 compatibility
     \DeclareRobustCommand{\reviewtcy}[1]{\rensuji{##1}}
+  \fi
+  \ifdefined\reviewicon\else% for 5.6.0 compatibility
+    \DeclareRobustCommand{\reviewicon}[1]{\reviewincludegraphics{##1}}
   \fi
 }
 


### PR DESCRIPTION
#1836 の対応。
文字高にするのはヒントを与えるのみとした(が、これを見てくれるのかという問題はある)。
