### PR TITLE
update rubocop 1.65.1

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -773,7 +773,7 @@ EOTGNUPLOT
     ## override TextUtils::detab
     def detab(str, num = nil)
       if num
-        super(str, num)
+        super
       elsif @tabwidth
         super(str, @tabwidth)
       else

--- a/lib/review/htmlbuilder.rb
+++ b/lib/review/htmlbuilder.rb
@@ -455,7 +455,7 @@ module ReVIEW
 
     def list(lines, id, caption, lang = nil)
       puts %Q(<div id="#{normalize_id(id)}" class="caption-code">)
-      super(lines, id, caption, lang)
+      super
       puts '</div>'
     end
 
@@ -480,7 +480,7 @@ module ReVIEW
 
     def source(lines, caption = nil, lang = nil)
       puts %Q(<div class="source-code">)
-      super(lines, caption, lang)
+      super
       puts '</div>'
     end
 
@@ -500,7 +500,7 @@ module ReVIEW
 
     def listnum(lines, id, caption, lang = nil)
       puts %Q(<div id="#{normalize_id(id)}" class="code">)
-      super(lines, id, caption, lang)
+      super
       puts '</div>'
     end
 
@@ -737,7 +737,7 @@ module ReVIEW
       else
         puts %Q(<div class="table">)
       end
-      super(lines, id, caption)
+      super
       puts '</div>'
     end
 
@@ -1117,9 +1117,9 @@ EOS
         chap, id2 = extract_chapter_id(id)
         n = chap.headline_index.number(id2)
         anchor = 'h' + n.tr('.', '-')
