### PR TITLE
improve image_finder speed by skipping mismatch label

### DIFF
--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -73,7 +73,7 @@ module ReVIEW
       end
 
       def imagedir
-        File.join(@basedir, config['imagedir'])
+        config['imagedir']
       end
 
       def image_types

--- a/lib/review/book/image_finder.rb
+++ b/lib/review/book/image_finder.rb
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2014-2018 Minero Aoki, Kenshi Muto, Masayoshi Takahashi
+# Copyright (c) 2014-2023 Minero Aoki, Kenshi Muto, Masayoshi Takahashi
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -13,35 +13,50 @@ require 'review/exception'
 module ReVIEW
   module Book
     class ImageFinder
-      def initialize(basedir, chapid, builder, exts)
-        @basedir = basedir
-        @chapid = chapid
-        @builder = builder
-        @exts = exts
-        @entries = dir_entries
+      def initialize(chapter)
+        @book = chapter.book
+        @basedir = @book.imagedir
+        @chapid = chapter.id
+        @builder = @book.config['builder']
+        @entries = dir_entries.map { |path| entry_object(path) }
+      end
+
+      def entry_object(path)
+        { path: path, basename: path.sub(/\.[^.]+$/, ''), downcase: path.sub(/\.[^.]+$/, $&.downcase) }
       end
 
       def dir_entries
-        Dir.glob(File.join(@basedir, '**{,/*/**}/*.*')).uniq.sort
+        Dir.glob(File.join(@basedir, '**{,/*/**}/*.*')).uniq.sort.map { |entry| entry.sub(%r{^\./}, '') }
       end
 
       def add_entry(path)
-        @entries << path unless @entries.include?(path)
+        path.sub!(%r{^\./}, '')
+        unless @entries.find { |entry| entry[:path] == path }
+          @entries << entry_object(path)
+        end
         @entries
       end
 
       def find_path(id)
         targets = target_list(id)
         targets.each do |target|
-          @exts.each do |ext|
-            @entries.find do |entry|
-              downname = entry.sub(/\.[^.]+$/, File.extname(entry).downcase)
-              if downname == "#{target}#{ext}" || File.absolute_path(downname) == File.absolute_path("#{target}#{ext}")
-                return entry
+          @book.image_types.each do |ext|
+            entries = @entries.select do |entry|
+              entry[:basename] == target
+            end
+
+            unless entries
+              break
+            end
+
+            entries.find do |entry|
+              if entry[:downcase] == "#{target}#{ext}"
+                return entry[:path]
               end
             end
           end
         end
+
         nil
       end
 

--- a/lib/review/book/index.rb
+++ b/lib/review/book/index.rb
@@ -138,14 +138,7 @@ module ReVIEW
       def initialize(chapter)
         super()
         @chapter = chapter
-        book = @chapter.book
-
-        chapid = chapter.id
-        basedir = book.imagedir
-        builder = book.config['builder']
-        types = book.image_types
-
-        @image_finder = ReVIEW::Book::ImageFinder.new(basedir, chapid, builder, types)
+        @image_finder = ReVIEW::Book::ImageFinder.new(@chapter)
       end
 
       def find_path(id)

--- a/test/test_image_finder.rb
+++ b/test/test_image_finder.rb
@@ -20,12 +20,17 @@ class ImageFinderTest < Test::Unit::TestCase
     end
   end
 
+  def finder
+    book = Book::Base.new(@dir, config: { 'builder' => 'builder', 'imagedir' => @dir })
+    book.image_types = ['.jpg']
+    ch = Book::Chapter.new(book, 1, 'ch01', nil)
+    ReVIEW::Book::ImageFinder.new(ch)
+  end
+
   def test_find_path_pattern1
     path = File.join(@dir, 'builder/ch01/foo.jpg')
     FileUtils.mkdir_p(File.dirname(path))
     FileUtils.touch(path)
-
-    finder = ReVIEW::Book::ImageFinder.new(@dir, 'ch01', 'builder', ['.jpg'])
 
     assert_equal(path, finder.find_path('foo'))
   end
