### PR TITLE
use '0.0.0.0' as default for Windows on review-init wizard mode

### DIFF
--- a/lib/review/init.rb
+++ b/lib/review/init.rb
@@ -61,7 +61,7 @@ module ReVIEW
 
     def parse_options(args)
       @port = 18000
-      @bind = '0'
+      @bind = '0.0.0.0'
 
       opts = OptionParser.new
       opts.version = ReVIEW::VERSION

--- a/lib/review/init.rb
+++ b/lib/review/init.rb
@@ -97,7 +97,7 @@ module ReVIEW
       opts.on('', '--port port', 'port to use for Web based layout configuration. (default: 18000)') do |port|
         @port = port
       end
-      opts.on('', '--bind bindaddress', 'address to use for Web based layout configuration. (default: 0 (any))') do |bind|
+      opts.on('', '--bind bindaddress', 'address to use for Web based layout configuration. (default: 0.0.0.0 (any))') do |bind|
         @bind = bind
       end
 
@@ -321,7 +321,7 @@ EOS
         AccessLog: [[File.open(IO::NULL, 'w'), '']]
       }
 
-      bind_address = (@bind == '0') ? '<thishost>' : @bind
+      bind_address = (@bind == '0.0.0.0') ? '<thishost>' : @bind
       puts "Please access http://#{bind_address}:#{web_config[:Port]} from Web browser."
       begin
         @web_server = WEBrick::HTTPServer.new(web_config)


### PR DESCRIPTION
#1824 の対応です
WEBrickで`0`でのIPバインドはWindowsのみダメだったので、どっちにしろデフォルトはIPv4でよかろう前提で`0.0.0.0`とします。
