### PR TITLE
Lock `ruby-zip` to v2

### DIFF
--- a/review.gemspec
+++ b/review.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('nkf')
   gem.add_dependency('rexml')
   gem.add_dependency('rouge')
-  gem.add_dependency('rubyzip')
+  gem.add_dependency('rubyzip', '~> 2.0')
   gem.add_dependency('tty-logger')
   gem.add_development_dependency('mini_magick', '~> 5.0.0')
   gem.add_development_dependency('playwright-runner')


### PR DESCRIPTION
現在、Re:VIEWで生成されたepubファイルを`epubcheck`でチェックすると、下記のようなエラーメッセージが表示されます。

```
ERROR(PKG-005): book.epub//D:/a/review/review/hello/book.epub(-1,-1): The mimetype file has an extra field of length 20. The use of the extra field feature of the ZIP format is not permitted for the mimetype file.
```
CI: https://github.com/kmuto/review/actions/runs/16746444069/job/47408103746?pr=1939

少し調査してみたところ、どうやら`ruby-zip` 3系を使う場合に上記エラーが発生するようです。

`ruby-zip` 3系のどの変更が原因かまでは確認出来ていませんが、生成されるファイルが不正な状態になる、及び、CIがエラーになっているのは良くない状態なので、一時的なに`ruby-zip`を2系にロックするのはどうでしょうか。