### PR TITLE
囲み記事のラベルをMEMO,NOTE等妥当なものにする

### DIFF
--- a/lib/review/i18n.yml
+++ b/lib/review/i18n.yml
@@ -17,7 +17,14 @@ ja:
   hd_quote_without_number: "「%s」"
   appendix: 付録%pA
   numberless_image: "図:"
-  memo_head: ■メモ
+  note_head: NOTE
+  tip_head: TIP
+  info_head: INFORMATION
+  warning_head: WARNING
+  important_head: IMPORTANT
+  caution_head: CAUTION
+  notice_head: NOTICE
+  memo_head: MEMO
   format_number: "%s.%d"
   format_number_header: "%s.%d:"
   format_number_without_chapter: "%d"
@@ -107,7 +114,14 @@ en:
   hd_quote_without_number: '"%s"'
   appendix: Appendix %s
   numberless_image: "Figure:"
-  memo_head: Note
+  note_head: NOTE
+  tip_head: TIP
+  info_head: INFORMATION
+  warning_head: WARNING
+  important_head: IMPORTANT
+  caution_head: CAUTION
+  notice_head: NOTICE
+  memo_head: MEMO
   format_number: "%s.%d"
   format_number_header: "%s.%d:"
   format_number_without_chapter: "%d"
@@ -178,6 +192,14 @@ zh-TW:
   hd_quote_without_number: "「%s」"
   appendix: 附錄%s
   numberless_image: "圖:"
+  note_head: NOTE
+  tip_head: TIP
+  info_head: INFORMATION
+  warning_head: WARNING
+  important_head: IMPORTANT
+  caution_head: CAUTION
+  notice_head: NOTICE
+  memo_head: MEMO
   format_number: "%s.%d"
   format_number_header: "%s.%d:"
   format_number_without_chapter: "%d"

--- a/templates/latex/config.erb
+++ b/templates/latex/config.erb
@@ -34,7 +34,9 @@
 \def\review@intn@table{<%= escape(I18n.t('table')) %>}
 \def\review@intn@equation{<%= escape(I18n.t('equation')) %>}
 \def\review@intn@columnname{<%= escape(I18n.t('columnname')) %>}
