### PR TITLE
fix: allow to use `Location#lineno` when io is nil

### DIFF
--- a/lib/review/location.rb
+++ b/lib/review/location.rb
@@ -20,15 +20,11 @@ module ReVIEW
     attr_reader :filename
 
     def lineno
-      @f.lineno
+      @f&.lineno
     end
 
     def string
-      begin
-        "#{@filename}:#{@f.lineno}"
-      rescue StandardError
-        "#{@filename}:nil"
-      end
+      "#{@filename}:#{@f&.lineno || 'nil'}"
     end
 
     alias_method :to_s, :string

--- a/test/test_location.rb
+++ b/test/test_location.rb
@@ -29,6 +29,7 @@ class LocationTest < Test::Unit::TestCase
   def test_to_s_nil
     location = ReVIEW::Location.new('foo', nil)
     assert_equal 'foo:nil', location.to_s
+    assert_equal nil, location.lineno
   end
 
   def test_snapshot


### PR DESCRIPTION
linenoを出力させようとするとエラーになるケースがあったので、`&.`を使ってnilを返すよう修正します（テストに追加したケースです）。
合わせて`Location#string`で、StandardErrorをrescueしていたところも例外を使わないで済ませるよう修正しています。