### PR TITLE
Add `ReVIEW::Book::Cache` and use it in `ReVIEW::Book::ImageFinder`

### DIFF
--- a/lib/review/book/base.rb
+++ b/lib/review/book/base.rb
@@ -10,6 +10,7 @@
 require 'review/configure'
 require 'review/catalog'
 require 'review/book/bib'
+require 'review/book/cache'
 
 module ReVIEW
   module Book
@@ -19,6 +20,7 @@ module ReVIEW
       attr_accessor :catalog
       attr_reader :basedir
       attr_accessor :bibpaper_index
+      attr_reader :cache
 
       def self.load(basedir = '.', config: nil)
         new(basedir, config: config)
@@ -39,6 +41,8 @@ module ReVIEW
 
         @warn_old_files = {} # XXX for checking CHAPS, PREDEF, POSTDEF
         @basedir_seen = {}
+
+        @cache = ReVIEW::Book::Cache.new
         update_rubyenv
       end
 

--- a/lib/review/book/cache.rb
+++ b/lib/review/book/cache.rb
@@ -1,0 +1,53 @@
+#
+# Copyright (c) 2014-2024 Minero Aoki, Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+# For details of LGPL, see the file "COPYING".
+#
+module ReVIEW
+  module Book
+    class Cache
+      def initialize
+        @store = {}
+      end
+
+      def reset
+        @store.clear
+      end
+
+      # key should be Symbol, not String
+      def fetch(key, &block)
+        raise ArgumentError, 'Key should be Symbol' unless key.kind_of?(Symbol)
+        if has_key?(key)
+          read(key)
+        else
+          exec_block_and_save(key, &block)
+        end
+      end
+
+      private
+
+      def has_key?(key)
+        @store.has_key?(key)
+      end
+
+      def read(key)
+        @store[key]
+      end
+
+      def write(key, value)
+        @store[key] = value
+      end
+
+      def exec_block_and_save(key, &block)
+        result = yield(key)
+
+        write(key, result)
+
+        result
+      end
+    end
+  end
+end

--- a/lib/review/book/cache.rb
+++ b/lib/review/book/cache.rb
@@ -19,8 +19,9 @@ module ReVIEW
 
       # key should be Symbol, not String
       def fetch(key, &block)
-        raise ArgumentError, 'Key should be Symbol' unless key.kind_of?(Symbol)
-        if has_key?(key)
+        raise ArgumentError, 'Key should be Symbol' unless key.is_a?(Symbol)
+
+        if key?(key)
           read(key)
         else
           exec_block_and_save(key, &block)
@@ -29,8 +30,8 @@ module ReVIEW
 
       private
 
-      def has_key?(key)
-        @store.has_key?(key)
+      def key?(key)
+        @store.key?(key)
       end
 
       def read(key)
@@ -41,7 +42,7 @@ module ReVIEW
         @store[key] = value
       end
 
-      def exec_block_and_save(key, &block)
+      def exec_block_and_save(key)
         result = yield(key)
 
         write(key, result)

--- a/lib/review/book/cache.rb
+++ b/lib/review/book/cache.rb
@@ -21,18 +21,18 @@ module ReVIEW
       def fetch(key, &block)
         raise ArgumentError, 'Key should be Symbol' unless key.is_a?(Symbol)
 
-        if key?(key)
+        if cached?(key)
           read(key)
         else
           exec_block_and_save(key, &block)
         end
       end
 
-      private
-
-      def key?(key)
+      def cached?(key)
         @store.key?(key)
       end
+
+      private
 
       def read(key)
         @store[key]

--- a/lib/review/book/image_finder.rb
+++ b/lib/review/book/image_finder.rb
@@ -26,7 +26,9 @@ module ReVIEW
       end
 
       def dir_entries
-        Dir.glob(File.join(@basedir, '**{,/*/**}/*.*')).uniq.sort.map { |entry| entry.sub(%r{^\./}, '') }
+        @book.cache.fetch(:image_finder_dir_entries) do
+          Dir.glob(File.join(@basedir, '**{,/*/**}/*.*')).uniq.sort.map { |entry| entry.sub(%r{^\./}, '') }
+        end
       end
 
       def add_entry(path)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -35,6 +35,7 @@ end
 def compile_block(text)
   method_name = "compile_block_#{@builder.target_name}"
   method_name = 'compile_block_default' unless self.respond_to?(method_name, true)
+  @chapter.book.cache.reset
   self.__send__(method_name, text)
 end
 


### PR DESCRIPTION
#1916 の対応のため、Dir.glob等でファイルシステムを読み込んだ結果をキャッシュするようにします。
そのためにクラスとして`ReVIEW::Book::Cache`を追加してます。

- キャッシュは`@book`単位で行っているので、`@book`を作り直している場合には使われません
- 反対に、テスト等の際に`@book`を使いまわしているような場合、キャッシュされた結果が使われるので誤動作する危険性があります
    - その場合は`@book.cache.reset`すれば再初期化されます
- `ReVIEW::Book::Cache`のインターフェースはRailsの`Rails.cache.fetch`を真似ていますが、expires等は不要そうなのでありません

## 関連

- #1916