### PR TITLE
apply rubocop 1.59.0. Drop Ruby 2.7 and add 3.3

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby-tex.yml
+++ b/.github/workflows/ruby-tex.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.2']
+        ruby: ['3.2']
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby-tex.yml
+++ b/.github/workflows/ruby-tex.yml
@@ -14,10 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['3.2']
-        os: [ubuntu-20.04]
+        os: [ubuntu-22.04]
     steps:
     - uses: actions/checkout@v2
-    - name: Install TeXLive 2020 in ubuntu
+    - name: Install TeXLive 2021 in ubuntu
       if: runner.os == 'Linux'
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq texlive-lang-japanese texlive-fonts-recommended texlive-fonts-extra texlive-luatex texlive-extra-utils texlive-latex-extra dvipng poppler-utils

--- a/.github/workflows/ruby-win.yml
+++ b/.github/workflows/ruby-win.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [ '3.2', '3.1', '3.0', '2.7' ]
+        ruby: [ '3.3', '3.2', '3.1', '3.0' ]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2', '3.3']
         os: [ubuntu-latest, macOS-latest]
     steps:
     - uses: actions/checkout@v2

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,7 +5,7 @@ AllCops:
     - tmp/*
   DisplayCopNames: true
   NewCops: enable
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 3.0
 
 require:
   - rubocop-performance
@@ -39,6 +39,9 @@ Performance/CollectionLiteralInLoop:
   Enabled: false
 
 Performance/MapCompact:
+  Enabled: false
+
+Performance/StringIdentifierArgument:
   Enabled: false
 
 #### Style

--- a/README.md
+++ b/README.md
@@ -117,4 +117,4 @@ Exception:
 
 ## Copyright
 
-Copyright (c) 2006-2023 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.
+Copyright (c) 2006-2024 Minero Aoki, Kenshi Muto, Masayoshi Takahashi, Masanori Kado.

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2002-2023 Minero Aoki, Kenshi Muto
+# Copyright (c) 2002-2024 Minero Aoki, Kenshi Muto
 #
 # This program is free software.
 # You can distribute or modify this program under the terms of
@@ -133,7 +133,7 @@ module ReVIEW
     end
 
     def target_name
-      self.class.to_s.gsub(/ReVIEW::/, '').gsub(/Builder/, '').downcase
+      self.class.to_s.gsub('ReVIEW::', '').gsub('Builder', '').downcase
     end
 
     def load_words(file)
@@ -405,10 +405,10 @@ module ReVIEW
     def inline_ruby(arg)
       base, *ruby = *arg.scan(/(?:(?:(?:\\\\)*\\,)|[^,\\]+)+/)
       if base
-        base = base.gsub(/\\,/, ',').strip
+        base = base.gsub('\,', ',').strip
       end
       if ruby
-        ruby = ruby.join(',').gsub(/\\,/, ',').strip
+        ruby = ruby.join(',').gsub('\,', ',').strip
       end
       compile_ruby(base, ruby)
     end
@@ -420,9 +420,9 @@ module ReVIEW
 
     def inline_href(arg)
       url, label = *arg.scan(/(?:(?:(?:\\\\)*\\,)|[^,\\]+)+/).map(&:lstrip)
-      url = url.gsub(/\\,/, ',').strip
+      url = url.gsub('\,', ',').strip
       if label
-        label = label.gsub(/\\,/, ',').strip
+        label = label.gsub('\,', ',').strip
       end
       compile_href(url, label)
     end
@@ -640,7 +640,7 @@ module ReVIEW
       tf.puts content
       tf.close
       begin
-        file_path = send("graph_#{command}".to_sym, id, file_path, content, tf.path)
+        file_path = send(:"graph_#{command}", id, file_path, content, tf.path)
       ensure
         tf.unlink
       end

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2009-2022 Minero Aoki, Kenshi Muto
+# Copyright (c) 2009-2024 Minero Aoki, Kenshi Muto
 # Copyright (c) 2002-2007 Minero Aoki
 #
 # This program is free software.
@@ -681,7 +681,7 @@ module ReVIEW
                   end
         break if words.empty?
 
-        result << compile_inline(revert_replace_fence(words.shift.gsub(/\\\}/, '}').gsub(/\\\\/, '\\')))
+        result << compile_inline(revert_replace_fence(words.shift.gsub('\\}', '}').gsub('\\\\', '\\')))
       end
       result
     rescue StandardError => e

--- a/lib/review/htmltoc.rb
+++ b/lib/review/htmltoc.rb
@@ -35,7 +35,7 @@ module ReVIEW
     end
 
     def encode_args(args)
-      args.delete_if { |_k, v| v.nil? }.map { |k, v| "#{k}=#{v}" }.join(',')
+      args.compact.map { |k, v| "#{k}=#{v}" }.join(',')
     end
   end
 end

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2023 Minero Aoki, Kenshi Muto
+# Copyright (c) 2008-2024 Minero Aoki, Kenshi Muto
 #               2002-2007 Minero Aoki
 #
 # This program is free software.
@@ -532,9 +532,9 @@ module ReVIEW
           next
         end
         if @tablewidth
-          rows.push(line.gsub(/\t\.\t/, "\tDUMMYCELLSPLITTER\t").gsub(/\t\.\.\t/, "\t.\t").gsub(/\t\.\Z/, "\tDUMMYCELLSPLITTER").gsub(/\t\.\.\Z/, "\t.").gsub(/\A\./, ''))
+          rows.push(line.gsub("\t.\t", "\tDUMMYCELLSPLITTER\t").gsub("\t..\t", "\t.\t").gsub(/\t\.\Z/, "\tDUMMYCELLSPLITTER").gsub(/\t\.\.\Z/, "\t.").gsub(/\A\./, ''))
         else
-          rows.push(line.gsub(/\t\.\t/, "\t\t").gsub(/\t\.\.\t/, "\t.\t").gsub(/\t\.\Z/, "\t").gsub(/\t\.\.\Z/, "\t.").gsub(/\A\./, ''))
+          rows.push(line.gsub("\t.\t", "\t\t").gsub("\t..\t", "\t.\t").gsub(/\t\.\Z/, "\t").gsub(/\t\.\.\Z/, "\t.").gsub(/\A\./, ''))
         end
         col2 = rows[rows.length - 1].split(table_row_separator_regexp).length
         @col = col2 if col2 > @col

--- a/lib/review/logger.rb
+++ b/lib/review/logger.rb
@@ -32,7 +32,7 @@ module ReVIEW
     end
 
     def ttylogger?
-      nil
+      false
     end
 
     def success(_log)

--- a/lib/review/markdownbuilder.rb
+++ b/lib/review/markdownbuilder.rb
@@ -190,19 +190,19 @@ module ReVIEW
     end
 
     def inline_i(str)
-      "*#{str.gsub(/\*/, '\*')}*"
+      "*#{str.gsub('*', '\*')}*"
     end
 
     def inline_em(str)
