### PR TITLE
use \par\vspace\par instead of vspace* for //blankline

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -1038,7 +1038,7 @@ module ReVIEW
     end
 
     def blankline
-      puts '\vspace*{\baselineskip}'
+      puts '\par\vspace{\baselineskip}\par'
     end
 
     def noindent

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1087,7 +1087,7 @@ EOS
   def test_blankline
     actual = compile_block("//blankline\nfoo\n")
     expected = <<-EOS
-\\vspace*{\\baselineskip}
+\\par\\vspace{\\baselineskip}\\par
 
 foo
 EOS

--- a/test/test_latexbuilder_v2.rb
+++ b/test/test_latexbuilder_v2.rb
@@ -707,7 +707,7 @@ EOS
   def test_blankline
     actual = compile_block("//blankline\nfoo\n")
     expected = <<-EOS
-\\vspace*{\\baselineskip}
+\\par\\vspace{\\baselineskip}\\par
 
 foo
 EOS


### PR DESCRIPTION
#1872 の修正です。
//blankline手前で改ページになったときに0になるよう、vspace*ではなくvspaceにします。

```
//blankline

//noindent
あ
```
のようなケースでつながってしまうことがあったため、`\par`で確実に改段するようにしました。

