### PR TITLE
update rubocop 1.80.1

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -204,6 +204,12 @@ Style/CombinableLoops:
 Style/FetchEnvVar:
   Enabled: false
 
+Style/MultipleComparison:
+  Enabled: false
+
+Style/EmptyStringInsideInterpolation:
+  Enabled: false
+
 ### Layout
 
 Layout/BlockAlignment:
@@ -291,6 +297,9 @@ Naming/FileName:
 Naming/HeredocDelimiterNaming:
   Enabled: false
 
+Naming/MethodName:
+  Enabled: false
+
 Naming/MethodParameterName:
   Enabled: false
 
@@ -299,6 +308,9 @@ Naming/VariableNumber:
   Enabled: true
   Exclude:
     - test/*
+
+Naming/PredicateMethod:
+  Enabled: false
 
 #### Security
 

--- a/lib/review/book/book_unit.rb
+++ b/lib/review/book/book_unit.rb
@@ -15,6 +15,7 @@ module ReVIEW
   module Book
     class BookUnit
       include TextUtils
+
       attr_reader :book
       attr_reader :path
       attr_reader :lines

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -630,7 +630,7 @@ module ReVIEW
     end
 
     def compile_block(syntax, args, lines)
-      @builder.__send__(syntax.name, (lines || default_block(syntax)), *args)
+      @builder.__send__(syntax.name, lines || default_block(syntax), *args)
     end
 
     def default_block(syntax)

--- a/lib/review/epubmaker/reviewheaderlistener.rb
+++ b/lib/review/epubmaker/reviewheaderlistener.rb
@@ -20,6 +20,7 @@ module ReVIEW
     #
     class ReVIEWHeaderListener
       include REXML::StreamListener
+
       def initialize(headlines)
         @level = nil
         @content = +''

--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -524,7 +524,7 @@ module ReVIEW
     end
 
     def make_code_block_args(title, caption, lang, first_line_num: 1)
-      caption_str = compile_inline((caption || ''))
+      caption_str = compile_inline(caption || '')
       if title == 'title' && caption_str == '' && @book.config.check_version('2', exception: false)
         caption_str = '\relax' ## dummy charactor to remove lstname
       end

--- a/lib/review/sec_counter.rb
+++ b/lib/review/sec_counter.rb
@@ -25,7 +25,7 @@ module ReVIEW
       n = level - 2
       @counter[n] += 1 if n >= 0
       if @counter.size > n
-        (n + 1..@counter.size).each do |i|
+        ((n + 1)..@counter.size).each do |i|
           @counter[i] = 0
         end
       end

--- a/review.gemspec
+++ b/review.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('playwright-runner')
   gem.add_development_dependency('pygments.rb')
   gem.add_development_dependency('rake')
-  gem.add_development_dependency('rubocop', '~> 1.65.1')
+  gem.add_development_dependency('rubocop', '~> 1.80.1')
   gem.add_development_dependency('rubocop-performance')
   gem.add_development_dependency('rubocop-rake')
   gem.add_development_dependency('simplecov')

--- a/test/test_book.rb
+++ b/test/test_book.rb
@@ -27,7 +27,7 @@ class BookTest < Test::Unit::TestCase
       Dir.mktmpdir do |dir|
         File.write(File.join(dir, 'review-ext.rb'), "#{test_const} = #{num}")
         Book::Base.new(dir)
-        assert_equal num, (Object.class_eval { const_get(test_const) })
+        assert_equal(num, Object.class_eval { const_get(test_const) })
       end
     ensure
       Object.class_eval { remove_const(test_const) }


### PR DESCRIPTION
rubocopを更新します。メソッド名を変えさせるようなcopsはdisableにしています。