### PR TITLE
Mermaidの変換実装

### DIFF
--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -262,6 +262,15 @@ toc: true
 # 追加する<meta>要素のプロパティとその値
 # opf_meta: {"ebpaj:guide-version": "1.1.3"}
 
+# Playwrightの利用オプション
+# playwright:
+  # playwrightコマンドのパス
+  # playwright_path: "./node_modules/.bin/playwright"
+  # pdfcropコマンドのパス
+  # pdfcrop_path: "pdfcrop"
+  # pdftocairoコマンドのパス
+  # pdftocairo_path: "pdftocairo"
+
 # 以下のパラメータを有効にするときには、
 # epubmaker:
 #    パラメータ: 値

--- a/lib/review/book/image_finder.rb
+++ b/lib/review/book/image_finder.rb
@@ -36,7 +36,7 @@ module ReVIEW
           @exts.each do |ext|
             @entries.find do |entry|
               downname = entry.sub(/\.[^.]+$/, File.extname(entry).downcase)
-              if downname == "#{target}#{ext}"
+              if downname == "#{target}#{ext}" || File.absolute_path(downname) == File.absolute_path("#{target}#{ext}")
                 return entry
               end
             end

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -699,6 +699,10 @@ EOTGNUPLOT
       file_path
     end
 
+    def graph_mermaid(_id, _file_path, _line, _tf_path)
+      app_error "#{@location}: could not handle Mermaid of //graph in this builder at this time"
+    end
+
     def image_ext
       raise NotImplementedError
     end

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -11,6 +11,7 @@ require 'review/textutils'
 require 'review/compiler'
 require 'review/sec_counter'
 require 'review/img_math'
+require 'review/img_graph'
 require 'review/loggable'
 require 'stringio'
 require 'fileutils'
@@ -35,13 +36,14 @@ module ReVIEW
     attr_accessor :doc_status
     attr_reader :location
 
-    def initialize(strict = false, *_args, img_math: nil)
+    def initialize(strict = false, *_args, img_math: nil, img_graph: nil)
       @strict = strict
       @output = nil
       @logger = ReVIEW.logger
       @doc_status = {}
       @dictionary = {}
       @img_math = img_math
+      @img_graph = img_graph
       @shown_endnotes = true
     end
 
@@ -61,6 +63,7 @@ module ReVIEW
       @tsize = nil
       if @book && @book.config
         @img_math ||= ReVIEW::ImgMath.new(@book.config)
+        @img_graph ||= ReVIEW::ImgGraph.new(@book.config, target_name)
         if words_file_path = @book.config['words_file']
           words_files = if words_file_path.is_a?(String)
                           [words_file_path]
@@ -699,8 +702,18 @@ EOTGNUPLOT
       file_path
     end
 
-    def graph_mermaid(_id, _file_path, _line, _tf_path)
-      app_error "#{@location}: could not handle Mermaid of //graph in this builder at this time"
+    def graph_mermaid_impl(id, _file_path, _line, tf_path)
+      begin
+        require 'playwrightrunner'
+      rescue LoadError
+        app_error "#{@location}: could not handle Mermaid of //graph in this builder."
+      end
+
+      @img_graph.defer_mermaid_image(File.read(tf_path), id)
+    end
+
+    def graph_mermaid(id, file_path, line, tf_path)
+      graph_mermaid_impl(id, file_path, line, tf_path)
     end
 
     def image_ext

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -68,6 +68,12 @@ module ReVIEW
         'externallink' => true,
         'join_lines_by_lang' => nil, # experimental. default should be nil
         'table_row_separator' => 'tabs',
+        # for Playwright
+        'playwright_options' => {
+          'playwright_path' => './node_modules/.bin/playwright',
+          'pdfcrop_path' => 'pdfcrop',
+          'pdftocairo_path' => 'pdftocairo'
+        },
         # for IDGXML
         'tableopt' => nil,
         'listinfo' => nil,

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -53,7 +53,6 @@ module ReVIEW
       @toc = nil
       @javascripts = []
       @section_stack = []
-      @use_graph_mermaid = nil
 
       maker = @book.config.maker || 'epubmaker' # for review-compile
       @use_section = @book.config[maker] && @book.config[maker]['use_section']
@@ -136,10 +135,6 @@ module ReVIEW
       if @book.config['math_format'] == 'mathjax'
         @javascripts.push(%Q(<script>MathJax = { tex: { inlineMath: [['\\\\(', '\\\\)']] }, svg: { fontCache: 'global' } };</script>))
         @javascripts.push(%Q(<script type="text/javascript" id="MathJax-script" async="true" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>))
