### PR TITLE
introduce Mermaid to //graph. It works only on HTMLBuilder

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -699,6 +699,10 @@ EOTGNUPLOT
       file_path
     end
 
+    def graph_mermaid(_id, _file_path, _line, _tf_path)
+      app_error "#{@location}: could not handle Mermaid of //graph in this builder at this time"
+    end
+
     def image_ext
       raise NotImplementedError
     end

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 Kenshi Muto
+# Copyright (c) 2018-2023 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -721,6 +721,14 @@ module ReVIEW
 
     def nofunc_text(str)
       str
+    end
+
+    def graph_mermaid(_id, file_path, _line, _tf_path)
+      file_path
+    end
+
+    def image_ext
+      'png'
     end
 
     alias_method :th, :nofunc_text

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -596,5 +596,9 @@ module ReVIEW
     def circle_begin(_level, _label, caption)
       puts "・\t#{caption}"
     end
+
+    def graph_mermaid(_id, _file_path, _line, _tf_path)
+      app_error "#{@location}: could not handle Mermaid of //graph in this builder at this time"
+    end
   end
 end # module ReVIEW

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -3326,4 +3326,24 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    actual = compile_block("//graph[id][mermaid]{\n<->\n//}")
+    expected = <<-EOS
+<div id="id" class="image">
+<pre class="mermaid">
+<->
+</pre>
+<p class="caption">
+図1.1: 
+</p>
+</div>
+EOS
+    assert_equal expected, actual
+  end
 end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -1526,4 +1526,14 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
+    assert_match(/not handle Mermaid/, e.message)
+  end
 end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -2969,4 +2969,14 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
+    assert_match(/not handle Mermaid/, e.message)
+  end
 end

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -368,4 +368,14 @@ EOS
     actual = compile_block('@<ruby>{謳,うた}い文句')
     assert_equal "<ruby>謳<rp>（</rp><rt>うた</rt><rp>）</rp></ruby>い文句\n\n", actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
+    assert_match(/not handle Mermaid/, e.message)
+  end
 end

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -1211,4 +1211,18 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    actual = compile_block("//graph[id][mermaid]{\n<->\n//}")
+    expected = <<-EOS
+図1.1　
+
+EOS
+    assert_equal expected, actual
+  end
 end

--- a/test/test_rstbuilder.rb
+++ b/test/test_rstbuilder.rb
@@ -616,4 +616,14 @@ EOS
 
     assert_equal expected, column_helper(review)
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
+    assert_match(/not handle Mermaid/, e.message)
+  end
 end

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -1298,4 +1298,14 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
+    assert_match(/not handle Mermaid/, e.message)
+  end
 end


### PR DESCRIPTION
今はやりのMermaidの対処の第一弾です。

`//graph[ID][mermaid][CAPTION]` のときにmermaidコード記述を許容します。

ブラウザjsがないとレンダリングできないので、ひとまず現時点ではHTMLBuilderのみで動作します。
EPUBでは動かないし、Vivliostyle CLIでもタイミングの問題なのかダメなので、現状では実質webのみの動作となります。
スキップして先に進めるのが難しいので、ほかのビルダでは即時アプリケーションエラーとしています。
