### PR TITLE
Add `logger` as a dependency

### DIFF
--- a/review.gemspec
+++ b/review.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('base64')
   gem.add_dependency('csv')
   gem.add_dependency('image_size')
+  gem.add_dependency('logger')
   gem.add_dependency('nkf')
   gem.add_dependency('rexml')
   gem.add_dependency('rouge')


### PR DESCRIPTION
現在、Ruby 3.4でRe:VIEWを実行すると、以下のようなwarningが表示されます。

```bash
$ bundle exec review-compile --target=html --footnotetext --stylesheet=style.css
/home/y-yagi/.rbenv/versions/3.4.4/lib/ruby/gems/3.4.0/gems/review-5.10.0/lib/review/logger.rb:1: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
```

warningメッセージの説明にある通り、これは`logger`がdefault gemでなくなる為です。

その為、このPRでは、`logger`をdependencyとして追加し、warningが出力されないよう対応しています。

過去の類似の対応：#1911