-      end
-
-      if @use_graph_mermaid
-        @javascripts.push(%Q(<script type="module">import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.esm.min.mjs'; mermaid.initialize({ startOnLoad: true });</script>))
       end
 
       ReVIEW::Template.load(layoutfile).result(binding)
@@ -1097,15 +1092,6 @@ EOS
 
     def bibpaper_bibpaper(_id, _caption, lines)
       print split_paragraph(lines).join
-    end
-
-    def graph_mermaid(_id, file_path, line, _tf_path)
-      @use_graph_mermaid = true
-      @text_image = <<EOT
-<pre class="mermaid">
-#{line}</pre>
-EOT
-      file_path
     end
 
     def inline_bib(id)

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2018-2022 Kenshi Muto
+# Copyright (c) 2018-2023 Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -721,6 +721,14 @@ module ReVIEW
 
     def nofunc_text(str)
       str
+    end
+
+    def graph_mermaid(_id, file_path, _line, _tf_path)
+      file_path
+    end
+
+    def image_ext
+      'png'
     end
 
     alias_method :th, :nofunc_text

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -596,5 +596,9 @@ module ReVIEW
     def circle_begin(_level, _label, caption)
       puts "・\t#{caption}"
     end
+
+    def graph_mermaid(_id, _file_path, _line, _tf_path)
+      app_error "#{@location}: could not handle Mermaid of //graph in this builder at this time"
+    end
   end
 end # module ReVIEW

--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -597,8 +597,8 @@ module ReVIEW
       puts "・\t#{caption}"
     end
 
-    def graph_mermaid(_id, _file_path, _line, _tf_path)
-      app_error "#{@location}: could not handle Mermaid of //graph in this builder at this time"
+    def graph_mermaid(id, file_path, line, tf_path)
+      graph_mermaid_impl(id, file_path, line, tf_path)
     end
   end
 end # module ReVIEW

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -3330,17 +3330,22 @@ EOS
   def test_graph_mermaid
     def @chapter.image(_id)
       item = Book::Index::Item.new('id', 1, 'id')
-      item.instance_eval { @path = './images/id.png' }
+      item.instance_eval { @path = './images/html/id.svg' }
       item
     end
-    actual = compile_block("//graph[id][mermaid]{\n<->\n//}")
+
+    begin
+      require 'playwrightrunner'
+    rescue LoadError
+      return true
+    end
+
+    actual = compile_block("//graph[id][mermaid][foo]{\ngraph LR; B --> C\n//}")
     expected = <<-EOS
 <div id="id" class="image">
-<pre class="mermaid">
-<->
-</pre>
+<img src="images/html/id.svg" alt="foo" />
 <p class="caption">
-図1.1: 
+図1.1: foo
 </p>
 </div>
 EOS

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -3326,4 +3326,24 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    actual = compile_block("//graph[id][mermaid]{\n<->\n//}")
+    expected = <<-EOS
+<div id="id" class="image">
+<pre class="mermaid">
+<->
+</pre>
+<p class="caption">
+図1.1: 
+</p>
+</div>
+EOS
+    assert_equal expected, actual
+  end
 end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -1526,4 +1526,14 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
+    assert_match(/not handle Mermaid/, e.message)
+  end
 end

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -1530,10 +1530,20 @@ EOS
   def test_graph_mermaid
     def @chapter.image(_id)
       item = Book::Index::Item.new('id', 1, 'id')
-      item.instance_eval { @path = './images/id.png' }
+      item.instance_eval { @path = './images/idgxml/id.pdf' }
       item
     end
-    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
-    assert_match(/not handle Mermaid/, e.message)
+
+    begin
+      require 'playwrightrunner'
+    rescue LoadError
+      return true
+    end
+
+    actual = compile_block("//graph[id][mermaid][foo]{\ngraph LR; B --> C\n//}")
+    expected = <<-EOS.chomp
+<img><Image href="file://images/idgxml/id.pdf" /><caption>図1.1　foo</caption></img>
+EOS
+    assert_equal expected, actual
   end
 end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -2973,10 +2973,24 @@ EOS
   def test_graph_mermaid
     def @chapter.image(_id)
       item = Book::Index::Item.new('id', 1, 'id')
-      item.instance_eval { @path = './images/id.png' }
+      item.instance_eval { @path = './images/latex/id.pdf' }
       item
     end
-    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
-    assert_match(/not handle Mermaid/, e.message)
+
+    begin
+      require 'playwrightrunner'
+    rescue LoadError
+      return true
+    end
+
+    actual = compile_block("//graph[id][mermaid][foo]{\ngraph LR; B --> C\n//}")
+    expected = <<-EOS
+\\begin{reviewimage}%%id
+\\reviewincludegraphics[width=\\maxwidth]{./images/latex/id.pdf}
+\\reviewimagecaption{foo}
+\\label{image:chap1:id}
+\\end{reviewimage}
+EOS
+    assert_equal expected, actual
   end
 end

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -2969,4 +2969,14 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
+    assert_match(/not handle Mermaid/, e.message)
+  end
 end

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -372,10 +372,22 @@ EOS
   def test_graph_mermaid
     def @chapter.image(_id)
       item = Book::Index::Item.new('id', 1, 'id')
-      item.instance_eval { @path = './images/id.png' }
+      item.instance_eval { @path = './images/markdown/id.svg' }
       item
     end
-    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
-    assert_match(/not handle Mermaid/, e.message)
+
+    begin
+      require 'playwrightrunner'
+    rescue LoadError
+      return true
+    end
+
+    actual = compile_block("//graph[id][mermaid][foo]{\ngraph LR; B --> C\n//}")
+    expected = <<-EOS
+
+![foo](images/markdown/id.svg)
+
+EOS
+    assert_equal expected, actual
   end
 end

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -368,4 +368,14 @@ EOS
     actual = compile_block('@<ruby>{謳,うた}い文句')
     assert_equal "<ruby>謳<rp>（</rp><rt>うた</rt><rp>）</rp></ruby>い文句\n\n", actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
+    assert_match(/not handle Mermaid/, e.message)
+  end
 end

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -1211,4 +1211,18 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    actual = compile_block("//graph[id][mermaid]{\n<->\n//}")
+    expected = <<-EOS
+図1.1　
+
+EOS
+    assert_equal expected, actual
+  end
 end

--- a/test/test_rstbuilder.rb
+++ b/test/test_rstbuilder.rb
@@ -620,10 +620,25 @@ EOS
   def test_graph_mermaid
     def @chapter.image(_id)
       item = Book::Index::Item.new('id', 1, 'id')
-      item.instance_eval { @path = './images/id.png' }
+      item.instance_eval { @path = './images/rst/id.pdf' }
       item
     end
-    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
-    assert_match(/not handle Mermaid/, e.message)
+
+    begin
+      require 'playwrightrunner'
+    rescue LoadError
+      return true
+    end
+
+    actual = compile_block("//graph[id][mermaid][foo]{\ngraph LR; B --> C\n//}")
+    expected = <<-EOS
+.. _id:
+
+.. figure:: images/-/id.png
+
+   foo
+
+EOS
+    assert_equal expected, actual
   end
 end

--- a/test/test_rstbuilder.rb
+++ b/test/test_rstbuilder.rb
@@ -616,4 +616,14 @@ EOS
 
     assert_equal expected, column_helper(review)
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
+    assert_match(/not handle Mermaid/, e.message)
+  end
 end

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -1302,10 +1302,25 @@ EOS
   def test_graph_mermaid
     def @chapter.image(_id)
       item = Book::Index::Item.new('id', 1, 'id')
-      item.instance_eval { @path = './images/id.png' }
+      item.instance_eval { @path = './images/top/id.pdf' }
       item
     end
-    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
-    assert_match(/not handle Mermaid/, e.message)
+
+    begin
+      require 'playwrightrunner'
+    rescue LoadError
+      return true
+    end
+
+    actual = compile_block("//graph[id][mermaid][foo]{\ngraph LR; B --> C\n//}")
+    expected = <<-EOS
+◆→開始:図←◆
+◆→./images/top/id.pdf←◆
+
+図1.1　foo
+◆→終了:図←◆
+
+EOS
+    assert_equal expected, actual
   end
 end

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -1298,4 +1298,14 @@ EOS
     actual = compile_block(src)
     assert_equal expected, actual
   end
+
+  def test_graph_mermaid
+    def @chapter.image(_id)
+      item = Book::Index::Item.new('id', 1, 'id')
+      item.instance_eval { @path = './images/id.png' }
+      item
+    end
+    e = assert_raises(ReVIEW::ApplicationError) { compile_block("//graph[id][mermaid]{\n<->\n//}") }
+    assert_match(/not handle Mermaid/, e.message)
+  end
 end


### PR DESCRIPTION
#1884 で仮実装をしていましたが、Playwrightを呼び出すplaywright-runner.gem https://rubygems.org/gems/playwright-runner を作ったので、これがあったときに各ビルダで使うようにしました。

- `//graph[ID][mermaid][CAPTION]` あるいは `//graph[ID][mermaid]` でMermaidコードが利用できます。
- Playwrightのchromiumを使い、makerの最後でPDFまたはSVGへのまとまったビルドを行います。`images/<ビルダ>/<ID>.拡張子` のファイルができます。
- playwright-runnerのmermaids_to_images自体が、playwright npm + pdfcrop (TeXLive) + pdftocairo (poppler) を必要とします。実質的にLinux専用となりそうです。 
- playwright-runnerライブラリがない場合にmermaid graphを使用したときには、単に強制終了エラーになります。
- image_finderの変更は、latexとほかとのbasedirの扱いの違いによるものです…根本にリファクタリングしたほうが必要そう。