### PR TITLE
EPUBMaker: verify_target_imagesが有効なときに、coverimageを暗黙に取り込む

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -220,6 +220,11 @@ module ReVIEW
           end
         end
       end
+
+      if @config['coverimage']
+        @config['epubmaker']['force_include_images'].push(File.join(@config['imagedir'], @config['coverimage']))
+      end
+
       @config['epubmaker']['force_include_images'] = @config['epubmaker']['force_include_images'].compact.sort.uniq
     end
 

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -214,7 +214,7 @@ module ReVIEW
           File.open(File.join(basetmpdir, content.file)) do |f|
             f.each_line do |l|
               l.scan(/url\((.+?)\)/) do |_m|
-                @config['epubmaker']['force_include_images'].push($1.strip)
+                @config['epubmaker']['force_include_images'].push($1.strip.gsub(/\A(['"])(.*)\1\Z/, '\2'))
               end
             end
           end

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -955,6 +955,7 @@ EOT
       epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'style.css')
       File.write(File.join(tmpdir, 'style.css'), 'div { background-image: url("images/bg.jpg")}')
       epubmaker.verify_target_images(tmpdir)
+      File.unlink(File.join(tmpdir, 'ch01.html'), File.join(tmpdir, 'style.css'))
 
       expect = %w[images/bg.jpg images/ch01.png images/cover.png]
       assert_equal expect, epubmaker.config['epubmaker']['force_include_images']

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -948,17 +948,17 @@ EOT
     end
   end
 
-  def test_verify_target_images
-    epubmaker_instance do |epubmaker, tmpdir|
-      epubmaker.config['epubmaker']['verify_target_images'] = true
-      epubmaker.config['coverimage'] = 'cover.png'
-
-      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'ch01.html', title: 'CH01', level: 1)
-      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'style.css')
-      epubmaker.verify_target_images(tmpdir)
-
-      expect = %w[images/bg.jpg images/ch01.png images/cover.png]
-      assert_equal expect, epubmaker.config['epubmaker']['force_include_images']
-    end
-  end
+  # def test_verify_target_images
+  #   epubmaker_instance do |epubmaker, tmpdir|
+  #     epubmaker.config['epubmaker']['verify_target_images'] = true
+  #     epubmaker.config['coverimage'] = 'cover.png'
+  #
+  #      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'ch01.html', title: 'CH01', level: 1)
+  #      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'style.css')
+  #      epubmaker.verify_target_images(tmpdir)
+  #
+  #      expect = %w[images/bg.jpg images/ch01.png images/cover.png]
+  #      assert_equal expect, epubmaker.config['epubmaker']['force_include_images']
+  #    end
+  #  end
 end

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -882,10 +882,11 @@ EOT
       Dir.mkdir(File.join(tmpdir, 'subdir'))
       File.write(File.join(tmpdir, 'subdir', 'exist.html'), '<html></html>')
 
+      Dir.mkdir(File.join(tmpdir, 'test'))
+      File.write(File.join(tmpdir, 'test', 'ch01.html'), '<html><img src="images/ch01.png" /></html>')
+      File.write(File.join(tmpdir, 'test', 'style.css'), 'div { background-image: url("images/bg.jpg")}')
+
       Dir.chdir(tmpdir) do
-        Dir.mkdir('test')
-        File.write(File.join(tmpdir, 'test', 'ch01.html'), '<html><img src="images/ch01.png" /></html>')
-        File.write(File.join(tmpdir, 'test', 'style.css'), 'div { background-image: url("images/bg.jpg")}')
         yield(epubmaker, File.join(tmpdir, 'test'))
       end
     end

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -949,7 +949,7 @@ EOT
   end
 
   def test_verify_target_images
-    epubmaker_instance do |epubmaker, _tmpdir|
+    epubmaker_instance do |epubmaker, tmpdir|
       epubmaker.config['epubmaker']['verify_target_images'] = true
       epubmaker.config['coverimage'] = 'cover.png'
 

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -956,7 +956,7 @@ EOT
       File.write(File.join(tmpdir, 'style.css'), 'div { background-image: url("images/bg.jpg")}')
       epubmaker.verify_target_images(tmpdir)
 
-      expect = %w(images/bg.jpg images/ch01.png images/cover.png)
+      expect = %w[images/bg.jpg images/ch01.png images/cover.png]
       assert_equal expect, epubmaker.config['epubmaker']['force_include_images']
     end
   end

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -867,6 +867,10 @@ EOT
           @config
         end
 
+        def producer
+          @producer
+        end
+
         def error(s)
           raise ApplicationError, s
         end
@@ -938,6 +942,22 @@ EOT
         assert_raise(SystemExit) { epubmaker.copy_backmatter(tmpdir) }
         assert_equal "ERROR --: #{name}: nothing.html is not found.\n", @log_io.string
       end
+    end
+  end
+
+  def test_verify_target_images
+    epubmaker_instance do |epubmaker, tmpdir|
+      epubmaker.config['epubmaker']['verify_target_images'] = true
+      epubmaker.config['coverimage'] = 'cover.png'
+
+      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'ch01.html', title: 'CH01', level: 1)
+      File.write(File.join(tmpdir, 'ch01.html'), '<html><img src="images/ch01.png" /></html>')
+      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'style.css')
+      File.write(File.join(tmpdir, 'style.css'), 'div { background-image: url("images/bg.jpg")}')
+      epubmaker.verify_target_images(tmpdir)
+
+      expect = %w(images/bg.jpg images/ch01.png images/cover.png)
+      assert_equal expect, epubmaker.config['epubmaker']['force_include_images']
     end
   end
 end

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -884,6 +884,8 @@ EOT
 
       Dir.chdir(tmpdir) do
         Dir.mkdir('test')
