### PR TITLE
Lock `ruby-zip to v2

### DIFF
--- a/review.gemspec
+++ b/review.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('nkf')
   gem.add_dependency('rexml')
   gem.add_dependency('rouge')
-  gem.add_dependency('rubyzip')
+  gem.add_dependency('rubyzip', '~> 2.0')
   gem.add_dependency('tty-logger')
   gem.add_development_dependency('mini_magick', '~> 5.0.0')
   gem.add_development_dependency('playwright-runner')


### PR DESCRIPTION
It seems that v3 generates invalid format file and epubcheck raises the following error.

```
ERROR(PKG-005): book.epub//D:/a/review/review/hello/book.epub(-1,-1): The mimetype file has an extra field of length 20. The use of the extra field feature of the ZIP format is not permitted for the mimetype file.
Validating using EPUB version 3.3 rules.
```