### PR TITLE
chore: use `require_relative` instead of `require` in test

### DIFF
--- a/test/test_book.rb
+++ b/test/test_book.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'book_test_helper'
+require_relative 'book_test_helper'
 require 'fileutils'
 
 class BookTest < Test::Unit::TestCase

--- a/test/test_book_chapter.rb
+++ b/test/test_book_chapter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'book_test_helper'
+require_relative 'book_test_helper'
 
 class ChapterTest < Test::Unit::TestCase
   include BookTestHelper

--- a/test/test_book_part.rb
+++ b/test/test_book_part.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'book_test_helper'
+require_relative 'book_test_helper'
 class PartTest < Test::Unit::TestCase
   include BookTestHelper
 

--- a/test/test_builder.rb
+++ b/test/test_builder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/builder'
 
 require 'review/book'

--- a/test/test_catalog.rb
+++ b/test/test_catalog.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'test_helper'
-require 'book_test_helper'
+require_relative 'test_helper'
+require_relative 'book_test_helper'
 require 'review/catalog'
 
 class CatalogTest < Test::Unit::TestCase

--- a/test/test_catalog_converter_cmd.rb
+++ b/test/test_catalog_converter_cmd.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'tmpdir'
 require 'fileutils'
 require 'yaml'

--- a/test/test_compiler.rb
+++ b/test/test_compiler.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/latexbuilder'

--- a/test/test_configure.rb
+++ b/test/test_configure.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/epubmaker'
 
 class ConfigureTest < Test::Unit::TestCase

--- a/test/test_converter.rb
+++ b/test/test_converter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'test_helper'
-require 'book_test_helper'
+require_relative 'test_helper'
+require_relative 'book_test_helper'
 require 'review/converter'
 require 'review/latexbuilder'
 

--- a/test/test_epub3maker.rb
+++ b/test/test_epub3maker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/configure'
 require 'review/epubmaker'
 

--- a/test/test_epubmaker.rb
+++ b/test/test_epubmaker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/epubmaker'
 
 class EPUBMakerTest < Test::Unit::TestCase

--- a/test/test_epubmaker_cmd.rb
+++ b/test/test_epubmaker_cmd.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'tmpdir'
 require 'fileutils'
 require 'yaml'

--- a/test/test_extentions_hash.rb
+++ b/test/test_extentions_hash.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/extentions/hash'
 
 class TestExtentionsHash < Test::Unit::TestCase

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'test_helper'
-require 'book_test_helper'
+require_relative 'test_helper'
+require_relative 'book_test_helper'
 require 'review'
 
 class HTMLBuidlerTest < Test::Unit::TestCase

--- a/test/test_htmltoc.rb
+++ b/test/test_htmltoc.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/htmltoc'
 
 class HTMLTocTest < Test::Unit::TestCase

--- a/test/test_htmlutils.rb
+++ b/test/test_htmlutils.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/htmlutils'
 
 class HTMLUtilsTest < Test::Unit::TestCase

--- a/test/test_i18n.rb
+++ b/test/test_i18n.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review'
 require 'tmpdir'
 

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'test_helper'
-require 'book_test_helper'
+require_relative 'test_helper'
+require_relative 'book_test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/idgxmlbuilder'

--- a/test/test_idgxmlmaker_cmd.rb
+++ b/test/test_idgxmlmaker_cmd.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'tmpdir'
 require 'fileutils'
 require 'yaml'

--- a/test/test_image_finder.rb
+++ b/test/test_image_finder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review'
 require 'review/book/image_finder'
 require 'fileutils'

--- a/test/test_img_graph.rb
+++ b/test/test_img_graph.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/htmlbuilder'
 require 'review/img_graph'
 

--- a/test/test_img_math.rb
+++ b/test/test_img_math.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/htmlbuilder'
 require 'review/img_math'
 require 'mini_magick'

--- a/test/test_index.rb
+++ b/test/test_index.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/book/index'

--- a/test/test_indexbuilder.rb
+++ b/test/test_indexbuilder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/builder'
 
 require 'review/book'

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/latexbuilder'

