### PR TITLE
use b5j instead of b5 for JIS size

### DIFF
--- a/samples/syntax-book/config-jlreq.yml
+++ b/samples/syntax-book/config-jlreq.yml
@@ -1,5 +1,5 @@
 # call me by 'REVIEW_TEMPLATE=review-jlreq REVIEW_CONFIG_FILE=config-jlreq.yml rake pdf'
 inherit: ["config.yml"]
-# texdocumentclass: ["review-jlreq", "media=print,paper=b5"]
-texdocumentclass: ["review-jlreq", "media=ebook,paper=b5"]
-# texdocumentclass: ["review-jlreq", "media=print,paper=b5,bleed_margin=3mm,cover=true,Q=14,startpage=3,serial_pagination=true,hiddenfolio=nikko-pc"]
+# texdocumentclass: ["review-jlreq", "media=print,paper=b5j"]
+texdocumentclass: ["review-jlreq", "media=ebook,paper=b5j"]
+# texdocumentclass: ["review-jlreq", "media=print,paper=b5j,bleed_margin=3mm,cover=true,Q=14,startpage=3,serial_pagination=true,hiddenfolio=nikko-pc"]

--- a/templates/latex/review-jlreq/README.md
+++ b/templates/latex/review-jlreq/README.md
@@ -47,7 +47,8 @@ texdocumentclass: ["review-jlreq", "クラスオプションたち（省略可�
 利用可能な特定の用紙サイズを指定できます。［デフォルト］は a5 です。
 
  * `a0` 〜 `a10`：A 列
- * `b0` 〜 `b10`：JIS B 列
+ * `b0j` 〜 `b10j`：JIS B 列
+ * `b0` 〜 `b10`：ISO B 列
  * `c0` 〜 `c8`：C 列
  * `a4var`：210mm x 283mm
  * `b5var`：182mm x 230mm
@@ -56,6 +57,8 @@ texdocumentclass: ["review-jlreq", "クラスオプションたち（省略可�
  * `executive`：エグゼクティブ、7.25in x 10.5in
  * `hagaki`：葉書き、100mm x 148mm
  * `{横幅,縦幅}`：任意の指定サイズ
+
+日本の B 列サイズにするには `b5j` のように j 付きで指定することに注意してください。
 
 ### トンボ用紙サイズ `tombopaper=<用紙サイズ>` および塗り足し幅 `bleed_margin=<幅>`
 

--- a/test/test_img_graph.rb
+++ b/test/test_img_graph.rb
@@ -37,6 +37,7 @@ EOB
     File.write(File.join(@tmpdir, 'package.json'), json)
     Dir.chdir(@tmpdir) do
       system('npm install')
+      system('npx playwright install chromium')
     end
 
     File.join(@tmpdir, 'node_modules', '.bin', 'playwright')


### PR DESCRIPTION
jlreq.clsではb5だとISOサイズになる。b5jを使うようにガイドなどを変更する。
(jsbookではb5のままでOK)