-      "*#{str.gsub(/\*/, '\*')}*"
+      "*#{str.gsub('*', '\*')}*"
     end
 
     def inline_b(str)
-      "**#{str.gsub(/\*/, '\*')}**"
+      "**#{str.gsub('*', '\*')}**"
     end
 
     def inline_strong(str)
-      "**#{str.gsub(/\*/, '\*')}**"
+      "**#{str.gsub('*', '\*')}**"
     end
 
     def inline_code(str)

--- a/lib/review/textutils.rb
+++ b/lib/review/textutils.rb
@@ -1,4 +1,4 @@
-# Copyright (c) 2008-2020 Minero Aoki, Kenshi Muto, Masayoshi Takahashi,
+# Copyright (c) 2008-2023 Minero Aoki, Kenshi Muto, Masayoshi Takahashi,
 #                         KADO Masanori
 #               2002-2007 Minero Aoki
 #
@@ -49,7 +49,7 @@ module ReVIEW
       tail = line1[-1]
       head = line2[0]
       if tail.nil? || head.nil?
-        return nil
+        return false
       end
 
       space = true

--- a/lib/review/yamlloader.rb
+++ b/lib/review/yamlloader.rb
@@ -16,7 +16,9 @@ module ReVIEW
             YAML.safe_load(f, [Date])
           rescue Psych::DisallowedClass
             # < Ruby 2.5
+            # rubocop:disable Style/YAMLFileRead
             YAML.safe_load(File.read(file), [Date])
+            # rubocop:enable Style/YAMLFileRead
           end
         end
       end

--- a/review.gemspec
+++ b/review.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('playwright-runner')
   gem.add_development_dependency('pygments.rb')
   gem.add_development_dependency('rake')
-  gem.add_development_dependency('rubocop', '~> 1.45.1')
+  gem.add_development_dependency('rubocop', '~> 1.59.0')
   gem.add_development_dependency('rubocop-performance')
   gem.add_development_dependency('rubocop-rake')
   gem.add_development_dependency('simplecov')


### PR DESCRIPTION
Rubocop 1.59.0を適用しました。
bundlerがもうだめっぽいので2.7をやめて、3.3を追加しました。
