### PR TITLE
mini_magick: use `SSIM` instead of `AE` for compare

### DIFF
--- a/.github/workflows/ruby-tex.yml
+++ b/.github/workflows/ruby-tex.yml
@@ -20,11 +20,19 @@ jobs:
     - name: Install TeXLive 2021 in ubuntu
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq texlive-lang-japanese texlive-fonts-recommended texlive-fonts-extra texlive-luatex texlive-extra-utils texlive-latex-extra dvipng poppler-utils
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq texlive-lang-japanese texlive-fonts-recommended texlive-fonts-extra texlive-luatex texlive-extra-utils texlive-latex-extra dvipng poppler-utils libfuse2
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+    - name: use vendor's imagemagick
+      run: |
+        export PATH=${GITHUB_WORKSPACE}/vendor/imagemagick:${PATH}
+        chmod 755 ${GITHUB_WORKSPACE}/vendor/imagemagick/magick
+        ln -s ${GITHUB_WORKSPACE}/vendor/imagemagick/magick ${GITHUB_WORKSPACE}/vendor/imagemagick/compare
+        which compare
+        magick -version
+        compare -version
     - name: fix ImageMagick policy.xml on Linux
       if: runner.os == 'Linux'
       run: sudo sed -i 's/none/read|write/g' /etc/ImageMagick-6/policy.xml
@@ -34,6 +42,7 @@ jobs:
         node-version: 18
     - name: Build and test with Rake
       run: |
+        export PATH=${GITHUB_WORKSPACE}/vendor/imagemagick:${PATH}
         gem install bundler --no-document
         bundle install --retry 3
         bundle exec rake

--- a/review.gemspec
+++ b/review.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.required_rubygems_version = Gem::Requirement.new('>= 0') if gem.respond_to?(:required_rubygems_version=)
   gem.metadata = { 'rubygems_mfa_required' => 'true' }
 
-  gem.files         = `git ls-files`.split("\n").reject { |f| f.match(/^test/) }
+  gem.files         = `git ls-files`.split("\n").reject { |f| f.match(/^test/) }.reject { |f| f.match(/^vendor\/imagemagick/) }
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.extra_rdoc_files = []
   gem.require_paths = ['lib']

--- a/review.gemspec
+++ b/review.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.required_rubygems_version = Gem::Requirement.new('>= 0') if gem.respond_to?(:required_rubygems_version=)
   gem.metadata = { 'rubygems_mfa_required' => 'true' }
 
-  gem.files         = `git ls-files`.split("\n").reject { |f| f.match(/^test/) }.reject { |f| f.match(/^vendor\/imagemagick/) }
+  gem.files         = `git ls-files`.split("\n").reject { |f| f.match(/^test/) }.reject { |f| f.match(%r{^vendor/imagemagick}) }
   gem.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   gem.extra_rdoc_files = []
   gem.require_paths = ['lib']

--- a/test/test_img_math.rb
+++ b/test/test_img_math.rb
@@ -47,13 +47,14 @@ class ImgMathTest < Test::Unit::TestCase
     assert File.exist?(img_path2)
 
     val1 = compare_images(img_path1, File.join(assets_dir, 'img_math/img1.png'))
-    assert_equal 0, val1
+    assert val1 >= 0.9
 
     val2 = compare_images(img_path2, File.join(assets_dir, 'img_math/img2.png'))
-    assert_equal 0, val2
+    assert val2 >= 0.9
 
     val3 = compare_images(img_path1, img_path2)
-    assert val3 > 100
+
+    assert val3 < 0.9
   end
 
   def test_make_math_image_pathname
@@ -81,23 +82,21 @@ class ImgMathTest < Test::Unit::TestCase
     assert File.exist?(img_path1)
 
     val1 = compare_images(img_path1, File.join(assets_dir, 'img_math/img3.png'))
-    assert val1 < 10
+    assert val1 >= 0.9
   end
 
   private
 
   def compare_images(image1, image2)
     MiniMagick.errors = false
-    compare = MiniMagick::Tool::Compare.new
-    compare << '-fuzz'
-    compare << '10%'
-    compare.metric('AE')
+    compare = MiniMagick.compare
+    compare.metric('SSIM')
     compare << image1
     compare << image2
     compare << File.join(@tmpdir, 'diff.jpg')
 
     compare.call do |_, dist, _|
-      return dist.to_i
+      return dist.to_f
     end
   end
 


### PR DESCRIPTION
#1917 の対応で、ImageMagickのcopmareのmetricとしてSSIMを使うようにしてみます。

https://qiita.com/yoya/items/510043d836c9f2f0fe2f

しきい値は0.9で、それ以上なら一致・それ未満なら不一致ということにしています。
なお`-fuzz`はあってもなくても変わらなかったので落としています。

