### PR TITLE
escape < and > in MathJax

### DIFF
--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -656,7 +656,7 @@ module ReVIEW
         p = MathML::LaTeX::Parser.new(symbol: MathML::Symbol::CharacterReference)
         print p.parse(lines.join("\n") + "\n", true)
       elsif @book.config['math_format'] == 'mathjax'
-        puts "$$#{lines.join("\n")}$$"
+        puts "$$#{lines.join("\n").gsub('<', '\lt{}').gsub('>', '\gt{}')}$$"
       elsif @book.config['math_format'] == 'imgmath'
         fontsize = @book.config['imgmath_options']['fontsize'].to_f
         lineheight = @book.config['imgmath_options']['lineheight'].to_f
@@ -1051,7 +1051,7 @@ EOS
         parser = MathML::LaTeX::Parser.new(symbol: MathML::Symbol::CharacterReference)
         %Q(<span class="equation">#{parser.parse(str, nil)}</span>)
       elsif @book.config['math_format'] == 'mathjax'
-        %Q(<span class="equation">\\( #{str} \\)</span>)
+        %Q(<span class="equation">\\( #{str.gsub('<', '\lt{}').gsub('>', '\gt{}')} \\)</span>)
       elsif @book.config['math_format'] == 'imgmath'
         math_str = '$' + str + '$'
         key = Digest::SHA256.hexdigest(str)

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -451,6 +451,9 @@ EOS
     actual = compile_inline('@<m>{\\frac{-b \\pm \\sqrt{b^2 - 4ac\\}\\}{2a\\}}')
     assert_equal %Q(<span class="equation">\\( \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a} \\)</span>), actual
 
+    actual = compile_inline('@<m>{a < b, b > c, a < b > c}')
+    assert_equal %Q(<span class="equation">\\( a \\lt{} b, b \\gt{} c, a \\lt{} b \\gt{} c \\)</span>), actual
+
     content = <<-EOF
 //texequation{
 \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}
@@ -458,6 +461,17 @@ EOS
 EOF
     actual = compile_block(content)
     expected = %Q(<div class="equation">\n$$\\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$\n</div>\n)
+    assert_equal expected, actual
+
+    content = <<-EOF
+//texequation{
+\\begin{aligned}
+a < b & b > c & a < b > c
+\\end{aligned}
+//}
+EOF
+    actual = compile_block(content)
+    expected = %Q(<div class="equation">\n$$\\begin{aligned}\na \\lt{} b & b \\gt{} c & a \\lt{} b \\gt{} c\n\\end{aligned}$$\n</div>\n)
     assert_equal expected, actual
   end
 


### PR DESCRIPTION
MathJaxで`<`と`>`はHTMLで困るので、`\lt`, `\gt`という代替名にする必要がありました。