+        File.write(File.join(tmpdir, 'test', 'ch01.html'), '<html><img src="images/ch01.png" /></html>')
+        File.write(File.join(tmpdir, 'test', 'style.css'), 'div { background-image: url("images/bg.jpg")}')
         yield(epubmaker, File.join(tmpdir, 'test'))
       end
     end
@@ -951,11 +953,8 @@ EOT
       epubmaker.config['coverimage'] = 'cover.png'
 
       epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'ch01.html', title: 'CH01', level: 1)
-      File.write(File.join(tmpdir, 'ch01.html'), '<html><img src="images/ch01.png" /></html>')
       epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'style.css')
-      File.write(File.join(tmpdir, 'style.css'), 'div { background-image: url("images/bg.jpg")}')
       epubmaker.verify_target_images(tmpdir)
-      File.unlink(File.join(tmpdir, 'ch01.html'), File.join(tmpdir, 'style.css'))
 
       expect = %w[images/bg.jpg images/ch01.png images/cover.png]
       assert_equal expect, epubmaker.config['epubmaker']['force_include_images']

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -891,7 +891,7 @@ EOT
           yield(epubmaker, File.join(tmpdir, 'test'))
         end
       end
-    rescue Errno::EACCES
+    rescue Errno::EACCES, Errno::ENOTEMPTY
       # Windows fails unlink when file is opened
     end
   end

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -948,17 +948,18 @@ EOT
     end
   end
 
-  # def test_verify_target_images
-  #   epubmaker_instance do |epubmaker, tmpdir|
-  #     epubmaker.config['epubmaker']['verify_target_images'] = true
-  #     epubmaker.config['coverimage'] = 'cover.png'
-  #
-  #      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'ch01.html', title: 'CH01', level: 1)
-  #      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'style.css')
-  #      epubmaker.verify_target_images(tmpdir)
-  #
-  #      expect = %w[images/bg.jpg images/ch01.png images/cover.png]
-  #      assert_equal expect, epubmaker.config['epubmaker']['force_include_images']
-  #    end
-  #  end
+  def test_verify_target_images
+    epubmaker_instance do |epubmaker, _tmpdir|
+      epubmaker.config['epubmaker']['verify_target_images'] = true
+      epubmaker.config['coverimage'] = 'cover.png'
+
+      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'ch01.html', title: 'CH01', level: 1)
+      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'style.css')
+      # epubmaker.verify_target_images(tmpdir)
+
+      # expect = %w[images/bg.jpg images/ch01.png images/cover.png]
+      # assert_equal expect, epubmaker.config['epubmaker']['force_include_images']
+      assert_equal true, true
+    end
+  end
 end

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -955,7 +955,7 @@ EOT
 
       epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'ch01.html', title: 'CH01', level: 1)
       epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'style.css')
-      # epubmaker.verify_target_images(tmpdir)
+      epubmaker.verify_target_images(tmpdir)
 
       # expect = %w[images/bg.jpg images/ch01.png images/cover.png]
       # assert_equal expect, epubmaker.config['epubmaker']['force_include_images']


### PR DESCRIPTION
#1918 で言及した、verify_target_imagesが有効なときにcoverimageの画像ファイルも暗黙に取り込むものです。
imagedirで設定されたフォルダ(通常はimages)直下にあるcoverimageの画像ファイルを探す決めうちとしています。