### PR TITLE
Fix some typos

### DIFF
--- a/NEWS.ja.md
+++ b/NEWS.ja.md
@@ -972,7 +972,7 @@
 * CSS 組版向けに EPUB ファイルを単一 HTML ファイルに変換する `review-epub2html` コマンドを追加しました ([#1098])
 
 ## 非互換の変更
-* PDFMaker: `texcommand`、`dvicommmand`、`makeindex_command` に空白文字入りのパスを指定できるようにしました。これに伴い、これらのパラメータはコマンドオプションを取ることはできなくなりました。コマンドオプションは本来の `texoptions`、`dvioptions`、`makeindex_options` のパラメータに指定してください ([#1091])
+* PDFMaker: `texcommand`、`dvicommand`、`makeindex_command` に空白文字入りのパスを指定できるようにしました。これに伴い、これらのパラメータはコマンドオプションを取ることはできなくなりました。コマンドオプションは本来の `texoptions`、`dvioptions`、`makeindex_options` のパラメータに指定してください ([#1091])
 * PDFMaker: book.re というファイルで生じるビルドの失敗を修正しました。これまではベースファイルとして `book.tex` という名前のファイルを内部で作成していましたが、`__REVIEW_BOOK__.tex` という名前に変更しました ([#1081])
 * PDFMaker: jsbook ベーススタイルにおいて、geometry を読み込まないようにしました ([#912])
 * PDFMaker: jsbook ベーススタイルにおいて、ページ番号を見開きの左右に振るようにしました ([#1032])
@@ -1117,7 +1117,7 @@
 
 ## 新機能
 * プレインテキストを出力する review-textmaker コマンドを用意しました ([#926])
-* LaTeX 向けに、図版の BoudingBox の採取手段を変更する `pdfmaker/bbox` パラメータを追加しました ([#947])
+* LaTeX 向けに、図版の BoundingBox の採取手段を変更する `pdfmaker/bbox` パラメータを追加しました ([#947])
 * 新機能：空行を入れる命令 `//blankline` を追加しました ([#942])
 
 ## 非互換の変更
@@ -1994,7 +1994,7 @@
 
 ### HTMLBuilder
 
-* pygmentsによるhiglightingをconfig.ymlで"pygments: true"と指定した場合のみ有効になるようにしました。
+* pygmentsによるhighlightingをconfig.ymlで"pygments: true"と指定した場合のみ有効になるようにしました。
 * EPUB3での脚注について、epub:type="noteref"とepub:type="footnote"が指定されるようになりました。
 
 ### LATEXBuilder

--- a/NEWS.md
+++ b/NEWS.md
@@ -279,7 +279,7 @@
 
 ## Bug Fixes
 * fixed WebMaker, review-vol and review-index errors when `contentdir` is defined ([#1633])
-* WebMaker: fixed `images/html` foder not being found ([#1623])
+* WebMaker: fixed `images/html` folder not being found ([#1623])
 * PDFMaker: fixed chapterlink in term list ([#1619])
 * PDFMaker: fixed errors when index contains `{`, `}`, or `|` ([#1611])
 * review-vol: valid error messages will be displayed when invalid headings are found ([#1604])
@@ -309,7 +309,7 @@
 * added a test of TeX compilation to GitHub Actions ([#1643])
 * refactored codes according to Rubocop 1.10 ([#1593], [#1598], [#1613], [#1636], [#1647], [#1669])
 * fixed duplicate IDs of syntax-book sample ([#1646])
-* refactored the way to reference relative pathes ([#1639])
+* refactored the way to reference relative paths ([#1639])
 * refactored `ReVIEW::LineInput` class ([#1638])
 * update Copyright to 2021 ([#1632])
 * added Ruby 3.0 to the test platform ([#1622])
@@ -386,7 +386,7 @@
 
 ## Bug Fixes
 * PDFMaker: fixed a problem with multiple same-named image files with different extensions that would cause them to be misaligned ([#1483])
-* PDFMaker: fixed a problem that cuased an error when the author name (`aut`) was empty ([#1517])
+* PDFMaker: fixed a problem that caused an error when the author name (`aut`) was empty ([#1517])
 * PDFMaker: fixed a problem that caused an error if `//indepimage`'s image file didn't exist and ID contained characters to be TeX-escaped ([#1527])
 * PDFMaker: fixed a problem with characters to be TeX-escaped in the `bookttilename` and `aut` parameters causing incorrect PDF metainformation ([#1533])
 * WebMaker: fixed to avoid nil in HTML template ([#1545])
@@ -396,7 +396,7 @@
 ## Enhancements
 * fix warning message to output more detailed information of item ([#1523])
 * PDFMaker: make `@<hd>` op a hyperlink (when `media=ebook`) ([#1530])
-* use `cgi/escape` first and `cgi/util` as fallback. remove orignal implementation in `ReVIEW::HTMLUtils.escape()` ([#1536])
+* use `cgi/escape` first and `cgi/util` as fallback. remove original implementation in `ReVIEW::HTMLUtils.escape()` ([#1536])
 * suppress warning with same `@<icon>` ([#1541])
 * fix an error handling when a badly encoded file is received ([#1544])
 * introduce IndexBuilder. IndexBuilder first scans the entire project files and provides indexes for each builder ([#1384], [#1552])
@@ -499,7 +499,7 @@
 
 # Version 4.1.0
 ## New Features
-* add `table_row_separator` to specify a separator that separates table rows. Accceptable value: tabs (means `\t+`, default), `singletab` (means `\t`), spaces (means `\s+`), verticalbar (means `\s*\|\s*`) ([#1420])
+* add `table_row_separator` to specify a separator that separates table rows. Acceptable value: tabs (means `\t+`, default), `singletab` (means `\t`), spaces (means `\s+`), verticalbar (means `\s*\|\s*`) ([#1420])
 * PDFMaker, EPUBMaker, WEBMaker, TEXTMaker, IDGXMLMaker: add `-y` (`--only`) option to specify the files to convert instead of all files ([#1428])
 * add `--without-config-comment` option to review-init command to exclude comments from config.yml ([#1453])
 * PDFMaker: add `use_original_image_size` in `pdfmaker` section. If this parameter is set to true, images in `//image`, `//indepimage`, and `//imgtable` will be placed in actual size, not textwidth ([#1461])
@@ -646,7 +646,7 @@
 * refactor mkdchap* and mkpart* ([#1383])
 * don't update rubygems in Travis CI ([#1389])
 * refactor around Index ([#1390])
-* add configration for review-jlreq to sample documents ([#1391])
+* add configuration for review-jlreq to sample documents ([#1391])
 * definition list should start with spaces ([#1398])
 
 ## Contributors
@@ -971,7 +971,7 @@
 * add `review-epub2html` to produce single HTML file from EPUB file for CSS typesetting ([#1098])
 
 ## Breaking Changes
-* PDFMaker: allow a path with space character on `texcommand`, `dvicommmand`, and `makeindex_command`. Due to this change, these parameters no longer take command options. use `texoptions`, `dvioptions`, and `makeindex_options` to specify  options ([#1091])
+* PDFMaker: allow a path with space character on `texcommand`, `dvicommand`, and `makeindex_command`. Due to this change, these parameters no longer take command options. use `texoptions`, `dvioptions`, and `makeindex_options` to specify  options ([#1091])
 * PDFMaker: the file used internally has been changed from `book.tex` to `__REVIEW_BOOK__.tex` ([#1081])
 * PDFMaker: dropped geometry.sty from jsbook style ([#912])
 * PDFMaker: use twocolumn option for jsbook style ([#1032])
@@ -991,7 +991,7 @@
 
 ## Docs
 * Move sample documents to /samples folder ([#1073])
-* Add descriptions abount hooks and parameters of indexing into `config.yml.sample` ([#1097])
+* Add descriptions about hooks and parameters of indexing into `config.yml.sample` ([#1097])
 * Fix typo in quickstart.md ([#1079])
 
 ## Contributors
@@ -1035,7 +1035,7 @@
 * When the value of review_version is 3 or more, `@<m>` no longer add a space before and after formula ([#943])
 * the function of automatic detection of highlight target language by identifier in `//list`, `//listnum` is removed from HTMLBuilder ([#1016])
 * LATEXBuilder: restructured `layout.tex.erb` ([#950])
-* LATEXBuilder: add a new envirionment `reviewlistblock` in LaTeX ([#916])
+* LATEXBuilder: add a new environment `reviewlistblock` in LaTeX ([#916])
 * LATEXBuilder: attach `plistings` package and suport it instead of jlisting  for `listings` ([#635])
 * LATEXBuilder: remove underline in anchor for printing use ([#808])
 * LATEXBuilder: use more abstract name like `\reviewbold` instead of `\textbf` ([#792])
@@ -1116,7 +1116,7 @@
 ## New Features
 
 * add a new maker command `review-textmaker` to output plain text files ([#926])
-* LATEXBuilder: add a new parameter `pdfmaker/bbox` for settings of BoudingBox ([#947])
+* LATEXBuilder: add a new parameter `pdfmaker/bbox` for settings of BoundingBox ([#947])
 * add a new command `//blankline` ([#942])
 
 ## Breaking Changes
@@ -1131,7 +1131,7 @@
 * fix column closing ([#894])
 * fix internal errors in `@<hd>` ([#896])
 * LATEXBuilder: fix to ignore empty caption ([#922])
-* fix invalid commmand errors in `//graph` when using gnuplot ([#931])
+* fix invalid command errors in `//graph` when using gnuplot ([#931])
 * fix errors of `review` command in Windows ([#940])
 * EPUBMaker: fix error of removing temporary files in Windows ([#946])
 
@@ -1196,7 +1196,7 @@
 * use built-in Logger class for warns and errors ([#705])
 * EPUBMaker: warn of large images because of rejecting ebook stores ([#819])
 * LATEXBuilder: add new inline command `@<pageref>` ([#836])
-* support inline notaion `| |` and `$ $` instead of `{}` to surpress escaping `}` ([#876])
+* support inline notation `| |` and `$ $` instead of `{}` to suppress escaping `}` ([#876])
 
 ## Breaking Changes
 
@@ -1211,7 +1211,7 @@
 
 * fix misrecognition of HeadlineIndex ([#121])
 * TOPBuilder: fix metric parameter in `//image` and `//indepimage` ([#805])
-* fix refering columns in other chapters ([#817])
+* fix referring columns in other chapters ([#817])
 * use execution date when `date` in config.yml is empty ([#824])
 * fix I18N messages of `listref`, `imgref`, and `tableref` in frontmatters and backmatters ([#830])
 * WebMaker: fix booktitle using Hash ([#831])
@@ -1235,7 +1235,7 @@
 
 ## Others
 
-* fix coding rules to surpress rubocop v0.50.0 ([#823])
+* fix coding rules to suppress rubocop v0.50.0 ([#823])
 
 ## Contributors
 
@@ -1340,7 +1340,7 @@
 * PDFMaker: support index `@<idx>`, `@<hidx>` ([#261],[#660],[#669],[#740])
 * add RSTBuilder ([#733],[#738])
 * add `//embed{...//}` and `@<embed>{...}` ([#730],[#751],[#757],[#758])
-* HTMLBuilder, IDGXMLBuilder, LATEXBuilder: suppot `//firstlinenum` for `//listnum` and `//emlistnum` ([#685],[#688])
+* HTMLBuilder, IDGXMLBuilder, LATEXBuilder: support `//firstlinenum` for `//listnum` and `//emlistnum` ([#685],[#688])
 * review-compile: `--nolfinxml` is deprecated ([#683],[#708])
 * HTMLBuilder: Enclose references (`@<img>`, `@<table>`, and `@<list>`) with `<span>`. Class names are 'imgref', 'tableref', and 'listref'. ([#696],[#697])
 * HTMLBuilder: support Rouge ([#684],[#710],[#711])
@@ -1549,7 +1549,7 @@
 * PDFMaker: Migrate platex to uplatex ([#541])
 * EPUBMaker: Support ebpaj format. ([#251], [#429])
 * EPUBMaker: Add `direction` in default setting ([#508])
-* EPUBMaker: Allow `pronounciation` of booktitle and author ([#507])
+* EPUBMaker: Allow `pronunciation` of booktitle and author ([#507])
 * review-preproc: allow monkeypatch in review-preproc ([#494])
 * HTMLBuilder: Disable hyperlink with `@<href>` with epubmaker/externallink: false in config.yml ([#509], [#544])
 * EPUBMaker: Add custom prefix and `<meta>` element in OPF ([#513])
@@ -2001,7 +2001,7 @@ To support language parameter for syntax highlighting, if you use review-ext.rb 
 
 ### HTMLBuilder
 
-* Use pygments higlighting only if "pygments: true" is defined.
+* Use pygments highlighting only if "pygments: true" is defined.
 * Support epub:type="noteref" and epub:type="footnote" in EPUB3
 
 ### LATEXBuilder

--- a/doc/config.yml.sample
+++ b/doc/config.yml.sample
@@ -416,7 +416,7 @@ pdfmaker:
   # 画像のデフォルトのサイズを、版面横幅合わせではなく、原寸をそのまま利用する
   # use_original_image_size: null
   #
-  # PDFやIllustratorファイル(.ai)の画像のBoudingBoxの抽出に指定のボックスを採用する
+  # PDFやIllustratorファイル(.ai)の画像のBoundingBoxの抽出に指定のボックスを採用する
   # cropbox(デフォルト), mediabox, artbox, trimbox, bleedboxから選択する。
   # Illustrator CC以降のIllustratorファイルに対してはmediaboxを指定する必要がある
   # bbox: mediabox

--- a/doc/config.yml.sample-simple
+++ b/doc/config.yml.sample-simple
@@ -3,7 +3,7 @@ review_version: 5.0
 
 # debug: true
 
-## inherited configuratons
+## inherited configurations
 
 # inherit: ["config-default.yml"]
 
@@ -23,7 +23,7 @@ prt: "Re:VIEW Printing inc."
 contact: "https://reviewml.org/"
 date: 2018-11-11
 history: [["2012-01-30"],["2016-04-20","2016-05-03"],["2018-11-11"]]
-rights: (C) 2016-2020 Re:VIEW Commiters, some rights reserved.
+rights: (C) 2016-2020 Re:VIEW Committers, some rights reserved.
 description: sample config.yml file for Re:VIEW book
 # urnid: urn:uuid:ffffffff-ffff-ffff-ffff-ffffffffffff
 # isbn: null

--- a/doc/format.md
+++ b/doc/format.md
@@ -44,7 +44,7 @@ Usage:
 
 Headings should not have any spaces before title; if line head has space, it is as paragraph.
 
-You should add emply lines between Paragraphs and Headings.
+You should add empty lines between Paragraphs and Headings.
 
 ## Column
 
@@ -107,7 +107,7 @@ Usage:
 In itemize, you must write one more space character at line head.
 When you use `*` without spaces in line head, it's just paragraph.
 
-You should add emply lines between Paragraphs and Itemize (same as Ordered and Non-Orderd).
+You should add empty lines between Paragraphs and Itemize (same as Ordered and Non-Ordered).
 
 ## Ordered Itemize
 
@@ -180,7 +180,7 @@ The syntax of block commands is below:
 //}
 ```
 
-If there is no options, the begining line is just `//command{`.  When you want to use a character `]`, you must use escaping `\]`.
+If there is no options, the beginning line is just `//command{`.  When you want to use a character `]`, you must use escaping `\]`.
 
 Some block commands has no content.
 
@@ -188,7 +188,7 @@ Some block commands has no content.
 //command[option1][option2]...
 ```
 
-Inline commands are used in block,  paragraphes, headings, block contents and block options.
+Inline commands are used in block,  paragraphs, headings, block contents and block options.
 
 ```
 @<command>{content}
@@ -370,7 +370,7 @@ When you refer a image in the other chapter, you can use the same way as a list 
 
 When you want to use images in paragraph or other inline context, you can use `@<icon>`.
 
-### Finding image pathes
+### Finding image paths
 
 The order of finding image is as follows.  The first matched one is used.
 
@@ -384,7 +384,7 @@ The order of finding image is as follows.  The first matched one is used.
 ```
 
 * ``<imgdir>`` is `images` as default.
-* ``<builder>`` is a builder (target) name to use.  When you use review-comile commmand with ``--target=html``, `<imagedir>/<builder>` is `images/html`. The builder name for epubmaker and webmaker is `html`, for pdfmaker it is `latex`, and for textmaker it is `top`.
+* ``<builder>`` is a builder (target) name to use.  When you use review-comile command with ``--target=html``, `<imagedir>/<builder>` is `images/html`. The builder name for epubmaker and webmaker is `html`, for pdfmaker it is `latex`, and for textmaker it is `top`.
 * ``<chapid>`` is basename of *.re file.  If the filename is `ch01.re`, chapid is `ch01`.
 * ``<id>`` is the ID of the first argument of `//image`.  You should use only printable ASCII characters as ID.
 * ``<ext>`` is file extensions of Re:VIEW.  They are different by the builder you use.
@@ -494,7 +494,7 @@ When you want to use an empty column, you write `.`.
 Usage:
 
 ```
-//table[envvars][Important environment varialbes]{
+//table[envvars][Important environment variables]{
 Name            Comment
 -------------------------------------------------------------
 PATH            Directories where commands exist
@@ -536,7 +536,7 @@ When using LaTeX or IDGXML builder, you can specify each column width of the tab
 //tsize[|builder|width-of-column1,width-of-column2,...]
 ```
 
-* The collumn width is specified in mm.
+* The column width is specified in mm.
 * For IDGXML, if only 1st of the three columns is specified, the remaining 2nd and 3rd columns will be the width of the remainder of the live area width equally divided. It is not possible to specify that only the 1st and 3rd columns are specified.
 * For LaTeX, you have to specify all column widths.
 * For LaTeX, you can also directly specify the column parameter of LaTeX table macro like `//tsize[|latex||p{20mm}cr|]`.
@@ -869,7 +869,7 @@ imgmath_options:
 
 `//noindent` is a tag for spacing.
 
-* `//noindent` : ingore indentation immediately following line. (in HTML, add `noindent` class)
+* `//noindent` : ignore indentation immediately following line. (in HTML, add `noindent` class)
 
 ## Blank line
 
@@ -890,7 +890,7 @@ Insert two blank line below.
 
 ## Referring headings
 
-There are 3 inline commands to refer a chapter.  These references use Chapter ID. The Chapter ID is filename of chapter without extentions.  For example, Chapter ID of `advanced.re` is `advance`.
+There are 3 inline commands to refer a chapter.  These references use Chapter ID. The Chapter ID is filename of chapter without extensions.  For example, Chapter ID of `advanced.re` is `advance`.
 
 * `@<chap>{ChapterID}` : chapter number (ex. `Chapter 17`).
 * `@<title>{ChapterID}` : chapter title

--- a/doc/makeindex.md
+++ b/doc/makeindex.md
@@ -93,5 +93,5 @@ For example, if you want to change the appearance of the index page, specify the
 ## Hint
 The builders other than LaTeX builder don't provide a method to use indexes. Because the targets of other builders don't have a general way of sorting or outputting indexes.
 
-In EPUB (HTML builder), the index is embeded as `<!-- IDX:indexword -->` comment. In IDGXML builder, it is embeded as `<index value="indexword">` XML element.
+In EPUB (HTML builder), the index is embedded as `<!-- IDX:indexword -->` comment. In IDGXML builder, it is embedded as `<index value="indexword">` XML element.
 You can probably pick up them and prepare your own tool to sort (by using LaTeX mendex command, e.g.) and output.

--- a/doc/pdfmaker.md
+++ b/doc/pdfmaker.md
@@ -33,7 +33,7 @@ Conversion from config.yml to TeX macro is executed in `templates/latex/config.e
 
 In the new `layout.tex.erb`, content is constructed by defining or changing the following macros.
 
-* `\reviewbegindocumenthook` : hook begining the document
+* `\reviewbegindocumenthook` : hook beginning the document
 * `\reviewcoverpagecont` : cover contents
 * `\reviewfrontmatterhook` : hook before frontmatter
 * `\reviewtitlepagecont` : titlepage contents

--- a/doc/preproc.md
+++ b/doc/preproc.md
@@ -69,7 +69,7 @@ $ rake preproc
 You also can embed a part of the target file with `#@maprange` marker.
 
 Add `#@range_begin(ID)` and `#@range_end` in the target file you want to embed.
-In `#@range_begin(ID)`, you must add ID as parameger to identify the part.
+In `#@range_begin(ID)`, you must add ID as parameter to identify the part.
 
 In the code below, `sample` is the ID of the range to embed.
 

--- a/doc/quickstart.md
+++ b/doc/quickstart.md
@@ -137,8 +137,8 @@ To convert files in the project, use review-*maker command.
 
 - review-pdfmaker: generate PDF
 - review-epubmaker: generate EPUB
-- review-textmaker: genrate plaintext
-- review-idgxmlmaker: genrate InDesign XML
+- review-textmaker: generate plaintext
+- review-idgxmlmaker: generate InDesign XML
 
 To generate PDF, you should install TeXLive 2012 or later. To generate EPUB, you should install zip command.
 When you want to use MathML, you should install [MathML library](http://www.hinet.mydns.jp/?mathml.rb)

--- a/doc/writing_vertical.md
+++ b/doc/writing_vertical.md
@@ -1,4 +1,4 @@
-# Supporing Vertical Writing (experimental)
+# Supporting Vertical Writing (experimental)
 
 From Re:VIEW 2.0, Re:VIEW supports vertical writings, especially for Japanese document.
 

--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -229,7 +229,7 @@ module ReVIEW
       when 'verticalbar'
         Regexp.new('\s*\\' + escape('|') + '\s*')
       else
-        app_error "Unknown value for 'table_row_separator', shold be: tabs, singletab, spaces, verticalbar"
+        app_error "Unknown value for 'table_row_separator', should be: tabs, singletab, spaces, verticalbar"
       end
     end
 

--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -647,7 +647,7 @@ module ReVIEW
         h = Math.sqrt(img.height * maxpixels / img.width)
         w = maxpixels / h
         fname.sub!("#{basetmpdir}/", '')
-        warn "#{fname}: #{img.width}x#{img.height} exceeds a limit. suggeted value is #{w.to_i}x#{h.to_i}"
+        warn "#{fname}: #{img.width}x#{img.height} exceeds a limit. suggested value is #{w.to_i}x#{h.to_i}"
       end
 
       true

--- a/samples/sample-book/src/config.yml
+++ b/samples/sample-book/src/config.yml
@@ -9,7 +9,7 @@ pbl: Re:VIEW Publishers
 edt: Re:VIEW Editors
 date: 2016-04-29
 history: [["2011-08-03 v1.0.0版発行"],["2016-04-29 v2.0.0版発行"]]
-rights: (C) 2016 Re:VIEW Commiters
+rights: (C) 2016 Re:VIEW Committers
 highlight: null
 htmlext: html
 stylesheet: ["style.css"]

--- a/test/test_epub3maker.rb
+++ b/test/test_epub3maker.rb
@@ -701,10 +701,10 @@ EOT
     end
 
     expected = <<-EOS
-large.gif: 250x150 exceeds a limit. suggeted value is 95x57
-large.jpg: 250x150 exceeds a limit. suggeted value is 95x57
-large.png: 250x150 exceeds a limit. suggeted value is 95x57
-large.svg: 250x150 exceeds a limit. suggeted value is 95x57
+large.gif: 250x150 exceeds a limit. suggested value is 95x57
+large.jpg: 250x150 exceeds a limit. suggested value is 95x57
+large.png: 250x150 exceeds a limit. suggested value is 95x57
+large.svg: 250x150 exceeds a limit. suggested value is 95x57
 EOS
     assert_equal expected, err
   end


### PR DESCRIPTION
Intentionally omitted changing for `doc/ChangeLog-*` and ruby module names.