-        %Q(<a href="#{chap.id}#{extname}##{anchor}">#{super(id)}</a>)
+        %Q(<a href="#{chap.id}#{extname}##{anchor}">#{super}</a>)
       else
-        super(id)
+        super
       end
     rescue KeyError
       app_error "unknown headline: #{id}"
@@ -1129,9 +1129,9 @@ EOS
       if @book.config['chapterlink']
         chap, id2 = extract_chapter_id(id)
         anchor = 'h' + chap.headline_index.number(id2).tr('.', '-')
-        %Q(<a href="#{chap.id}#{extname}##{anchor}">#{super(id)}</a>)
+        %Q(<a href="#{chap.id}#{extname}##{anchor}">#{super}</a>)
       else
-        super(id)
+        super
       end
     rescue KeyError
       app_error "unknown headline: #{id}"
@@ -1154,7 +1154,7 @@ EOS
     end
 
     def inline_list(id)
-      str = super(id)
+      str = super
       chapter, id = extract_chapter_id(id)
       if @book.config['chapterlink']
         %Q(<span class="listref"><a href="./#{chapter.id}#{extname}##{normalize_id(id)}">#{str}</a></span>)
@@ -1164,7 +1164,7 @@ EOS
     end
 
     def inline_table(id)
-      str = super(id)
+      str = super
       chapter, id = extract_chapter_id(id)
       if @book.config['chapterlink']
         %Q(<span class="tableref"><a href="./#{chapter.id}#{extname}##{normalize_id(id)}">#{str}</a></span>)
@@ -1174,7 +1174,7 @@ EOS
     end
 
     def inline_img(id)
-      str = super(id)
+      str = super
       chapter, id = extract_chapter_id(id)
       if @book.config['chapterlink']
         %Q(<span class="imgref"><a href="./#{chapter.id}#{extname}##{normalize_id(id)}">#{str}</a></span>)
@@ -1184,7 +1184,7 @@ EOS
     end
 
     def inline_eq(id)
-      str = super(id)
+      str = super
       chapter, id = extract_chapter_id(id)
       if @book.config['chapterlink']
         %Q(<span class="eqref"><a href="./#{chapter.id}#{extname}##{normalize_id(id)}">#{str}</a></span>)
@@ -1308,7 +1308,7 @@ EOS
     end
 
     def inline_raw(str) # rubocop:disable Lint/UselessMethodDefinition
-      super(str)
+      super
     end
 
     def nofunc_text(str)

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -273,7 +273,7 @@ module ReVIEW
     end
 
     def inline_list(id)
-      "<span type='list'>#{super(id)}</span>"
+      "<span type='list'>#{super}</span>"
     end
 
     def list_header(id, caption, _lang)
@@ -304,7 +304,7 @@ module ReVIEW
 
     def list(lines, id, caption, lang = nil)
       puts '<codelist>'
-      super(lines, id, caption, lang)
+      super
       puts '</codelist>'
     end
 
@@ -329,7 +329,7 @@ module ReVIEW
 
     def listnum(lines, id, caption, lang = nil)
       puts '<codelist>'
-      super(lines, id, caption, lang)
+      super
       puts '</codelist>'
     end
 
@@ -389,15 +389,15 @@ module ReVIEW
     end
 
     def inline_table(id)
-      "<span type='table'>#{super(id)}</span>"
+      "<span type='table'>#{super}</span>"
     end
 
     def inline_img(id)
-      "<span type='image'>#{super(id)}</span>"
+      "<span type='image'>#{super}</span>"
     end
 
     def inline_eq(id)
-      "<span type='eq'>#{super(id)}</span>"
+      "<span type='eq'>#{super}</span>"
     end
 
     def inline_imgref(id)
@@ -725,7 +725,7 @@ module ReVIEW
     end
 
     def inline_raw(str)
-      super(str).gsub('\\n', "\n")
+      super.gsub('\\n', "\n")
     end
 
     def inline_hint(str)

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -556,7 +556,7 @@ module ReVIEW
     end
 
     def parse_metric(type, metric)
-      s = super(type, metric)
+      s = super
       if @book.config['pdfmaker']['use_original_image_size'] && s.empty? && !metric.present?
         return ' ' # pass empty to \reviewincludegraphics
       end
@@ -1292,11 +1292,11 @@ module ReVIEW
 
     def inline_sec(id)
       if @book.config['chapterlink']
-        n = super(id)
+        n = super
         anchor = n.tr('.', '-')
         macro('reviewsecref', n, sec_label(anchor))
       else
-        super(id)
+        super
       end
     rescue KeyError
       app_error "unknown headline: #{id}"
@@ -1306,9 +1306,9 @@ module ReVIEW
       if @book.config['chapterlink']
         chap, id2 = extract_chapter_id(id)
         anchor = chap.headline_index.number(id2).tr('.', '-')
-        macro('reviewsecref', super(id), sec_label(anchor))
+        macro('reviewsecref', super, sec_label(anchor))
       else
-        super(id)
+        super
       end
     end
 
@@ -1321,7 +1321,7 @@ module ReVIEW
     end
 
     def inline_raw(str) # rubocop:disable Lint/UselessMethodDefinition
-      super(str)
+      super
     end
 
     def inline_sub(str)

--- a/lib/review/logger.rb
+++ b/lib/review/logger.rb
@@ -3,7 +3,7 @@ require 'logger'
 module ReVIEW
   class Logger < ::Logger
     def initialize(io = $stderr, progname: '--')
-      super(io, progname: progname)
+      super
       self.formatter = ->(severity, _datetime, name, msg) { "#{severity} #{name}: #{msg}\n" }
     end
 

--- a/lib/review/plaintextbuilder.rb
+++ b/lib/review/plaintextbuilder.rb
@@ -362,7 +362,7 @@ module ReVIEW
     end
 
     def inline_raw(str)
-      super(str).gsub('\\n', "\n")
+      super.gsub('\\n', "\n")
     end
 
     def inline_hidx(_str)

--- a/lib/review/tocprinter.rb
+++ b/lib/review/tocprinter.rb
@@ -21,12 +21,12 @@ module ReVIEW
         print "\x01H#{level}\x01"
       end
       # embed header information for tocparser
-      super(level, label, caption)
+      super
     end
 
     def base_block(type, lines, caption = nil)
       puts "\x01STARTLIST\x01"
-      super(type, lines, caption)
+      super
       puts "\x01ENDLIST\x01"
     end
 

--- a/review.gemspec
+++ b/review.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('playwright-runner')
   gem.add_development_dependency('pygments.rb')
   gem.add_development_dependency('rake')
-  gem.add_development_dependency('rubocop', '~> 1.59.0')
+  gem.add_development_dependency('rubocop', '~> 1.65.1')
   gem.add_development_dependency('rubocop-performance')
   gem.add_development_dependency('rubocop-rake')
   gem.add_development_dependency('simplecov')


### PR DESCRIPTION
RuboCopを1.65.1に更新します。

`Style/SuperArguments`を適用してsuperの引数を省略しています。