### PR TITLE
ignore missing files in verify_target_images

### DIFF
--- a/lib/review/epubmaker.rb
+++ b/lib/review/epubmaker.rb
@@ -202,7 +202,10 @@ module ReVIEW
       @producer.contents.each do |content|
         case content.media
         when 'application/xhtml+xml'
-          File.open("#{basetmpdir}/#{content.file}") do |f|
+          unless File.exist?(File.join(basetmpdir, content.file))
+            next
+          end
+          File.open(File.join(basetmpdir, content.file)) do |f|
             REXML::Document.new(File.new(f)).each_element('//img') do |e|
               @config['epubmaker']['force_include_images'].push(e.attributes['src'])
               if e.attributes['src'] =~ /svg\Z/i
@@ -211,6 +214,9 @@ module ReVIEW
             end
           end
         when 'text/css'
+          unless File.exist?(File.join(basetmpdir, content.file))
+            next
+          end
           File.open(File.join(basetmpdir, content.file)) do |f|
             f.each_line do |l|
               l.scan(/url\((.+?)\)/) do |_m|

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -966,4 +966,19 @@ EOT
       assert_equal true, true
     end
   end
+
+  def test_accept_missing_file_in_verify_target_images
+    epubmaker_instance do |epubmaker, tmpdir|
+      epubmaker.config['epubmaker']['verify_target_images'] = true
+      epubmaker.config['coverimage'] = 'cover.png'
+
+      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'missing.html', title: 'MISSING', level: 1)
+      epubmaker.producer.contents << ReVIEW::EPUBMaker::Content.new(file: 'missing.css')
+      epubmaker.verify_target_images(tmpdir)
+
+      expect = %w[images/cover.png]
+      assert_equal expect, epubmaker.config['epubmaker']['force_include_images']
+      assert_equal true, true
+    end
+  end
 end


### PR DESCRIPTION
#1927 へのworkaroundとなります。
verify_target_imagesにおいて、存在しないcontentsを無視します。
