### PR TITLE
fix deprecation; use `MiniMagick.compare`

### DIFF
--- a/test/test_img_math.rb
+++ b/test/test_img_math.rb
@@ -88,7 +88,7 @@ class ImgMathTest < Test::Unit::TestCase
 
   def compare_images(image1, image2)
     MiniMagick.errors = false
-    compare = MiniMagick::Tool::Compare.new
+    compare = MiniMagick.compare
     compare << '-fuzz'
     compare << '10%'
     compare.metric('AE')


### PR DESCRIPTION
`MiniMagick::Tool::Compare`がdeprecatedになったので`MiniMagick.compare`に置き換えます。

https://github.com/minimagick/minimagick/commit/74fafc69577cb609f46668c9d75e4c194f65191b での変更を反映させるものです。