### PR TITLE
fix: test_idgxmlmaker_cmd を単体でも実行できるようにする

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -19,7 +19,7 @@ def prepare_samplebook(srcdir, bookdir, latextemplatedir, configfile)
   samplebook_dir = File.expand_path("../samples/#{bookdir}/", __dir__)
   files = Dir.glob(File.join(samplebook_dir, '*'))
   # ignore temporary built files
-  files.delete_if { |file| file =~ /.*-(pdf|epub|text)/ || file == 'webroot' }
+  files.delete_if { |file| file =~ /.*-(pdf|epub|text|idgxml)/ || file == 'webroot' }
   FileUtils.cp_r(files, srcdir)
   if latextemplatedir
     # copy from review-jsbook or review-jlreq

--- a/test/test_idgxmlmaker_cmd.rb
+++ b/test/test_idgxmlmaker_cmd.rb
@@ -31,7 +31,15 @@ class IDGXMLMakerCmdTest < Test::Unit::TestCase
       ruby_cmd = File.join(RbConfig::CONFIG['bindir'], RbConfig::CONFIG['ruby_install_name']) + RbConfig::CONFIG['EXEEXT']
       Dir.chdir(@tmpdir1) do
         _o, e, s = Open3.capture3("#{ruby_cmd} -S #{REVIEW_IDGXMLMAKER} #{option} #{configfile}")
-        if defined?(ReVIEW::TTYLogger)
+        # Check if tty-logger is available by attempting to require it
+        tty_logger_available = begin
+          require 'tty-logger'
+          true
+        rescue LoadError
+          false
+        end
+
+        if tty_logger_available
           assert_match(/SUCCESS|INFO/, e) # XXX TTY::Logger should be fixed
         else
           assert_equal '', e


### PR DESCRIPTION
`ruby test/test_idgxmlmaker_cmd.rb`と単体で実行するとエラーになるのを修正します。

* `ReVIEW::TTYLogger`が事前に読み込まれてなくても動くようにする
* 一時ファイルを消す
