### PR TITLE
Add csv and nkf to gem's dependency

### DIFF
--- a/review.gemspec
+++ b/review.gemspec
@@ -19,7 +19,9 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = []
   gem.require_paths = ['lib']
 
+  gem.add_dependency('csv')
   gem.add_dependency('image_size')
+  gem.add_dependency('nkf')
   gem.add_dependency('rexml')
   gem.add_dependency('rouge')
   gem.add_dependency('rubyzip')


### PR DESCRIPTION
Re:VIEWをRuby 3.3.1で実行すると、以下のようなwarningが発生します。(csvとnkfは3.4以降default gemでなくなる予定)

本PRはgemの依存先にcsvとnkfを追加するもので、それによってwarningの発生を抑止し、(おそらく今年の年末にリリースされる)3.4以降のRubyのアップデートに対応できるようにします。

```
$HOME/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/review-5.9.0/lib/review/textutils.rb:9: warning: nkf was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add nkf to your Gemfile or gemspec. Also contact author of review-5.9.0 to add nkf into its gemspec.
$HOME/.rbenv/versions/3.3.1/lib/ruby/gems/3.3.0/gems/review-5.9.0/lib/review/builder.rb:19: warning: csv was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add csv to your Gemfile or gemspec. Also contact author of review-5.9.0 to add csv into its gemspec.
```

参照: [3.3.0のリリースノート](https://www.ruby-lang.org/en/news/2023/12/25/ruby-3-3-0-released/)の"Standard library updates"節