### PR TITLE
review-base.sty (\reviewtt, \reviewcode, \reviewtti, \reviewttb): inserted \frenchspacing inside

### DIFF
--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -247,10 +247,10 @@
   \review@ba@breaktrue
   \review@break@all@a
 }
-\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewtt}[1]{{\frenchspacing\ttfamily\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewcode}[1]{{\frenchspacing\ttfamily\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewtti}[1]{{\frenchspacing\ttfamily\itshape\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewttb}[1]{{\frenchspacing\ttfamily\bfseries\reviewbreakall{#1}}}
 
 \DeclareRobustCommand{\reviewbou}[1]{\kenten{#1}}
 

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -206,7 +206,7 @@
   \def\reviewcode#1{#1}
   \def\reviewtti#1{#1}
   \def\reviewttb#1{#1}
-  \def\reviewicon\@gobble
+  \let\reviewicon\@gobble
 }
 \newif\ifreview@ba@break
 \def\review@ba@end{\review@ba@end@}

--- a/templates/latex/review-jlreq/review-base.sty
+++ b/templates/latex/review-jlreq/review-base.sty
@@ -202,6 +202,11 @@
   \def\reviewinsert#1{#1}
   \def\reviewstrike#1{#1}
   \def\reviewunderline#1{#1}
+  \def\reviewtt#1{#1}
+  \def\reviewcode#1{#1}
+  \def\reviewtti#1{#1}
+  \def\reviewttb#1{#1}
+  \def\reviewicon\@gobble
 }
 \newif\ifreview@ba@break
 \def\review@ba@end{\review@ba@end@}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -281,7 +281,7 @@
   \def\reviewcode#1{#1}
   \def\reviewtti#1{#1}
   \def\reviewttb#1{#1}
-  \def\reviewicon\@gobble
+  \let\reviewicon\@gobble
 }
 \newif\ifreview@ba@break
 \def\review@ba@end{\review@ba@end@}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -277,6 +277,11 @@
   \def\reviewinsert#1{#1}
   \def\reviewstrike#1{#1}
   \def\reviewunderline#1{#1}
+  \def\reviewtt#1{#1}
+  \def\reviewcode#1{#1}
+  \def\reviewtti#1{#1}
+  \def\reviewttb#1{#1}
+  \def\reviewicon\@gobble
 }
 \newif\ifreview@ba@break
 \def\review@ba@end{\review@ba@end@}

--- a/templates/latex/review-jsbook/review-base.sty
+++ b/templates/latex/review-jsbook/review-base.sty
@@ -322,10 +322,10 @@
   \review@ba@breaktrue
   \review@break@all@a
 }
-\DeclareRobustCommand{\reviewtt}[1]{{\ttfamily\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewcode}[1]{{\ttfamily\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewtti}[1]{{\ttfamily\itshape\reviewbreakall{#1}}}
-\DeclareRobustCommand{\reviewttb}[1]{{\ttfamily\bfseries\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewtt}[1]{{\frenchspacing\ttfamily\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewcode}[1]{{\frenchspacing\ttfamily\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewtti}[1]{{\frenchspacing\ttfamily\itshape\reviewbreakall{#1}}}
+\DeclareRobustCommand{\reviewttb}[1]{{\frenchspacing\ttfamily\bfseries\reviewbreakall{#1}}}
 
 \DeclareRobustCommand{\reviewbou}[1]{\kenten{#1}}
 


### PR DESCRIPTION
本PRの変更内容は、3点です。

1. インラインコード`@<code>`類における https://github.com/kmuto/review/issues/1906 の（とりあえずの）対処
        * 詳細は、Noteのとおり。
2. インラインコード`@<code>{コード}`類がPDF栞に入ったときに、`コード`（単なる文字列）が入るように対応
        * 1に間接的に影響する。
3. インライン画像`@<icon>`がPDF栞に入ったときに、何も入らないように対応

----------

ref. #1906 

latexビルダに対するインラインなコード要素（等幅） `@<code>`, `@<tt>`, `@<tti>`, `@<ttb>` において、「. (period+space)」直後の“余計な”（に見える）空白アキをひとまず除きます。

現状のRe:VIEW標準の`\reviewcode{...}`（`@<code>{...}`）は、ある種の`\texttt{...}`の**通常の入力された文字列**としてLaTeXに組版してもらっています（`\texttt`は`\verb/verbatim`ではない）。

> [!NOTE] 
> lmtt10の標準なTeX font metric（T1 encodingなら、`rm-lmtt10`）がそうなっているからですね。
> 「. (period+space)」は、「.」のあとにSPACE 0.525+EXTRASPACE 0.525が入るので、空白2つ分となります。
> 逆に、（必要であれば別名にして）EXTRASPACE 0.0としたfont metricを作ると、「. (period+space)」は空白1つ分となります。
