### PR TITLE
fix: use hyperref for internal anchors in LATEXBuilder

### DIFF
--- a/lib/review/latexbuilder.rb
+++ b/lib/review/latexbuilder.rb
@@ -1435,7 +1435,15 @@ module ReVIEW
     end
 
     def compile_href(url, label)
-      if /\A[a-z]+:/.match?(url)
+      # Handle internal references (URLs starting with #)
+      if url.start_with?('#')
+        anchor = url.sub(/\A#/, '')
+        if label
+          "\\hyperref[#{escape(anchor)}]{#{escape(label)}}"
+        else
+          "\\hyperref[#{escape(anchor)}]{#{escape(url)}}"
+        end
+      elsif /\A[a-z]+:/.match?(url)
         if label
           macro('href', escape_url(url), escape(label))
         else

--- a/test/test_latexbuilder.rb
+++ b/test/test_latexbuilder.rb
@@ -131,6 +131,16 @@ EOS
     assert_equal '\\href{mailto:takahashim@example.com}{takahashim@example.com}', actual
   end
 
+  def test_href_internal_with_label
+    actual = compile_inline('@<href>{#inlineop, inline operations}')
+    assert_equal '\\hyperref[inlineop]{inline operations}', actual
+  end
+
+  def test_href_internal_without_label
+    actual = compile_inline('@<href>{#inlineop}')
+    assert_equal '\\hyperref[inlineop]{\\#inlineop}', actual
+  end
+
   def test_inline_br
     actual = compile_inline('@<br>{}')
     assert_equal %Q(\\\\\n), actual


### PR DESCRIPTION
samples/syntax-book/ch02.reにある`@<href>{#inlineop}`のような参照がLATEXBuilderでは壊れるのを修正します。

### Before

<img width="745" height="98" alt="before_review" src="https://github.com/user-attachments/assets/29e76ec8-2333-431b-905d-a526b01eab38" />

### After

<img width="765" height="108" alt="after_review" src="https://github.com/user-attachments/assets/65ce1688-7cc1-44cb-a66b-bbd004cd7dbb" />