-\def\review@intn@memohead{<%= escape(I18n.t('memo_head')) %>}
+<%- %w[note tip info warning important caution notice memo].each do |mini| -%>
+\def\review@intn@<%= mini%>head{<%= escape(I18n.t("#{mini}_head")) %>}
+<%- end -%>
 \def\review@intn@edition{<%= escape(I18n.t('edition')) %>}
 \def\review@intn@publishedby{<%= escape(I18n.t('published_by', @config.names_of('pbl').join(I18n.t('names_splitter'))))%>}
 \def\review@intn@captionprefix{<%= escape(I18n.t('caption_prefix')) %>}

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -146,35 +146,35 @@
 
 % 囲み記事
 \newenvironment{reviewnote}[1][]{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries NOTE #1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries \review@intn@notehead\hspace{0.75\zw}#1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
  {\end{tcolorbox}}
 
 \newenvironment{reviewmemo}[1][]{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries MEMO #1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries \review@intn@memohead\hspace{0.75\zw}#1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
  {\end{tcolorbox}}
 
 \newenvironment{reviewtip}[1][]{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries Tips #1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries \review@intn@tiphead\hspace{0.75\zw}#1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
  {\end{tcolorbox}}
 
 \newenvironment{reviewinfo}[1][]{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries INFORMATION #1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries \review@intn@infohead\hspace{0.75\zw}#1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
  {\end{tcolorbox}}
 
 \newenvironment{reviewwarning}[1][]{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries WARNING! #1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries \review@intn@warninghead\hspace{0.75\zw}#1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
  {\end{tcolorbox}}
 
 \newenvironment{reviewimportant}[1][]{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries IMPORTANT! #1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries \review@intn@importanthead\hspace{0.75\zw}#1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
  {\end{tcolorbox}}
 
 \newenvironment{reviewcaution}[1][]{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries CAUTION! #1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries \review@intn@cautionhead\hspace{0.75\zw}#1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
  {\end{tcolorbox}}
 
 \newenvironment{reviewnotice}[1][]{%
-  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries NOTICE #1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
+  \begin{tcolorbox}[skin=enhanced jigsaw,breakable,empty,coltitle=black,title={\sffamily\bfseries \review@intn@noticehead\hspace{0.75\zw}#1},borderline horizontal={0.5mm}{0pt}{black!50}, left=1mm, right=1mm, left skip=6mm]}
  {\end{tcolorbox}}
 
 % 書体

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -214,9 +214,9 @@
 \renewcommand{\thesection}{\thepart.\@arabic\c@section}%
 }{}
 
-\newcommand{\reviewminicolumntitle}[1]{%
+\newcommand{\reviewminicolumntitle}[2]{%
 \review@ifempty{#1}{}{%
-  {\large \review@intn@memohead{}: #1}\\}}
+  {\large ■#2: #1}\\}}
 
 \renewcommand{\contentsname}{\review@toctitle}
 
@@ -226,35 +226,35 @@
 
 \newenvironment{reviewnote}[1][]{%
   \begin{reviewminicolumn}
-\review@ifempty{#1}{}{\reviewminicolumntitle{#1}}
+  \reviewminicolumntitle{#1}{\review@intn@notehead}
 }{\end{reviewminicolumn}}
 \newenvironment{reviewmemo}[1][]{%
   \begin{reviewminicolumn}
-  \reviewminicolumntitle{#1}
+  \reviewminicolumntitle{#1}{\review@intn@memohead}
 }{\end{reviewminicolumn}}
 \newenvironment{reviewtip}[1][]{%
   \begin{reviewminicolumn}
-  \reviewminicolumntitle{#1}
+  \reviewminicolumntitle{#1}{\review@intn@tiphead}
 }{\end{reviewminicolumn}}
 \newenvironment{reviewinfo}[1][]{%
   \begin{reviewminicolumn}
-  \reviewminicolumntitle{#1}
+  \reviewminicolumntitle{#1}{\review@intn@infohead}
 }{\end{reviewminicolumn}}
 \newenvironment{reviewwarning}[1][]{%
   \begin{reviewminicolumn}
-  \reviewminicolumntitle{#1}
+  \reviewminicolumntitle{#1}{\review@intn@warninghead}
 }{\end{reviewminicolumn}}
 \newenvironment{reviewimportant}[1][]{%
   \begin{reviewminicolumn}
-  \reviewminicolumntitle{#1}
+  \reviewminicolumntitle{#1}{\review@intn@importanthead}
 }{\end{reviewminicolumn}}
 \newenvironment{reviewcaution}[1][]{%
   \begin{reviewminicolumn}
-  \reviewminicolumntitle{#1}
+  \reviewminicolumntitle{#1}{\review@intn@cautionhead}
 }{\end{reviewminicolumn}}
 \newenvironment{reviewnotice}[1][]{%
   \begin{reviewminicolumn}
-  \reviewminicolumntitle{#1}
+  \reviewminicolumntitle{#1}{\review@intn@noticehead}
 }{\end{reviewminicolumn}}
 
 \DeclareRobustCommand{\reviewkw}[1]{\textbf{\textgt{#1}}}

--- a/test/assets/test_template.tex
+++ b/test/assets/test_template.tex
@@ -22,7 +22,14 @@
 \def\review@intn@table{表}
 \def\review@intn@equation{式}
 \def\review@intn@columnname{コラム}
-\def\review@intn@memohead{■メモ}
+\def\review@intn@notehead{NOTE}
+\def\review@intn@tiphead{TIP}
+\def\review@intn@infohead{INFORMATION}
+\def\review@intn@warninghead{WARNING}
+\def\review@intn@importanthead{IMPORTANT}
+\def\review@intn@cautionhead{CAUTION}
+\def\review@intn@noticehead{NOTICE}
+\def\review@intn@memohead{MEMO}
 \def\review@intn@edition{版}
 \def\review@intn@publishedby{ 発行}
 \def\review@intn@captionprefix{ }

--- a/test/assets/test_template_backmatter.tex
+++ b/test/assets/test_template_backmatter.tex
@@ -22,7 +22,14 @@
 \def\review@intn@table{表}
 \def\review@intn@equation{式}
 \def\review@intn@columnname{コラム}
-\def\review@intn@memohead{■メモ}
+\def\review@intn@notehead{NOTE}
+\def\review@intn@tiphead{TIP}
+\def\review@intn@infohead{INFORMATION}
+\def\review@intn@warninghead{WARNING}
+\def\review@intn@importanthead{IMPORTANT}
+\def\review@intn@cautionhead{CAUTION}
+\def\review@intn@noticehead{NOTICE}
+\def\review@intn@memohead{MEMO}
 \def\review@intn@edition{版}
 \def\review@intn@publishedby{ 発行}
 \def\review@intn@captionprefix{ }


### PR DESCRIPTION
#1843 の対応です。

- i18n.ymlで、memo_headだけでなく、note_head,tip_head,info_head,warning_head,important_head,caution_head,notice_head, memo_head と個別に定義するようにした。
- review-jsbookにおける見出しの■はreview-baseスタイル側で入れるようにした。
- 各ヘッド文字に適切な日本語というのを決めにくいので英語大文字にした。

古い環境への影響
- i18n.ymlのmemo_headラベルで「■」を入れなくなっているのと「メモ」ではなく「MEMO」にしたので、locale.ymlを使ってmemo_headを昔のものに再定義(`memo_head: ■メモ`)する必要がある。
- review-jlreqにおいてreviewnoteなどで直に「NOTE」のように書いていたのをやめたり全大文字にしたりしているため、昔のものと完全一致させるにはlocale.ymlで再定義する必要がある。
- この機能を使っているのはLaTeX PDFMakerのみであり、EPUB等には影響しない。