### PR TITLE
feat: use pure Ruby library instead of `MiniMagick` in test

### DIFF
--- a/review.gemspec
+++ b/review.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('rouge')
   gem.add_dependency('rubyzip')
   gem.add_dependency('tty-logger')
-  gem.add_development_dependency('mini_magick', '~> 5.0.0')
+  gem.add_development_dependency('chunky_png')
   gem.add_development_dependency('playwright-runner')
   gem.add_development_dependency('pygments.rb')
   gem.add_development_dependency('rake')

--- a/test/image_comparator.rb
+++ b/test/image_comparator.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'chunky_png'
+
+# Compares images using the Structural Similarity Index Measure (SSIM) algorithm
+class ImageComparator
+  def compare(img1, img2)
+    i1 = ChunkyPNG::Image.from_file(img1)
+    i2 = ChunkyPNG::Image.from_file(img2)
+
+    ssim(i1, i2)
+  end
+
+  def ssim(i1, i2)
+    # Return 0 if image dimensions don't match
+    return 0.0 if i1.width != i2.width || i1.height != i2.height
+
+    pixels1 = i1.pixels.map { |p| ChunkyPNG::Color.r(p) } # use only RED
+    pixels2 = i2.pixels.map { |p| ChunkyPNG::Color.r(p) }
+
+    m1 = mean(pixels1)
+    m2 = mean(pixels2)
+    v1 = variance(pixels1, m1)
+    v2 = variance(pixels2, m2)
+    c12 = covariance(pixels1, pixels2, m1, m2)
+
+    k1 = 0.01
+    k2 = 0.03
+    l = 255.0
+    c1 = (k1 * l)**2
+    c2 = (k2 * l)**2
+
+    (((2 * m1 * m2) + c1) * ((2 * c12) + c2)) / (((m1**2) + (m2**2) + c1) * (v1 + v2 + c2))
+  end
+
+  private
+
+  def mean(arr)
+    arr.sum.to_f / arr.size
+  end
+
+  def variance(arr, m)
+    arr.sum { |x| (x - m)**2 }.to_f / arr.size
+  end
+
+  def covariance(arr1, arr2, m1, m2)
+    arr1.zip(arr2).sum { |x, y| (x - m1) * (y - m2) }.to_f / arr1.size
+  end
+end

--- a/test/test_img_math.rb
+++ b/test/test_img_math.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 require 'review/htmlbuilder'
 require 'review/img_math'
-require 'mini_magick'
+require_relative 'image_comparator'
 
 class ImgMathTest < Test::Unit::TestCase
   def setup
@@ -90,16 +90,8 @@ class ImgMathTest < Test::Unit::TestCase
   private
 
   def compare_images(image1, image2)
-    MiniMagick.errors = false
-    compare = MiniMagick.compare
-    compare.metric('SSIM')
-    compare << image1
-    compare << image2
-    compare << File.join(@tmpdir, 'diff.jpg')
-
-    compare.call do |_, dist, _|
-      return dist.to_f
-    end
+    comparator = ImageComparator.new
+    comparator.compare(image1, image2)
   end
 
   def support_latex_in_tests?


### PR DESCRIPTION
MiniMagickでの画像比較がどうにもうまくいかない（imagemagick 6とimagemagick 7の両対応も面倒くさそう）ので、SSIMをRubyで実装して（ChatGPTとClaude Codeに実装させて）みました。

* （当然ながら）あまり速くはないですが大した画像でもないので許容できそう
* PNGのみ対応ですが、それ以外のフォーマットの対応は不要なはず
* 画像比較アルゴリズムは素直に書いただけなので、継続的に手を入れる必要もないはず

ということで、この程度ならまあいいか…というところです。