--- a/test/test_latexbuilder_v2.rb
+++ b/test/test_latexbuilder_v2.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/latexbuilder'

--- a/test/test_lineinput.rb
+++ b/test/test_lineinput.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/lineinput'
 require 'tempfile'
 require 'stringio'

--- a/test/test_location.rb
+++ b/test/test_location.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/compiler'
 
 class LocationTest < Test::Unit::TestCase

--- a/test/test_logger.rb
+++ b/test/test_logger.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/logger'
 
 class LoggerTest < Test::Unit::TestCase

--- a/test/test_makerhelper.rb
+++ b/test/test_makerhelper.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/makerhelper'
 require 'tmpdir'
 require 'fileutils'

--- a/test/test_markdownbuilder.rb
+++ b/test/test_markdownbuilder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/markdownbuilder'

--- a/test/test_md2inaobuilder.rb
+++ b/test/test_md2inaobuilder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/md2inaobuilder'

--- a/test/test_pdfmaker.rb
+++ b/test/test_pdfmaker.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/pdfmaker'
 
 class PDFMakerTest < Test::Unit::TestCase

--- a/test/test_pdfmaker_cmd.rb
+++ b/test/test_pdfmaker_cmd.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'tmpdir'
 require 'fileutils'
 require 'yaml'

--- a/test/test_plaintextbuilder.rb
+++ b/test/test_plaintextbuilder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/plaintextbuilder'

--- a/test/test_preprocessor.rb
+++ b/test/test_preprocessor.rb
@@ -1,9 +1,9 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/preprocessor'
 require 'stringio'
-require 'book_test_helper'
+require_relative 'book_test_helper'
 
 class PreprocessorTest < Test::Unit::TestCase
   include ReVIEW

--- a/test/test_review_ext.rb
+++ b/test/test_review_ext.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'test_helper'
-require 'book_test_helper'
+require_relative 'test_helper'
+require_relative 'book_test_helper'
 require 'review/compiler'
 require 'review/htmlbuilder'
 

--- a/test/test_reviewheaderlistener.rb
+++ b/test/test_reviewheaderlistener.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'rexml/document'
 require 'rexml/streamlistener'
 require 'review/epubmaker'

--- a/test/test_rstbuilder.rb
+++ b/test/test_rstbuilder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/rstbuilder'

--- a/test/test_sec_counter.rb
+++ b/test/test_sec_counter.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'test_helper'
-require 'book_test_helper'
+require_relative 'test_helper'
+require_relative 'book_test_helper'
 require 'review/sec_counter'
 
 class SecCounterTest < Test::Unit::TestCase

--- a/test/test_template.rb
+++ b/test/test_template.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/template'
 
 class TemplateTest < Test::Unit::TestCase

--- a/test/test_textmaker_cmd.rb
+++ b/test/test_textmaker_cmd.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'tmpdir'
 require 'fileutils'
 require 'yaml'

--- a/test/test_textutils.rb
+++ b/test/test_textutils.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/textutils'
 
 class TextUtilsTest < Test::Unit::TestCase

--- a/test/test_tocprinter.rb
+++ b/test/test_tocprinter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/tocprinter'
 require 'unicode/eaw'
 

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/compiler'
 require 'review/book'
 require 'review/topbuilder'

--- a/test/test_update.rb
+++ b/test/test_update.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/update'
 require 'tmpdir'
 require 'fileutils'

--- a/test/test_webtocprinter.rb
+++ b/test/test_webtocprinter.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/webtocprinter'
-require 'book_test_helper'
+require_relative 'book_test_helper'
 
 class WEBTOCPrinterTest < Test::Unit::TestCase
   include ReVIEW

--- a/test/test_yamlloader.rb
+++ b/test/test_yamlloader.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/yamlloader'
 require 'review/extentions'
 require 'tmpdir'

--- a/test/test_zip_exporter.rb
+++ b/test/test_zip_exporter.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require_relative 'test_helper'
 require 'review/epubmaker'
 require 'review/epubmaker/zip_exporter'
 require 'fileutils'


### PR DESCRIPTION
個別のテストが実行しやすいよう、テストのヘルパーを相対で読み込めるようにします。