@@ -35,7 +40,6 @@ class ImageFinderTest < Test::Unit::TestCase
     FileUtils.mkdir_p(File.dirname(path))
     FileUtils.touch(path)
 
-    finder = ReVIEW::Book::ImageFinder.new(@dir, 'ch01', 'builder', ['.jpg'])
     assert_equal(path, finder.find_path('foo'))
   end
 
@@ -44,7 +48,6 @@ class ImageFinderTest < Test::Unit::TestCase
     FileUtils.mkdir_p(File.dirname(path))
     FileUtils.touch(path)
 
-    finder = ReVIEW::Book::ImageFinder.new(@dir, 'ch01', 'builder', ['.jpg'])
     assert_equal(path, finder.find_path('foo'))
   end
 
@@ -53,7 +56,6 @@ class ImageFinderTest < Test::Unit::TestCase
     FileUtils.mkdir_p(File.dirname(path))
     FileUtils.touch(path)
 
-    finder = ReVIEW::Book::ImageFinder.new(@dir, 'ch01', 'builder', ['.jpg'])
     assert_equal(path, finder.find_path('foo'))
   end
 
@@ -62,7 +64,6 @@ class ImageFinderTest < Test::Unit::TestCase
     FileUtils.mkdir_p(File.dirname(path))
     FileUtils.touch(path)
 
-    finder = ReVIEW::Book::ImageFinder.new(@dir, 'ch01', 'builder', ['.jpg'])
     assert_equal(path, finder.find_path('foo'))
   end
 
@@ -75,7 +76,6 @@ class ImageFinderTest < Test::Unit::TestCase
     path_dstimg = File.join(path_dst, 'foo.jpg')
     FileUtils.touch(path_srcimg)
 
-    finder = ReVIEW::Book::ImageFinder.new(@dir, 'ch01', 'builder', ['.jpg'])
     assert_equal(path_dstimg, finder.find_path('foo'))
   end
 end

--- a/test/test_image_finder.rb
+++ b/test/test_image_finder.rb
@@ -78,4 +78,9 @@ class ImageFinderTest < Test::Unit::TestCase
 
     assert_equal(path_dstimg, finder.find_path('foo'))
   end
+
+  def test_entry_object
+    assert_equal({ basename: 'ch01/Foo', downcase: 'ch01/Foo.jpg', path: 'ch01/Foo.JPG' },
+                 finder.entry_object('ch01/Foo.JPG'))
+  end
 end


### PR DESCRIPTION
#1896 の手当てです。
#1895 もこれで直るかと思います( #1895 自体は入れてよさそうな気はします)。

- base.rb: imagedirメソッドがプロジェクトフォルダ+`config['imagedir']`(つまりimages)を返していたのをやめて、`config['imagedir']`の結果だけを返すようにしました
- image_finder.rb:
  - imagesフォルダを収集したときに、従来の完全なパス(path)のほか、拡張子を除いたもの(basename)、拡張子を小文字にしたもの(downcase)をハッシュで格納するようにしました
  - initializeをChapterオブジェクトをとるだけにしました。Chapterオブジェクトがあれば組み立てられるのと、拡張子候補のextsはinitialize時点ではビルド固有(`builder_init_file`)設定が呼び出されていなくて適切化されていないためです
  - イメージパスの先頭の「./」を除くようにしました。比較のときにここで厄介なことになっていたので…(そのため、厳密には結果互換性は失われます)
  - 発見ロジックで、まず拡張子を除いたパスターゲット(target)に一致するものをまずエントリ一覧から収集し、そもそも存在しなければその瞬間に次のパスターゲット試行にいく、存在したら拡張子試行をしてみる、というようにしました。これにより無駄な試行が大幅に削減されて高速化します。また、これまでinitializeで行っていた拡張子候補取得をここでやる(`@book.image_types`)ようにしたので、ビルダ固有のものが使われるようになりました
- index.rb: image_finder.rbのinitialize変更との同期

#1896 で報告される以前でも2000個くらいの画像を喰わせてみたときには止まってしまっていたのですが、このPRの適用では数秒で解決できています。
ただ、そこそこ広めに影響しそうなパッチなので、一応レビューいただければと思います。