### PR TITLE
feat: add `math_ml` as dev/test dependency for testing against multiple Ruby verions

### DIFF
--- a/review.gemspec
+++ b/review.gemspec
@@ -31,6 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('rubyzip')
   gem.add_dependency('tty-logger')
   gem.add_development_dependency('chunky_png')
+  gem.add_development_dependency('math_ml')
   gem.add_development_dependency('playwright-runner')
   gem.add_development_dependency('pygments.rb')
   gem.add_development_dependency('rake')


### PR DESCRIPTION
math_ml gemがRubyのバージョンによって（依存関係のため）挙動が変わりそうなので、テストでも有効になるようにしてみます