### PR TITLE
EPUBMaker: fix missing `<title>` in autobuilt part

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -327,6 +327,7 @@ module ReVIEW
       File.open(File.join(basetmpdir, htmlfile), 'w') do |f|
         @part_number = part.number
         @part_title = part.name.strip
+        @title = @part_title
         @body = ReVIEW::Template.generate(path: template_name(localfile: '_part_body.html.erb', systemfile: 'html/_part_body.html.erb'), binding: binding)
         @language = @producer.config['language']
         @stylesheets = @producer.config['stylesheet']


### PR DESCRIPTION
reファイルがないときに生成する部HTMLファイルにおいて、`<title>`の値が空になることに気付きました。
(epubcheckで怒られた)
