### PR TITLE
chore: add `ReVIEW::LineInput.from_string`

### DIFF
--- a/lib/review/book/chapter.rb
+++ b/lib/review/book/chapter.rb
@@ -70,7 +70,7 @@ module ReVIEW
       end
 
       def find_first_header_option
-        f = LineInput.new(StringIO.new(@content))
+        f = LineInput.from_string(@content)
         begin
           while f.next?
             case f.peek

--- a/lib/review/compiler.rb
+++ b/lib/review/compiler.rb
@@ -280,7 +280,7 @@ module ReVIEW
     private
 
     def do_compile
-      f = LineInput.new(StringIO.new(@chapter.content))
+      f = LineInput.from_string(@chapter.content)
       @builder.bind(self, @chapter, Location.new(@chapter.basename, f))
       @previous_list_type = nil
 

--- a/lib/review/lineinput.rb
+++ b/lib/review/lineinput.rb
@@ -8,6 +8,7 @@
 # the GNU LGPL, Lesser General Public License version 2.1.
 #
 require 'review/exception'
+require 'stringio'
 
 module ReVIEW
   class LineInput
@@ -20,6 +21,11 @@ module ReVIEW
       @buf = []
       @lineno = 0
       @eof_p = false
+    end
+
+    # Create LineInput from a string directly
+    def self.from_string(string)
+      new(StringIO.new(string))
     end
 
     def inspect

--- a/test/test_lineinput.rb
+++ b/test/test_lineinput.rb
@@ -43,25 +43,24 @@ class LineInputTest < Test::Unit::TestCase
   end
 
   def test_peek
-    li = ReVIEW::LineInput.new(StringIO.new)
+    li = ReVIEW::LineInput.from_string('')
     assert_equal nil, li.peek
 
-    li = ReVIEW::LineInput.new(StringIO.new('abc'))
+    li = ReVIEW::LineInput.from_string('abc')
     assert_equal 'abc', li.peek
   end
 
   def test_next?
-    li = ReVIEW::LineInput.new(StringIO.new)
+    li = ReVIEW::LineInput.from_string('')
     assert !li.next?
 
-    li = ReVIEW::LineInput.new(StringIO.new('abc'))
+    li = ReVIEW::LineInput.from_string('abc')
     assert li.next?
   end
 
   def test_each
     content = "abc\ndef\nghi"
-    io = StringIO.new(content)
-    li = ReVIEW::LineInput.new(io)
+    li = ReVIEW::LineInput.from_string(content)
 
     data = []
     li.each { |l| data << l } # rubocop:disable Style/MapIntoArray
@@ -69,8 +68,7 @@ class LineInputTest < Test::Unit::TestCase
   end
 
   def test_while_match
-    io = StringIO.new("abc\ndef\nghi")
-    li = ReVIEW::LineInput.new(io)
+    li = ReVIEW::LineInput.from_string("abc\ndef\nghi")
 
     li.while_match(/^[ad]/) do
       # skip
@@ -80,8 +78,7 @@ class LineInputTest < Test::Unit::TestCase
   end
 
   def test_until_match
-    io = StringIO.new("abc\ndef\nghi")
-    li = ReVIEW::LineInput.new(io)
+    li = ReVIEW::LineInput.from_string("abc\ndef\nghi")
 
     li.until_match(/^[^a]/) do
       # skip
@@ -93,8 +90,7 @@ class LineInputTest < Test::Unit::TestCase
   def test_invalid_control_sequence
     0.upto(31) do |n|
       content = n.chr
-      io = StringIO.new(content)
-      li = ReVIEW::LineInput.new(io)
+      li = ReVIEW::LineInput.from_string(content)
       if [9, 10, 13].include?(n) # TAB, LF, CR
         assert_equal content, li.gets
       else


### PR DESCRIPTION
こちらも細かい修正です。

文字列から直接`ReVIEW::LineInput`のオブジェクトを作れる`ReVIEW::LineInput.from_string`メソッドを追加します。
これはコンストラクタがシンプルになるだけで、挙動の変更は特にありません。