### PR TITLE
fix: add `ReVIEW::SnapshotLocation` (frozen Location) class

### DIFF
--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -719,7 +719,7 @@ module ReVIEW
     end
 
     def location
-      @builder.location
+      @builder.location.snapshot
     end
 
     ## override

--- a/lib/review/location.rb
+++ b/lib/review/location.rb
@@ -8,6 +8,8 @@
 # the GNU LGPL, Lesser General Public License version 2.1.
 #
 
+require 'review/snapshot_location'
+
 module ReVIEW
   class Location
     def initialize(filename, f)
@@ -30,5 +32,9 @@ module ReVIEW
     end
 
     alias_method :to_s, :string
+
+    def snapshot
+      SnapshotLocation.new(@filename, lineno)
+    end
   end
 end

--- a/lib/review/snapshot_location.rb
+++ b/lib/review/snapshot_location.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Minero Aoki, Kenshi Muto
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+module ReVIEW
+  # Immutable snapshot of a source file location (filename and line number)
+  class SnapshotLocation
+    def initialize(filename, lineno)
+      @filename = filename
+      @lineno = lineno
+      freeze
+    end
+
+    attr_reader :filename, :lineno
+
+    def string
+      "#{@filename}:#{@lineno}"
+    end
+
+    alias_method :to_s, :string
+
+    def snapshot
+      self
+    end
+  end
+end

--- a/test/test_location.rb
+++ b/test/test_location.rb
@@ -2,6 +2,7 @@
 
 require_relative 'test_helper'
 require 'review/compiler'
+require 'stringio'
 
 class LocationTest < Test::Unit::TestCase
   def setup
@@ -28,5 +29,32 @@ class LocationTest < Test::Unit::TestCase
   def test_to_s_nil
     location = ReVIEW::Location.new('foo', nil)
     assert_equal 'foo:nil', location.to_s
+  end
+
+  def test_snapshot
+    f = StringIO.new("a\nb\nc\n")
+    location = ReVIEW::Location.new('foo', f)
+    snapshot = location.snapshot
+    assert_instance_of(ReVIEW::SnapshotLocation, snapshot)
+    assert_equal 'foo', snapshot.filename
+    assert_equal 0, snapshot.lineno
+    assert_equal 'foo:0', snapshot.to_s
+
+    f.gets
+    assert_equal 1, location.lineno
+    # Snapshot should remain unchanged
+    assert_equal 0, snapshot.lineno
+  end
+
+  def test_snapshot_location_immutable
+    snapshot = ReVIEW::SnapshotLocation.new('bar', 42)
+    assert_equal 'bar:42', snapshot.string
+    assert snapshot.frozen?
+  end
+
+  def test_snapshot_location_snapshot
+    snapshot = ReVIEW::SnapshotLocation.new('baz', 10)
+    snapshot2 = snapshot.snapshot
+    assert_same(snapshot, snapshot2)
   end
 end


### PR DESCRIPTION
細かい修正です。

`ReVIEW::Location`はfilenameとlinenoを持ったmutableなオブジェクトのため、テスト等で特定の場所の情報として扱おうとすると思わぬ結果になることがあるようです。
そのためimmutableなオブジェクトになる`ReVIEW::SnapshotLocation`を追加し、場合によってはこちらを使うよう修正します。