### PR TITLE
add the link to cover as first item in toc.html

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ Exception:
 
 ## Copyright
 
-Copyright (c) 2006-2022 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
+Copyright (c) 2006-2023 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.

--- a/lib/review/epubmaker/epubcommon.rb
+++ b/lib/review/epubmaker/epubcommon.rb
@@ -231,6 +231,10 @@ module ReVIEW
         ReVIEW::Template.generate(path: template_name, binding: binding)
       end
 
+      def coveritem
+        []
+      end
+
       def hierarchy_ncx(type)
         require 'rexml/document'
         level = 1
@@ -264,7 +268,7 @@ module ReVIEW
         doc.context[:attribute_quote] = :quote
 
         e = doc.root.elements[1] # first <li/>
-        contents.each do |item|
+        (coveritem + contents).each do |item|
           next if !item.notoc.nil? || item.level.nil? || item.file.nil? || item.title.nil? || item.level > toclevel
 
           if item.level == level
@@ -304,7 +308,7 @@ module ReVIEW
 
       def flat_ncx(type, indent = nil)
         s = %Q(<#{type} class="toc-h1">\n)
-        contents.each do |item|
+        (coveritem + contents).each do |item|
           next if !item.notoc.nil? || item.level.nil? || item.file.nil? || item.title.nil? || item.level > config['toclevel'].to_i
 
           is = indent == true ? '　' * item.level : ''
@@ -324,10 +328,12 @@ module ReVIEW
         FileUtils.mkdir_p("#{tmpdir}/OEBPS")
         File.write(File.join(tmpdir, opf_path), opf)
 
-        if File.exist?("#{basedir}/#{config['cover']}")
-          FileUtils.cp("#{basedir}/#{config['cover']}", "#{tmpdir}/OEBPS")
-        else
-          File.write("#{tmpdir}/OEBPS/#{config['cover']}", cover)
+        if config['cover']
+          if File.exist?("#{basedir}/#{config['cover']}")
+            FileUtils.cp("#{basedir}/#{config['cover']}", "#{tmpdir}/OEBPS")
+          else
+            File.write("#{tmpdir}/OEBPS/#{config['cover']}", cover)
+          end
         end
 
         if config['colophon'] && !config['colophon'].is_a?(String)

--- a/lib/review/epubmaker/epubcommon.rb
+++ b/lib/review/epubmaker/epubcommon.rb
@@ -1,6 +1,6 @@
 # = epubcommon.rb -- super class for EPUBv2 and EPUBv3
 #
-# Copyright (c) 2010-2022 Kenshi Muto and Masayoshi Takahashi
+# Copyright (c) 2010-2023 Kenshi Muto and Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of

--- a/lib/review/epubmaker/epubv3.rb
+++ b/lib/review/epubmaker/epubv3.rb
@@ -1,6 +1,6 @@
 # = epubv3.rb -- EPUB version 3 producer.
 #
-# Copyright (c) 2010-2022 Kenshi Muto
+# Copyright (c) 2010-2023 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of

--- a/lib/review/epubmaker/epubv3.rb
+++ b/lib/review/epubmaker/epubv3.rb
@@ -213,6 +213,14 @@ module ReVIEW
         ReVIEW::Template.generate(path: template_name, binding: binding)
       end
 
+      def coveritem
+        if config['cover']
+          [Content.new(file: config['cover'], title: ReVIEW::I18n.t('covertitle'), level: 1, chaptype: 'cover')]
+        else
+          []
+        end
+      end
+
       # Produce EPUB file +epubfile+.
       # +work_dir+ points the directory has contents.
       # +tmpdir+ defines temporary directory.

--- a/templates/opf/epubv2.opf.erb
+++ b/templates/opf/epubv2.opf.erb
@@ -7,7 +7,9 @@
 <%= @opf_manifest %>
 <%= @opf_toc %>
   <guide>
+<% if @config['cover'].present? %>
     <reference type="cover" title="<%= ReVIEW::I18n.t('covertitle') %>" href="<%= @config['cover'] %>"/>
+<% end %>
 <% if @config['titlepage'].present? %>
     <reference type="title-page" title="<%= ReVIEW::I18n.t('titlepagetitle') %>" href="titlepage.<%= @config['htmlext'] %>"/>
 <% end %>

--- a/templates/opf/epubv3.opf.erb
+++ b/templates/opf/epubv3.opf.erb
@@ -7,7 +7,9 @@
 <%= @opf_manifest %>
 <%= @opf_toc %>
   <guide>
+<% if @config['cover'].present? %>
     <reference type="cover" title="<%= ReVIEW::I18n.t('covertitle') %>" href="<%= @config['cover'] %>"/>
+<% end %>
 <% if @config["titlepage"].present? %>
     <reference type="title-page" title="<%= ReVIEW::I18n.t('titlepagetitle') %>" href="titlepage.<%= @config['htmlext'] %>"/>
 <% end %>

--- a/templates/opf/opf_manifest_epubv2.opf.erb
+++ b/templates/opf/opf_manifest_epubv2.opf.erb
@@ -1,6 +1,8 @@
   <manifest>
     <item id="ncx" href="<%= @config['bookname'] %>.ncx" media-type="application/x-dtbncx+xml"/>
+<% if @config['cover'] %>
     <item id="<%= @config['bookname'] %>" href="<%= @config['cover'] %>" media-type="application/xhtml+xml"/>
+<% end %>
 <% if @config['toc'] && @config['mytoc'] %>
     <item id="toc" href="<%= @config['bookname'] %>-toc.<%= @config['htmlext'] %>" media-type="application/xhtml+xml"/>
 <% end %>

--- a/templates/opf/opf_manifest_epubv3.opf.erb
+++ b/templates/opf/opf_manifest_epubv3.opf.erb
@@ -1,6 +1,8 @@
   <manifest>
     <item properties="nav" id="<%= @config['bookname'] %>-toc.<%= @config['htmlext'] %>" href="<%= @config['bookname'] %>-toc.<%= @config['htmlext'] %>" media-type="application/xhtml+xml"/>
+<% if @config['cover'] %>
     <item id="<%= @config['bookname'] %>" href="<%= @config['cover'] %>" media-type="application/xhtml+xml"/>
+<% end %>
 <% if @coverimage %>
     <item properties="cover-image" id="cover-<%= @coverimage.id %>" href="<%= @coverimage.file %>" media-type="<%= @coverimage.media %>"/>
 <% end %>

--- a/templates/opf/opf_tocx_epubv3.opf.erb
+++ b/templates/opf/opf_tocx_epubv3.opf.erb
@@ -3,7 +3,9 @@
 <% else %>
   <spine>
 <% end %>
+<% if @config['cover'].present? %>
     <itemref idref="<%= @config['bookname'] %>" linear="<%= @cover_linear %>"/>
+<% end %>
 <% toc = nil %>
 <% @tocx_contents.each do |item| %>
 <%   if toc.nil? && item.chaptype != 'pre' %>

--- a/test/test_epub3maker.rb
+++ b/test/test_epub3maker.rb
@@ -174,11 +174,20 @@ EOT
   <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
   <h1 class="toc-title">Table of Contents</h1>
 
-<ol class="toc-h1"></ol>  </nav>
+<ol class="toc-h1"><li><a href="sample.html">Cover</a></li>
+</ol>  </nav>
 </body>
 </html>
 EOT
     assert_equal expect, output
+
+    @producer.config['cover'] = 'mycover.html'
+    output = @producer.instance_eval { @epub.ncx([]) }
+    assert_equal expect.sub('sample.html', 'mycover.html'), output
+
+    @producer.config['cover'] = nil
+    output = @producer.instance_eval { @epub.ncx([]) }
+    assert_equal expect.sub(%Q(<li><a href="sample.html">Cover</a></li>\n), ''), output
   end
 
   def stage2
@@ -243,7 +252,8 @@ EOT
   <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
   <h1 class="toc-title">Table of Contents</h1>
 
-<ol class="toc-h1"><li><a href="ch01.html">CH01</a></li>
+<ol class="toc-h1"><li><a href="sample.html">Cover</a></li>
+<li><a href="ch01.html">CH01</a></li>
 </ol>  </nav>
 </body>
 </html>
@@ -361,7 +371,8 @@ EOT
   <nav xmlns:epub="http://www.idpf.org/2007/ops" epub:type="toc" id="toc">
   <h1 class="toc-title">Table of Contents</h1>
 
-<ol class="toc-h1"><li><a href="ch01.html">CH01&lt;&gt;&amp;&quot;</a></li>
+<ol class="toc-h1"><li><a href="sample.html">Cover</a></li>
+<li><a href="ch01.html">CH01&lt;&gt;&amp;&quot;</a></li>
 <li><a href="ch02.html">CH02</a>
 <ol class="toc-h2"><li><a href="ch02.html#S1">CH02.1</a></li>
 <li><a href="ch02.html#S2">CH02.2</a></li>
@@ -393,7 +404,8 @@ EOT
 <body>
   <h1 class="toc-title">Table of Contents</h1>
 
-<ul class="toc-h1"><li><a href="ch01.html">CH01&lt;&gt;&amp;&quot;</a></li>
+<ul class="toc-h1"><li><a href="sample.html">Cover</a></li>
+<li><a href="ch01.html">CH01&lt;&gt;&amp;&quot;</a></li>
 <li><a href="ch02.html">CH02</a>
 <ul class="toc-h2"><li><a href="ch02.html#S1">CH02.1</a></li>
 <li><a href="ch02.html#S2">CH02.2</a></li>
@@ -428,6 +440,7 @@ EOT
 <body>
   <h1 class="toc-title">Table of Contents</h1>
 <ul class="toc-h1">
+<li><a href="sample.html">Cover</a></li>
 <li><a href="ch01.html">CH01&lt;&gt;&amp;&quot;</a></li>
 <li><a href="ch02.html">CH02</a></li>
 <li><a href="ch02.html#S1">CH02.1</a></li>


### PR DESCRIPTION
#1874 の対応です。

- EPUBcheckで明示リンク参照されないnon-linearコンテンツがエラーとされるようになったため、EPUB3において、表紙へのリンクを目次の最初に入れるようにします。
- coverパラメータをnilにしたときに諸々エラーになるので手当てしました。
- EPUB2については何もしません。

(EPUB2まわりをやめて作り直したほうがいいのではという気もありますが…)
