### PR TITLE
WIP: VivliostyleMakerとreview-ast-vivliomakerコマンドを追加

### DIFF
--- a/bin/review-ast-vivliostylemaker
+++ b/bin/review-ast-vivliostylemaker
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'pathname'
+
+bindir = Pathname.new(__FILE__).realpath.dirname
+$LOAD_PATH.unshift((bindir + '../lib').realpath)
+
+require 'review/ast/command/vivliostyle_maker'
+
+ReVIEW::AST::Command::VivliostyleMaker.execute(*ARGV)

--- a/lib/review/ast/command/vivliostyle/asset_manager.rb
+++ b/lib/review/ast/command/vivliostyle/asset_manager.rb
@@ -30,15 +30,8 @@ module ReVIEW
               # Use npm theme (will be resolved by Vivliostyle CLI)
               debug("Using Vivliostyle theme: #{theme}")
             else
-              # Use bundled theme-review.css
-              css_src = @context.template_path('vivliostyle/theme-review.css')
-              if css_src && File.exist?(css_src)
-                FileUtils.cp(css_src, @context.build_path)
-                @context.add_stylesheet('theme-review.css')
-                debug('Using bundled theme-review.css')
-              else
-                warn 'theme-review.css not found, no default stylesheet applied'
-              end
+              # Copy all CSS files from vivliostyle template directory
+              copy_bundled_stylesheets
             end
 
             # Copy additional CSS files from vivliostylemaker config
@@ -88,6 +81,29 @@ module ReVIEW
 
           def config
             @context.config
+          end
+
+          # Copy all CSS files from templates/vivliostyle/ directory
+          def copy_bundled_stylesheets
+            vivliostyle_template_dir = @context.template_path('vivliostyle')
+            return unless vivliostyle_template_dir && File.directory?(vivliostyle_template_dir)
+
+            css_files = Dir.glob(File.join(vivliostyle_template_dir, '*.css'))
+            if css_files.empty?
+              warn 'No CSS files found in vivliostyle template directory'
+              return
+            end
+
+            css_files.each do |css_src|
+              basename = File.basename(css_src)
+              FileUtils.cp(css_src, @context.build_path)
+              debug("Copied #{basename}")
+
+              # Only add theme-review.css to stylesheet list (others are @imported)
+              if basename == 'theme-review.css'
+                @context.add_stylesheet(basename)
+              end
+            end
           end
 
           def copy_images_recursive(src_dir, dest_dir, exts)

--- a/lib/review/ast/command/vivliostyle/asset_manager.rb
+++ b/lib/review/ast/command/vivliostyle/asset_manager.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'fileutils'
+require 'review/loggable'
+require 'review/template'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        # AssetManager handles stylesheets, javascripts, and image copying
+        class AssetManager
+          include Loggable
+
+          def initialize(context:)
+            @context = context
+            @logger = ReVIEW.logger
+          end
+
+          def setup_stylesheets
+            theme = config['vivliostylemaker']['theme']
+
+            if theme
+              # Use npm theme (will be resolved by Vivliostyle CLI)
+              debug("Using Vivliostyle theme: #{theme}")
+            else
+              # Use bundled theme-review.css
+              css_src = @context.template_path('vivliostyle/theme-review.css')
+              if css_src && File.exist?(css_src)
+                FileUtils.cp(css_src, @context.build_path)
+                @context.add_stylesheet('theme-review.css')
+                debug('Using bundled theme-review.css')
+              else
+                warn 'theme-review.css not found, no default stylesheet applied'
+              end
+            end
+
+            # Copy additional CSS files from vivliostylemaker config
+            additional_css = config['vivliostylemaker']['css'] || []
+            additional_css.each do |css_file|
+              src = @context.source_path(css_file)
+              if File.exist?(src)
+                FileUtils.cp(src, @context.build_path)
+                @context.add_stylesheet(File.basename(css_file))
+              else
+                warn "CSS file not found: #{css_file}"
+              end
+            end
+
+            # Copy user stylesheets from config (exclude style.css)
+            (config['stylesheet'] || []).each do |css_file|
+              basename = File.basename(css_file)
+              next if basename == 'style.css' # Ignore legacy style.css
+
+              src = @context.source_path(css_file)
+              if File.exist?(src)
+                FileUtils.cp(src, @context.build_path)
+                @context.add_stylesheet(basename)
+              end
+            end
+          end
+
+          def setup_javascripts
+            # Always include MathJax for Vivliostyle (default math rendering, no LaTeX required)
+            @context.add_javascript(%Q(<script>MathJax = { tex: { inlineMath: [['\\\\(', '\\\\)']] }, svg: { fontCache: 'global' } };</script>))
+            @context.add_javascript(%Q(<script type="text/javascript" id="MathJax-script" async="true" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>))
+          end
+
+          def copy_images
+            imagedir = config['imagedir']
+            src_dir = @context.source_path(imagedir)
+            return unless File.exist?(src_dir)
+
+            dest_dir = @context.output_path(imagedir)
+            FileUtils.mkdir_p(dest_dir)
+
+            exts = config['image_ext'] || %w[png gif jpg jpeg svg]
+            copy_images_recursive(src_dir, dest_dir, exts)
+          end
+
+          private
+
+          def config
+            @context.config
+          end
+
+          def copy_images_recursive(src_dir, dest_dir, exts)
+            Dir.foreach(src_dir) do |entry|
+              next if entry.start_with?('.')
+
+              src_path = File.join(src_dir, entry)
+              dest_path = File.join(dest_dir, entry)
+
+              if File.directory?(src_path)
+                FileUtils.mkdir_p(dest_path)
+                copy_images_recursive(src_path, dest_path, exts)
+              elsif exts.any? { |ext| entry.downcase.end_with?(".#{ext}") }
+                FileUtils.cp(src_path, dest_path)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/build_context.rb
+++ b/lib/review/ast/command/vivliostyle/build_context.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'tmpdir'
+require 'fileutils'
+require 'review/template'
+require_relative 'layout_wrapper'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        # BuildContext manages build configuration, paths, and shared state
+        class BuildContext
+          attr_reader :config, :basedir, :build_path, :buildonly, :layout_wrapper
+          attr_accessor :book
+          attr_reader :entry_files, :stylesheets, :javascripts
+
+          def initialize(config:, basedir:, debug: false, buildonly: nil)
+            @config = config
+            @basedir = basedir
+            @debug = debug
+            @buildonly = buildonly
+            @build_path = nil
+            @book = nil
+            @entry_files = []
+            @stylesheets = []
+            @javascripts = []
+            @layout_wrapper = LayoutWrapper.new(context: self)
+          end
+
+          def debug?
+            @debug
+          end
+
+          def setup_build_directory
+            @build_path = if @debug
+                            path = File.expand_path("#{@config['bookname']}-vivliostyle", Dir.pwd)
+                            FileUtils.rm_rf(path, secure: true)
+                            Dir.mkdir(path)
+                            path
+                          else
+                            Dir.mktmpdir("#{@config['bookname']}-vivliostyle-")
+                          end
+          end
+
+          def cleanup
+            return if @debug || @build_path.nil?
+
+            FileUtils.remove_entry_secure(@build_path)
+          end
+
+          def add_entry_file(filename)
+            @entry_files << filename
+          end
+
+          def add_stylesheet(filename)
+            @stylesheets << filename
+          end
+
+          def add_javascript(script)
+            @javascripts << script
+          end
+
+          # Returns absolute path from basedir
+          def source_path(relative)
+            File.join(@basedir, relative)
+          end
+
+          # Returns absolute path from build_path
+          def output_path(relative)
+            File.join(@build_path, relative)
+          end
+
+          # Find template file path (user layouts dir first, then system templates)
+          def template_path(relative)
+            # Check user's layouts directory first
+            user_path = File.join(@basedir, 'layouts', relative)
+            return user_path if File.exist?(user_path)
+
+            # Check system templates
+            system_path = File.join(ReVIEW::Template::TEMPLATE_DIR, relative)
+            return system_path if File.exist?(system_path)
+
+            nil
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/cli/parser.rb
+++ b/lib/review/ast/command/vivliostyle/cli/parser.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'optparse'
+require 'review/version'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        module CLI
+          # ParsedOptions holds the result of command line argument parsing
+          ParsedOptions = Struct.new(:cmd_config, :yamlfile, :buildonly, keyword_init: true)
+
+          # Parser handles command line argument parsing for VivliostyleMaker
+          class Parser
+            def self.parse(args)
+              new.parse(args)
+            end
+
+            def parse(args)
+              cmd_config = {}
+              buildonly = nil
+
+              opts = OptionParser.new
+              opts.banner = 'Usage: review-ast-vivliostylemaker [options] configfile'
+              opts.version = ReVIEW::VERSION
+
+              opts.on('--help', 'Prints this message and quit.') do
+                puts opts.help
+                exit 0
+              end
+
+              opts.on('--[no-]debug', 'Keep temporary files.') do |debug|
+                cmd_config['debug'] = debug
+              end
+
+              opts.on('--ignore-errors', 'Ignore compile errors.') do
+                cmd_config['ignore-errors'] = true
+              end
+
+              opts.on('-y', '--only file1,file2,...', 'Build only specified files.') do |v|
+                buildonly = v.split(/\s*,\s*/).map { |m| m.strip.sub(/\.re\Z/, '') }
+              end
+
+              opts.parse!(args)
+
+              if args.size != 1
+                puts opts.help
+                exit 0
+              end
+
+              ParsedOptions.new(
+                cmd_config: cmd_config,
+                yamlfile: args[0],
+                buildonly: buildonly
+              )
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/entries/chapter_entry.rb
+++ b/lib/review/ast/command/vivliostyle/entries/chapter_entry.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'review/ast'
+require 'review/renderer/html_renderer'
+require_relative '../entry'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        module Entries
+          # ChapterEntry generates the chapter HTML using AST Compiler and HtmlRenderer
+          class ChapterEntry < Entry
+            attr_reader :chapter
+
+            def initialize(context:, chapter:)
+              super(context: context)
+              @chapter = chapter
+              @filename = "#{chapter.name}.html"
+              @title = chapter.title
+              @compile_error = false
+            end
+
+            def compile_error?
+              @compile_error
+            end
+
+            def generate
+              id = File.basename(@chapter.path, '.*')
+
+              if @context.buildonly && !@context.buildonly.include?(id)
+                warn "skip #{id}.re"
+                return
+              end
+
+              begin
+                write
+                debug("Compiled #{@chapter.path} -> #{@filename}")
+              rescue StandardError => e
+                @compile_error = true
+                error "compile error in #{@chapter.path} (#{e.class})"
+                error e.message
+                puts e.backtrace.first(10).join("\n") if @context.debug?
+              end
+            end
+
+            def render
+              # Compile chapter to AST
+              compiler = ReVIEW::AST::Compiler.for_chapter(@chapter)
+              ast_root = compiler.compile_to_ast(@chapter)
+
+              # Render to HTML
+              renderer = ReVIEW::Renderer::HtmlRenderer.new(@chapter)
+              renderer.visit(ast_root)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/entries/colophon_entry.rb
+++ b/lib/review/ast/command/vivliostyle/entries/colophon_entry.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'review/i18n'
+require 'review/template'
+require_relative '../entry'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        module Entries
+          # ColophonEntry generates the colophon (imprint) HTML
+          class ColophonEntry < Entry
+            def initialize(context:)
+              super
+              @filename = 'colophon.html'
+              @title = I18n.t('colophontitle')
+            end
+
+            def render
+              template_path = @context.template_path('vivliostyle/_colophon.html.erb')
+              if template_path && File.exist?(template_path)
+                ReVIEW::Template.generate(path: template_path, binding: binding)
+              else
+                fallback_colophon
+              end
+            end
+
+            private
+
+            def fallback_colophon
+              items = []
+              (config['colophon_order'] || []).each do |key|
+                value = config.name_of(key)
+                next unless value
+
+                label = I18n.t("colophon_#{key}", nil) || key
+                items << "<dt>#{h(label)}</dt><dd>#{h(value)}</dd>"
+              end
+
+              <<~HTML
+                <div class="colophon">
+                  <h1>#{h(config.name_of('booktitle'))}</h1>
+                  <dl>
+                    #{items.join("\n")}
+                  </dl>
+                  <p class="date">#{h(config['date'].to_s)}</p>
+                </div>
+              HTML
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/entries/colophon_entry.rb
+++ b/lib/review/ast/command/vivliostyle/entries/colophon_entry.rb
@@ -25,35 +25,74 @@ module ReVIEW
 
             def render
               template_path = @context.template_path('vivliostyle/_colophon.html.erb')
-              if template_path && File.exist?(template_path)
-                ReVIEW::Template.generate(path: template_path, binding: binding)
-              else
-                fallback_colophon
-              end
+              ReVIEW::Template.generate(path: template_path, binding: binding)
             end
 
             private
 
-            def fallback_colophon
-              items = []
-              (config['colophon_order'] || []).each do |key|
-                value = config.name_of(key)
-                next unless value
+            # ISBN with hyphens
+            def isbn_hyphen
+              str = config['isbn'].to_s
+              return nil if str.empty?
 
-                label = I18n.t("colophon_#{key}", nil) || key
-                items << "<dt>#{h(label)}</dt><dd>#{h(value)}</dd>"
+              if /\A\d{10}\Z/.match?(str)
+                "#{str[0..0]}-#{str[1..5]}-#{str[6..8]}-#{str[9..9]}"
+              elsif /\A\d{13}\Z/.match?(str)
+                "#{str[0..2]}-#{str[3..3]}-#{str[4..8]}-#{str[9..11]}-#{str[12..12]}"
+              else
+                str
               end
-
-              <<~HTML
-                <div class="colophon">
-                  <h1>#{h(config.name_of('booktitle'))}</h1>
-                  <dl>
-                    #{items.join("\n")}
-                  </dl>
-                  <p class="date">#{h(config['date'].to_s)}</p>
-                </div>
-              HTML
             end
+
+            # Generate colophon history section
+            def colophon_history
+              @col_history = build_col_history
+              template_path = @context.template_path('vivliostyle/_colophon_history.html.erb')
+              ReVIEW::Template.generate(path: template_path, binding: binding)
+            end
+
+            # Accessor for template
+            def col_history
+              @col_history ||= build_col_history
+            end
+
+            def build_col_history
+              history = []
+              if config['history']
+                config['history'].each_with_index do |items, edit|
+                  items.each_with_index do |item, rev|
+                    editstr = edit == 0 ? I18n.t('first_edition') : I18n.t('nth_edition', (edit + 1).to_s)
+                    revstr = I18n.t('nth_impression', (rev + 1).to_s)
+                    if /\A\d+-\d+-\d+\Z/.match?(item)
+                      history << I18n.t('published_by1', [date_to_s(item), editstr + revstr])
+                    elsif /\A(\d+-\d+-\d+)[\s　](.+)/.match?(item)
+                      # custom date with string
+                      item.match(/\A(\d+-\d+-\d+)[\s　](.+)/) do |m|
+                        history << I18n.t('published_by3', [date_to_s(m[1]), m[2]])
+                      end
+                    else
+                      # free format
+                      history << item
+                    end
+                  end
+                end
+              end
+              history
+            end
+
+            def date_to_s(date)
+              require 'date'
+              d = Date.parse(date)
+              d.strftime(I18n.t('date_format'))
+            end
+
+            # Join array with separator
+            def join_with_separator(ary, sep)
+              return '' if ary.nil? || ary.empty?
+
+              ary.join(sep)
+            end
+
           end
         end
       end

--- a/lib/review/ast/command/vivliostyle/entries/colophon_entry.rb
+++ b/lib/review/ast/command/vivliostyle/entries/colophon_entry.rb
@@ -92,7 +92,6 @@ module ReVIEW
 
               ary.join(sep)
             end
-
           end
         end
       end

--- a/lib/review/ast/command/vivliostyle/entries/cover_entry.rb
+++ b/lib/review/ast/command/vivliostyle/entries/cover_entry.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'fileutils'
+require 'review/ast'
+require 'review/renderer/html_renderer'
+require 'review/book/chapter'
+require_relative '../entry'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        module Entries
+          # CoverEntry generates the cover page HTML from various source types
+          class CoverEntry < Entry
+            SUPPORTED_IMAGE_EXTS = %w[.png .jpg .jpeg .gif .svg].freeze
+            SUPPORTED_HTML_EXTS = %w[.html .htm .xhtml].freeze
+            SUPPORTED_REVIEW_EXTS = %w[.re .md].freeze
+
+            attr_reader :source
+
+            def initialize(context:, source:)
+              super(context: context)
+              @source = source
+              @filename = 'cover.html'
+              @title = config.name_of('booktitle')
+              @source_type = detect_source_type
+            end
+
+            def generate
+              case @source_type
+              when :image
+                generate_image_cover
+              when :html
+                generate_html_cover
+              when :review
+                generate_review_cover
+              when :coverimage
+                generate_coverimage
+              else
+                warn "Unsupported cover source: #{@source}"
+              end
+            end
+
+            def render
+              # render is called by generate_review_cover
+              raise NotImplementedError, 'CoverEntry#render should not be called directly'
+            end
+
+            private
+
+            def detect_source_type
+              return :coverimage if @source.start_with?('coverimage:')
+
+              ext = File.extname(@source).downcase
+              if SUPPORTED_IMAGE_EXTS.include?(ext)
+                :image
+              elsif SUPPORTED_HTML_EXTS.include?(ext)
+                :html
+              elsif SUPPORTED_REVIEW_EXTS.include?(ext)
+                :review
+              else
+                :unknown
+              end
+            end
+
+            # Generate cover from image file in coverfile
+            def generate_image_cover
+              src_path = @context.source_path(@source)
+              unless File.exist?(src_path)
+                warn "Cover file not found: #{@source}"
+                return
+              end
+
+              render_image_cover(src_path, File.basename(@source))
+            end
+
+            # Generate cover from coverimage (relative to imagedir)
+            def generate_coverimage
+              image_name = @source.sub(/\Acoverimage:/, '')
+              src_path = @context.source_path(File.join(config['imagedir'], image_name))
+              unless File.exist?(src_path)
+                warn "Cover image not found: #{image_name}"
+                return
+              end
+
+              render_image_cover(src_path, image_name)
+            end
+
+            def render_image_cover(src_path, original_filename)
+              # Copy cover image to build directory
+              dest_filename = "cover#{File.extname(original_filename)}"
+              FileUtils.cp(src_path, @context.output_path(dest_filename))
+
+              # Generate cover HTML
+              body = <<~HTML
+                <div class="cover">
+                  <img src="#{h(dest_filename)}" alt="#{h(@title)}" class="cover-image" />
+                </div>
+              HTML
+              html = layout_wrapper.wrap(body, title: @title)
+              layout_wrapper.write_html(@filename, html)
+              @context.add_entry_file(@filename)
+              debug("Generated cover page from image: #{original_filename}")
+            end
+
+            def generate_html_cover
+              src_path = @context.source_path(@source)
+              unless File.exist?(src_path)
+                warn "Cover file not found: #{@source}"
+                return
+              end
+
+              content = File.read(src_path)
+
+              # If it's a fragment (no DOCTYPE), wrap with layout
+              html = if content.include?('<!DOCTYPE') || content.include?('<html')
+                       # Full HTML document - use as-is
+                       content
+                     else
+                       # HTML fragment - wrap with layout
+                       layout_wrapper.wrap(content, title: @title)
+                     end
+
+              layout_wrapper.write_html(@filename, html)
+              @context.add_entry_file(@filename)
+              debug("Copied cover page: #{@source}")
+            end
+
+            def generate_review_cover
+              cover_path = @context.source_path(@source)
+              unless File.exist?(cover_path)
+                warn "Cover file not found: #{@source}"
+                return
+              end
+
+              begin
+                # Create a temporary chapter for the cover
+                cover_chapter = ReVIEW::Book::Chapter.new(
+                  book, nil, '-', cover_path, nil
+                )
+
+                # Compile to AST
+                compiler = ReVIEW::AST::Compiler.for_chapter(cover_chapter)
+                ast_root = compiler.compile_to_ast(cover_chapter)
+
+                # Render to HTML
+                renderer = ReVIEW::Renderer::HtmlRenderer.new(cover_chapter)
+                html_body = renderer.visit(ast_root)
+
+                # Wrap with layout
+                body = %Q(<div class="cover">#{html_body}</div>)
+                html = layout_wrapper.wrap(body, title: @title)
+
+                layout_wrapper.write_html(@filename, html)
+                @context.add_entry_file(@filename)
+                debug("Compiled cover page: #{@source}")
+              rescue StandardError => e
+                warn "Failed to compile cover file: #{e.message}"
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/entries/part_entry.rb
+++ b/lib/review/ast/command/vivliostyle/entries/part_entry.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'review/i18n'
+require_relative '../entry'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        module Entries
+          # PartEntry generates the part divider HTML
+          class PartEntry < Entry
+            attr_reader :part
+
+            def initialize(context:, part:)
+              super(context: context)
+              @part = part
+              @filename = "part_#{part.number}.html"
+              @title = "#{I18n.t('part', part.number)} #{part.name}"
+            end
+
+            def render
+              <<~HTML
+                <div class="part">
+                  <h1 class="part-number">#{h(I18n.t('part', part.number))}</h1>
+                  <h2 class="part-title">#{h(part.name)}</h2>
+                </div>
+              HTML
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/entries/titlepage_entry.rb
+++ b/lib/review/ast/command/vivliostyle/entries/titlepage_entry.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'review/i18n'
+require 'review/template'
+require_relative '../entry'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        module Entries
+          # TitlepageEntry generates the title page HTML
+          class TitlepageEntry < Entry
+            def initialize(context:)
+              super
+              @filename = 'titlepage.html'
+              @title = config.name_of('booktitle')
+            end
+
+            def render
+              template_path = @context.template_path('vivliostyle/_titlepage.html.erb')
+              if template_path && File.exist?(template_path)
+                ReVIEW::Template.generate(path: template_path, binding: binding)
+              else
+                fallback_titlepage
+              end
+            end
+
+            private
+
+            def fallback_titlepage
+              author_names = join_with_separator(config.names_of('aut'), I18n.t('names_splitter'))
+              <<~HTML
+                <div class="titlepage">
+                  <h1 class="booktitle">#{h(config.name_of('booktitle'))}</h1>
+                  <p class="author">#{h(author_names)}</p>
+                </div>
+              HTML
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/entries/toc_entry.rb
+++ b/lib/review/ast/command/vivliostyle/entries/toc_entry.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'review/i18n'
+require_relative '../entry'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        module Entries
+          # TocEntry generates the table of contents HTML
+          class TocEntry < Entry
+            def initialize(context:)
+              super
+              @filename = 'toc.html'
+              @title = I18n.t('toctitle')
+            end
+
+            def render
+              toc_items = []
+
+              book.parts.each do |part|
+                if part.name.present? && !part.file?
+                  toc_items << %Q(<li class="part">#{h(part.name)}</li>)
+                end
+                part.chapters.each do |chap|
+                  toc_items << %Q(<li><a href="#{chap.name}.html">#{h(chap.title)}</a></li>)
+                end
+              end
+
+              <<~HTML
+                <nav class="toc">
+                  <h1>#{h(I18n.t('toctitle'))}</h1>
+                  <ol>
+                    #{toc_items.join("\n")}
+                  </ol>
+                </nav>
+              HTML
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/entry.rb
+++ b/lib/review/ast/command/vivliostyle/entry.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'erb'
+require 'review/loggable'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        # Entry is the base class for all HTML output entries
+        # Each Entry represents one HTML file to be generated
+        class Entry
+          include ERB::Util
+          include Loggable
+
+          attr_reader :filename, :title
+
+          def initialize(context:)
+            @context = context
+            @filename = nil
+            @title = nil
+            @logger = ReVIEW.logger
+          end
+
+          # Render HTML body content (to be implemented by subclasses)
+          def render
+            raise NotImplementedError, "#{self.class}#render must be implemented"
+          end
+
+          # Write the entry to file
+          def write
+            body = render
+            html = layout_wrapper.wrap(body, title: @title)
+            layout_wrapper.write_html(@filename, html)
+            @context.add_entry_file(@filename)
+          end
+
+          # Generate the entry (render + layout + write)
+          def generate
+            write
+          end
+
+          protected
+
+          def config
+            @context.config
+          end
+
+          def book
+            @context.book
+          end
+
+          def layout_wrapper
+            @context.layout_wrapper
+          end
+
+          # Helper to join array values with separator
+          def join_with_separator(value, sep)
+            if value.is_a?(Array)
+              value.join(sep)
+            else
+              value.to_s
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/layout_wrapper.rb
+++ b/lib/review/ast/command/vivliostyle/layout_wrapper.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'erb'
+require 'review/template'
+require 'review/loggable'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        # LayoutWrapper wraps HTML content with layout template
+        class LayoutWrapper
+          include ERB::Util
+          include Loggable
+
+          def initialize(context:)
+            @context = context
+            @logger = ReVIEW.logger
+          end
+
+          def wrap(body, title:)
+            @body = body
+            @title = title
+            @language = @context.config['language']
+            @stylesheets = @context.stylesheets
+            @javascripts = @context.javascripts
+            @config = @context.config
+
+            template_path = @context.template_path('vivliostyle/layout.html.erb')
+            ReVIEW::Template.generate(path: template_path, binding: binding)
+          end
+
+          def write_html(filename, content)
+            File.write(@context.output_path(filename), content)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle/runner.rb
+++ b/lib/review/ast/command/vivliostyle/runner.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'json'
+require 'fileutils'
+require 'review/i18n'
+require 'review/loggable'
+
+module ReVIEW
+  module AST
+    module Command
+      module Vivliostyle
+        # Runner handles Vivliostyle config generation and CLI execution
+        class Runner
+          include Loggable
+
+          def initialize(context:)
+            @context = context
+            @logger = ReVIEW.logger
+          end
+
+          def generate_config
+            author_names = join_with_separator(config.names_of('aut'), I18n.t('names_splitter'))
+
+            config_data = {
+              'title' => config.name_of('booktitle'),
+              'author' => author_names,
+              'language' => config['language'],
+              'size' => config['vivliostylemaker']['size'] || 'JIS-B5',
+              'entry' => @context.entry_files,
+              'output' => "#{config['bookname']}.pdf",
+              'workspaceDir' => '.vivliostyle'
+            }
+
+            # Add theme if specified
+            theme = config['vivliostylemaker']['theme']
+            config_data['theme'] = theme if theme
+
+            config_path = @context.output_path('vivliostyle.config.json')
+            File.write(config_path, JSON.pretty_generate(config_data))
+            debug('Generated vivliostyle.config.json')
+          end
+
+          def run_build
+            cmd = build_vivliostyle_command
+
+            debug("Running: #{cmd.join(' ')}")
+
+            Dir.chdir(@context.build_path) do
+              result = system(*cmd)
+              unless result
+                error! 'Vivliostyle build failed. Check the output above for details.'
+              end
+            end
+          end
+
+          def finalize_output
+            bookname = config['bookname']
+            src_pdf = @context.output_path("#{bookname}.pdf")
+            dest_pdf = File.join(@context.basedir, "#{bookname}.pdf")
+
+            if File.exist?(src_pdf)
+              FileUtils.cp(src_pdf, dest_pdf)
+              debug("Output: #{dest_pdf}")
+            else
+              error! "PDF file was not generated: #{src_pdf}"
+            end
+          end
+
+          private
+
+          def config
+            @context.config
+          end
+
+          def build_vivliostyle_command
+            cmd = if config['vivliostylemaker']['use_npx']
+                    # Use npx (ignores vivliostyle_path)
+                    ['npx', '@vivliostyle/cli', 'build', '-c', 'vivliostyle.config.json']
+                  else
+                    # Use vivliostyle_path
+                    vivliostyle_path = resolve_vivliostyle_path
+                    [vivliostyle_path, 'build', '-c', 'vivliostyle.config.json']
+                  end
+
+            # Add press-ready option if specified
+            if config['vivliostylemaker']['press_ready']
+              cmd << '--press-ready'
+            end
+
+            cmd
+          end
+
+          def resolve_vivliostyle_path
+            vivliostyle_path = config['vivliostylemaker']['vivliostyle_path'] || 'vivliostyle'
+
+            # Check if vivliostyle exists
+            if system("which #{vivliostyle_path} > /dev/null 2>&1") ||
+               File.exist?(File.join(@context.basedir, vivliostyle_path))
+              return vivliostyle_path
+            end
+
+            # Try to find in node_modules
+            node_path = File.join(@context.basedir, 'node_modules', '.bin', 'vivliostyle')
+            if File.exist?(node_path)
+              return node_path
+            end
+
+            error! 'Vivliostyle CLI not found. Please install with: npm install @vivliostyle/cli'
+          end
+
+          def join_with_separator(value, sep)
+            if value.is_a?(Array)
+              value.join(sep)
+            else
+              value.to_s
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/ast/command/vivliostyle_maker.rb
+++ b/lib/review/ast/command/vivliostyle_maker.rb
@@ -6,12 +6,6 @@
 # You can distribute or modify this program under the terms of
 # the GNU LGPL, Lesser General Public License version 2.1.
 
-require 'optparse'
-require 'tmpdir'
-require 'fileutils'
-require 'json'
-require 'erb'
-
 require 'review/i18n'
 require 'review/book'
 require 'review/configure'
@@ -19,18 +13,27 @@ require 'review/version'
 require 'review/makerhelper'
 require 'review/loggable'
 require 'review/call_hook'
-require 'review/template'
 
 require 'review/ast'
 require 'review/ast/book_indexer'
-require 'review/renderer/html_renderer'
+
+require_relative 'vivliostyle/cli/parser'
+require_relative 'vivliostyle/build_context'
+require_relative 'vivliostyle/asset_manager'
+require_relative 'vivliostyle/entry'
+require_relative 'vivliostyle/entries/cover_entry'
+require_relative 'vivliostyle/entries/titlepage_entry'
+require_relative 'vivliostyle/entries/toc_entry'
+require_relative 'vivliostyle/entries/part_entry'
+require_relative 'vivliostyle/entries/chapter_entry'
+require_relative 'vivliostyle/entries/colophon_entry'
+require_relative 'vivliostyle/runner'
 
 module ReVIEW
   module AST
     module Command
       # VivliostyleMaker - PDF generator using Vivliostyle CLI with AST Renderer
       class VivliostyleMaker
-        include ERB::Util
         include MakerHelper
         include Loggable
         include ReVIEW::CallHook
@@ -40,51 +43,21 @@ module ReVIEW
         def initialize
           @basedir = nil
           @logger = ReVIEW.logger
-          @compile_errors = nil
-          @entry_files = []
-          @stylesheets = []
-          @javascripts = []
         end
 
         def self.execute(*args)
-          self.new.execute(*args)
-        end
-
-        def parse_opts(args)
-          cmd_config = {}
-          opts = OptionParser.new
-          @buildonly = nil
-
-          opts.banner = 'Usage: review-ast-vivliostylemaker [options] configfile'
-          opts.version = ReVIEW::VERSION
-          opts.on('--help', 'Prints this message and quit.') do
-            puts opts.help
-            exit 0
-          end
-          opts.on('--[no-]debug', 'Keep temporary files.') { |debug| cmd_config['debug'] = debug }
-          opts.on('--ignore-errors', 'Ignore compile errors.') { cmd_config['ignore-errors'] = true }
-          opts.on('-y', '--only file1,file2,...', 'Build only specified files.') do |v|
-            @buildonly = v.split(/\s*,\s*/).map { |m| m.strip.sub(/\.re\Z/, '') }
-          end
-
-          opts.parse!(args)
-          if args.size != 1
-            puts opts.help
-            exit 0
-          end
-
-          [cmd_config, args[0]]
+          new.execute(*args)
         end
 
         def execute(*args)
-          cmd_config, yamlfile = parse_opts(args)
-          error! "#{yamlfile} not found." unless File.exist?(yamlfile)
+          options = Vivliostyle::CLI::Parser.parse(args)
+          error! "#{options.yamlfile} not found." unless File.exist?(options.yamlfile)
 
           begin
             @config = ReVIEW::Configure.create(
               maker: 'vivliostylemaker',
-              yamlfile: yamlfile,
-              config: cmd_config
+              yamlfile: options.yamlfile,
+              config: options.cmd_config
             )
           rescue ReVIEW::ConfigError => e
             error! e.message
@@ -94,13 +67,15 @@ module ReVIEW
           I18n.setup(@config['language'])
 
           begin
-            generate_pdf(yamlfile)
+            generate_pdf(options.yamlfile, buildonly: options.buildonly)
           rescue ApplicationError => e
             raise if @config['debug']
 
             error! e.message
           end
         end
+
+        private
 
         def update_log_level
           if @config['debug']
@@ -115,18 +90,7 @@ module ReVIEW
           end
         end
 
-        def build_path
-          if @config['debug']
-            path = File.expand_path("#{@config['bookname']}-vivliostyle", Dir.pwd)
-            FileUtils.rm_rf(path, secure: true)
-            Dir.mkdir(path)
-            path
-          else
-            Dir.mktmpdir("#{@config['bookname']}-vivliostyle-")
-          end
-        end
-
-        def generate_pdf(yamlfile)
+        def generate_pdf(yamlfile, buildonly: nil)
           @basedir = File.absolute_path(File.dirname(yamlfile))
           bookname = @config['bookname']
 
@@ -141,571 +105,132 @@ module ReVIEW
           # Remove old PDF
           FileUtils.rm_f("#{bookname}.pdf")
 
-          @path = build_path
-          begin
-            debug("Created temporary directory as #{@path}.")
+          # Create build context
+          context = Vivliostyle::BuildContext.new(
+            config: @config,
+            basedir: @basedir,
+            debug: @config['debug'],
+            buildonly: buildonly
+          )
 
-            call_hook('hook_beforeprocess', @path, base_dir: @basedir)
+          begin
+            context.setup_build_directory
+            debug("Created temporary directory as #{context.build_path}.")
+
+            call_hook('hook_beforeprocess', context.build_path, base_dir: @basedir)
 
             # Initialize book and build indexes
-            @book = ReVIEW::Book::Base.new(@basedir, config: @config)
-            ReVIEW::AST::BookIndexer.build(@book)
+            book = ReVIEW::Book::Base.new(@basedir, config: @config)
+            ReVIEW::AST::BookIndexer.build(book)
+            context.book = book
 
-            # Setup stylesheets and javascripts
-            setup_stylesheet
-            setup_javascripts
+            # Setup assets
+            asset_manager = Vivliostyle::AssetManager.new(context: context)
+            asset_manager.setup_stylesheets
+            asset_manager.setup_javascripts
 
-            # Build HTML files
-            build_frontmatter
-            build_body
-            call_hook('hook_afterbody', @path, base_dir: @basedir)
-            build_backmatter
+            # Generate all entries
+            compile_errors = generate_entries(context)
+
+            call_hook('hook_afterbody', context.build_path, base_dir: @basedir)
 
             # Copy images
-            copy_images(@config['imagedir'], File.join(@path, @config['imagedir']))
-            call_hook('hook_aftercopyimage', @path, base_dir: @basedir)
+            asset_manager.copy_images
+            call_hook('hook_aftercopyimage', context.build_path, base_dir: @basedir)
 
-            # Generate vivliostyle.config.json
-            generate_vivliostyle_config
+            # Check compile status
+            check_compile_status(compile_errors)
 
-            # Run Vivliostyle CLI
-            call_hook('hook_beforevivliostyle', @path, base_dir: @basedir)
-            run_vivliostyle(bookname)
-            call_hook('hook_aftervivliostyle', @path, base_dir: @basedir)
-
-            # Copy output PDF
-            finalize_output(bookname)
+            # Run Vivliostyle
+            runner = Vivliostyle::Runner.new(context: context)
+            runner.generate_config
+            call_hook('hook_beforevivliostyle', context.build_path, base_dir: @basedir)
+            runner.run_build
+            call_hook('hook_aftervivliostyle', context.build_path, base_dir: @basedir)
+            runner.finalize_output
 
             @logger.success("built #{bookname}.pdf")
           ensure
-            FileUtils.remove_entry_secure(@path) unless @config['debug']
+            context.cleanup unless @config['debug']
           end
         end
 
-        private
+        def generate_entries(context)
+          compile_errors = false
 
-        def setup_stylesheet
-          theme = @config['vivliostylemaker']['theme']
+          # Frontmatter
+          generate_frontmatter(context)
 
-          if theme
-            # Use npm theme (will be resolved by Vivliostyle CLI)
-            debug("Using Vivliostyle theme: #{theme}")
-            @stylesheets = []
-          else
-            # Use bundled theme-review.css
-            css_src = find_template_path('vivliostyle/theme-review.css')
-            if css_src && File.exist?(css_src)
-              FileUtils.cp(css_src, @path)
-              @stylesheets = ['theme-review.css']
-              debug('Using bundled theme-review.css')
-            else
-              warn 'theme-review.css not found, no default stylesheet applied'
-              @stylesheets = []
+          # Body (parts and chapters)
+          context.book.parts.each do |part|
+            if part.name.present? && !part.file?
+              entry = Vivliostyle::Entries::PartEntry.new(
+                context: context,
+                part: part
+              )
+              entry.generate
+            end
+
+            part.chapters.each do |chapter|
+              entry = Vivliostyle::Entries::ChapterEntry.new(
+                context: context,
+                chapter: chapter
+              )
+              entry.generate
+              compile_errors = true if entry.compile_error?
             end
           end
 
-          # Copy additional CSS files
-          additional_css = @config['vivliostylemaker']['css'] || []
-          additional_css.each do |css_file|
-            src = File.join(@basedir, css_file)
-            if File.exist?(src)
-              FileUtils.cp(src, @path)
-              @stylesheets << File.basename(css_file)
-            else
-              warn "CSS file not found: #{css_file}"
-            end
-          end
+          # Backmatter
+          generate_backmatter(context)
 
-          # Copy user stylesheets from config (exclude style.css)
-          (@config['stylesheet'] || []).each do |css_file|
-            basename = File.basename(css_file)
-            next if basename == 'style.css' # Ignore legacy style.css
-
-            src = File.join(@basedir, css_file)
-            if File.exist?(src)
-              FileUtils.cp(src, @path)
-              @stylesheets << basename
-            end
-          end
+          compile_errors
         end
 
-        def setup_javascripts
-          # Always include MathJax for Vivliostyle (default math rendering, no LaTeX required)
-          @javascripts.push(%Q(<script>MathJax = { tex: { inlineMath: [['\\\\(', '\\\\)']] }, svg: { fontCache: 'global' } };</script>))
-          @javascripts.push(%Q(<script type="text/javascript" id="MathJax-script" async="true" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>))
-        end
-
-        def find_template_path(relative_path)
-          # Check user's layouts directory first
-          if @basedir
-            user_path = File.join(@basedir, 'layouts', relative_path)
-            return user_path if File.exist?(user_path)
-          end
-
-          # Check system templates
-          system_path = File.join(ReVIEW::Template::TEMPLATE_DIR, relative_path)
-          return system_path if File.exist?(system_path)
-
-          nil
-        end
-
-        def build_frontmatter
+        def generate_frontmatter(context)
           # Cover page
-          if @config['coverfile'] || @config['coverimage']
-            build_cover
+          if @config['coverfile']
+            entry = Vivliostyle::Entries::CoverEntry.new(
+              context: context,
+              source: @config['coverfile']
+            )
+            entry.generate
+          elsif @config['coverimage']
+            entry = Vivliostyle::Entries::CoverEntry.new(
+              context: context,
+              source: "coverimage:#{@config['coverimage']}"
+            )
+            entry.generate
           end
 
           # Title page
           if @config['titlepage']
-            build_titlepage
+            entry = Vivliostyle::Entries::TitlepageEntry.new(context: context)
+            entry.generate
           end
 
           # Table of contents
           if @config['toc']
-            build_toc
+            entry = Vivliostyle::Entries::TocEntry.new(context: context)
+            entry.generate
           end
         end
 
-        def build_cover
-          coverfile = @config['coverfile']
-          coverimage = @config['coverimage']
-
-          if coverfile
-            build_cover_from_file(coverfile)
-          elsif coverimage
-            build_cover_from_image(coverimage)
-          end
-        end
-
-        def build_cover_from_file(coverfile)
-          src_path = File.join(@basedir, coverfile)
-
-          unless File.exist?(src_path)
-            warn "Cover file not found: #{coverfile}"
-            return
-          end
-
-          ext = File.extname(coverfile).downcase
-
-          if %w[.png .jpg .jpeg .gif .svg].include?(ext)
-            # Image cover - create HTML wrapper
-            build_image_cover(src_path, File.basename(coverfile))
-          elsif %w[.html .htm .xhtml].include?(ext)
-            # HTML cover - copy directly
-            build_html_cover(src_path, coverfile)
-          elsif %w[.re .md].include?(ext)
-            # Re:VIEW/Markdown cover - compile
-            build_review_cover(coverfile)
-          else
-            warn "Unsupported cover file format: #{ext}"
-          end
-        end
-
-        def build_cover_from_image(coverimage)
-          # coverimage is relative to imagedir
-          src_path = File.join(@basedir, @config['imagedir'], coverimage)
-
-          unless File.exist?(src_path)
-            warn "Cover image not found: #{coverimage}"
-            return
-          end
-
-          build_image_cover(src_path, coverimage)
-        end
-
-        def build_image_cover(src_path, filename)
-          # Copy cover image to build directory
-          dest_filename = "cover#{File.extname(filename)}"
-          FileUtils.cp(src_path, File.join(@path, dest_filename))
-
-          # Generate cover HTML
-          @title = @config.name_of('booktitle')
-          @body = <<~HTML
-            <div class="cover">
-              <img src="#{h(dest_filename)}" alt="#{h(@title)}" class="cover-image" />
-            </div>
-          HTML
-          html = wrap_with_layout(@body, @title)
-          write_html_file('cover.html', html)
-          @entry_files << 'cover.html'
-          debug("Generated cover page from image: #{filename}")
-        end
-
-        def build_html_cover(src_path, coverfile)
-          # Copy HTML cover file
-          dest_filename = 'cover.html'
-          content = File.read(src_path)
-
-          # If it's a fragment (no DOCTYPE), wrap with layout
-          if content.include?('<!DOCTYPE') || content.include?('<html')
-            # Full HTML document - copy as-is but ensure stylesheets are linked
-            write_html_file(dest_filename, content)
-          else
-            # HTML fragment - wrap with layout
-            @title = @config.name_of('booktitle')
-            @body = content
-            html = wrap_with_layout(@body, @title)
-            write_html_file(dest_filename, html)
-          end
-
-          @entry_files << dest_filename
-          debug("Copied cover page: #{coverfile}")
-        end
-
-        def build_review_cover(coverfile)
-          # Find the cover chapter
-          cover_path = File.join(@basedir, coverfile)
-
-          begin
-            # Create a temporary chapter for the cover
-            cover_chapter = ReVIEW::Book::Chapter.new(
-              @book, nil, '-', cover_path, nil
-            )
-
-            # Compile to AST
-            compiler = ReVIEW::AST::Compiler.for_chapter(cover_chapter)
-            ast_root = compiler.compile_to_ast(cover_chapter)
-
-            # Render to HTML
-            renderer = ReVIEW::Renderer::HtmlRenderer.new(cover_chapter)
-            html_body = renderer.visit(ast_root)
-
-            # Wrap with layout
-            @title = @config.name_of('booktitle')
-            @body = %(<div class="cover">#{html_body}</div>)
-            html = wrap_with_layout(@body, @title)
-
-            write_html_file('cover.html', html)
-            @entry_files << 'cover.html'
-            debug("Compiled cover page: #{coverfile}")
-          rescue StandardError => e
-            warn "Failed to compile cover file: #{e.message}"
-          end
-        end
-
-        def build_titlepage
-          @title = @config.name_of('booktitle')
-          @body = generate_titlepage_body
-          html = wrap_with_layout(@body, @title)
-          write_html_file('titlepage.html', html)
-          @entry_files << 'titlepage.html'
-        end
-
-        def generate_titlepage_body
-          template_path = find_template_path('vivliostyle/_titlepage.html.erb')
-          if template_path && File.exist?(template_path)
-            ReVIEW::Template.generate(path: template_path, binding: binding)
-          else
-            # Fallback simple titlepage
-            author_names = join_with_separator(@config.names_of('aut'), I18n.t('names_splitter'))
-            <<~HTML
-              <div class="titlepage">
-                <h1 class="booktitle">#{h(@config.name_of('booktitle'))}</h1>
-                <p class="author">#{h(author_names)}</p>
-              </div>
-            HTML
-          end
-        end
-
-        def build_toc
-          @title = I18n.t('toctitle')
-          @body = generate_toc_body
-          html = wrap_with_layout(@body, @title)
-          write_html_file('toc.html', html)
-          @entry_files << 'toc.html'
-        end
-
-        def generate_toc_body
-          toc_items = []
-          @book.parts.each do |part|
-            if part.name.present? && !part.file?
-              toc_items << %Q(<li class="part">#{h(part.name)}</li>)
-            end
-            part.chapters.each do |chap|
-              toc_items << %Q(<li><a href="#{chap.name}.html">#{h(chap.title)}</a></li>)
-            end
-          end
-
-          <<~HTML
-            <nav class="toc">
-              <h1>#{h(I18n.t('toctitle'))}</h1>
-              <ol>
-                #{toc_items.join("\n")}
-              </ol>
-            </nav>
-          HTML
-        end
-
-        def build_body
-          @compile_errors = nil
-
-          @book.parts.each do |part|
-            if part.name.present? && !part.file?
-              build_part_html(part)
-            end
-
-            part.chapters.each do |chap|
-              build_chapter_html(chap)
-            end
-          end
-
-          check_compile_status
-        end
-
-        def build_part_html(part)
-          @title = "#{I18n.t('part', part.number)} #{part.name}"
-          @body = <<~HTML
-            <div class="part">
-              <h1 class="part-number">#{h(I18n.t('part', part.number))}</h1>
-              <h2 class="part-title">#{h(part.name)}</h2>
-            </div>
-          HTML
-          html = wrap_with_layout(@body, @title)
-          filename = "part_#{part.number}.html"
-          write_html_file(filename, html)
-          @entry_files << filename
-        end
-
-        def build_chapter_html(chapter)
-          id = File.basename(chapter.path, '.*')
-
-          if @buildonly && !@buildonly.include?(id)
-            warn "skip #{id}.re"
-            return
-          end
-
-          begin
-            # Compile chapter to AST
-            compiler = ReVIEW::AST::Compiler.for_chapter(chapter)
-            ast_root = compiler.compile_to_ast(chapter)
-
-            # Render to HTML (body only, without layout wrapper)
-            renderer = ReVIEW::Renderer::HtmlRenderer.new(chapter)
-            html_body = renderer.visit(ast_root)
-
-            # Wrap with layout
-            @title = chapter.title
-            @body = html_body
-            html = wrap_with_layout(@body, @title)
-
-            filename = "#{chapter.name}.html"
-            write_html_file(filename, html)
-            @entry_files << filename
-
-            debug("Compiled #{chapter.path} -> #{filename}")
-          rescue StandardError => e
-            @compile_errors = true
-            error "compile error in #{chapter.path} (#{e.class})"
-            error e.message
-            if @config['debug']
-              puts e.backtrace.first(10).join("\n")
-            end
-          end
-        end
-
-        def build_backmatter
+        def generate_backmatter(context)
+          # Colophon
           if @config['colophon']
-            build_colophon
+            entry = Vivliostyle::Entries::ColophonEntry.new(context: context)
+            entry.generate
           end
         end
 
-        def build_colophon
-          @title = I18n.t('colophontitle')
-          @body = generate_colophon_body
-          html = wrap_with_layout(@body, @title)
-          write_html_file('colophon.html', html)
-          @entry_files << 'colophon.html'
-        end
-
-        def generate_colophon_body
-          template_path = find_template_path('vivliostyle/_colophon.html.erb')
-          if template_path && File.exist?(template_path)
-            ReVIEW::Template.generate(path: template_path, binding: binding)
-          else
-            # Fallback simple colophon
-            items = []
-            (@config['colophon_order'] || []).each do |key|
-              value = @config.name_of(key)
-              next unless value
-
-              label = I18n.t("colophon_#{key}", nil) || key
-              items << "<dt>#{h(label)}</dt><dd>#{h(value)}</dd>"
-            end
-
-            <<~HTML
-              <div class="colophon">
-                <h1>#{h(@config.name_of('booktitle'))}</h1>
-                <dl>
-                  #{items.join("\n")}
-                </dl>
-                <p class="date">#{h(@config['date'].to_s)}</p>
-              </div>
-            HTML
-          end
-        end
-
-        def wrap_with_layout(body, title)
-          @body = body
-          @title = title
-          @language = @config['language']
-
-          template_path = find_template_path('vivliostyle/layout.html.erb')
-          if template_path && File.exist?(template_path)
-            ReVIEW::Template.generate(path: template_path, binding: binding)
-          else
-            # Fallback layout
-            javascript_tags = @javascripts.map { |js| "  #{js}" }.join("\n")
-            stylesheet_links = @stylesheets.map do |css|
-              %Q(  <link rel="stylesheet" href="#{h(css)}">)
-            end.join("\n")
-
-            <<~HTML
-              <!DOCTYPE html>
-              <html lang="#{h(@language)}">
-              <head>
-                <meta charset="UTF-8">
-              #{javascript_tags}
-              #{stylesheet_links}
-                <title>#{h(@title)}</title>
-              </head>
-              <body>
-              #{@body}
-              </body>
-              </html>
-            HTML
-          end
-        end
-
-        def write_html_file(filename, content)
-          File.write(File.join(@path, filename), content)
-        end
-
-        def copy_images(from_dir, to_dir)
-          return unless File.exist?(File.join(@basedir, from_dir))
-
-          src_dir = File.join(@basedir, from_dir)
-          FileUtils.mkdir_p(to_dir)
-
-          exts = @config['image_ext'] || %w[png gif jpg jpeg svg]
-          copy_images_recursive(src_dir, to_dir, exts)
-        end
-
-        def copy_images_recursive(src_dir, dest_dir, exts)
-          Dir.foreach(src_dir) do |entry|
-            next if entry.start_with?('.')
-
-            src_path = File.join(src_dir, entry)
-            dest_path = File.join(dest_dir, entry)
-
-            if File.directory?(src_path)
-              FileUtils.mkdir_p(dest_path)
-              copy_images_recursive(src_path, dest_path, exts)
-            elsif exts.any? { |ext| entry.downcase.end_with?(".#{ext}") }
-              FileUtils.cp(src_path, dest_path)
-            end
-          end
-        end
-
-        def generate_vivliostyle_config
-          author_names = join_with_separator(@config.names_of('aut'), I18n.t('names_splitter'))
-          config_data = {
-            'title' => @config.name_of('booktitle'),
-            'author' => author_names,
-            'language' => @config['language'],
-            'size' => @config['vivliostylemaker']['size'] || 'JIS-B5',
-            'entry' => @entry_files,
-            'output' => "#{@config['bookname']}.pdf",
-            'workspaceDir' => '.vivliostyle'
-          }
-
-          # Add theme if specified
-          theme = @config['vivliostylemaker']['theme']
-          if theme
-            config_data['theme'] = theme
-          end
-
-          config_path = File.join(@path, 'vivliostyle.config.json')
-          File.write(config_path, JSON.pretty_generate(config_data))
-          debug('Generated vivliostyle.config.json')
-        end
-
-        def run_vivliostyle(_bookname)
-          cmd = build_vivliostyle_command
-
-          debug("Running: #{cmd.join(' ')}")
-
-          # Execute vivliostyle
-          Dir.chdir(@path) do
-            result = system(*cmd)
-            unless result
-              error! 'Vivliostyle build failed. Check the output above for details.'
-            end
-          end
-        end
-
-        def build_vivliostyle_command
-          cmd = if @config['vivliostylemaker']['use_npx']
-                  # Use npx (ignores vivliostyle_path)
-                  ['npx', '@vivliostyle/cli', 'build', '-c', 'vivliostyle.config.json']
-                else
-                  # Use vivliostyle_path
-                  vivliostyle_path = resolve_vivliostyle_path
-                  [vivliostyle_path, 'build', '-c', 'vivliostyle.config.json']
-                end
-
-          # Add press-ready option if specified
-          if @config['vivliostylemaker']['press_ready']
-            cmd << '--press-ready'
-          end
-
-          cmd
-        end
-
-        def resolve_vivliostyle_path
-          vivliostyle_path = @config['vivliostylemaker']['vivliostyle_path'] || 'vivliostyle'
-
-          # Check if vivliostyle exists
-          if system("which #{vivliostyle_path} > /dev/null 2>&1") ||
-             File.exist?(File.join(@basedir, vivliostyle_path))
-            return vivliostyle_path
-          end
-
-          # Try to find in node_modules
-          node_path = File.join(@basedir, 'node_modules', '.bin', 'vivliostyle')
-          if File.exist?(node_path)
-            return node_path
-          end
-
-          error! 'Vivliostyle CLI not found. Please install with: npm install @vivliostyle/cli'
-        end
-
-        def finalize_output(bookname)
-          src_pdf = File.join(@path, "#{bookname}.pdf")
-          dest_pdf = File.join(@basedir, "#{bookname}.pdf")
-
-          if File.exist?(src_pdf)
-            FileUtils.cp(src_pdf, dest_pdf)
-            debug("Output: #{dest_pdf}")
-          else
-            error! "PDF file was not generated: #{src_pdf}"
-          end
-        end
-
-        def check_compile_status
-          if @compile_errors
+        def check_compile_status(compile_errors)
+          if compile_errors
             if @config['ignore-errors']
               warn 'compile error exists, but ignored due to --ignore-errors option'
             else
               error! 'compile error, PDF file not generated.'
             end
-          end
-        end
-
-        def join_with_separator(value, sep)
-          if value.is_a?(Array)
-            value.join(sep)
-          else
-            value.to_s
           end
         end
       end

--- a/lib/review/ast/command/vivliostyle_maker.rb
+++ b/lib/review/ast/command/vivliostyle_maker.rb
@@ -1,0 +1,714 @@
+# frozen_string_literal: true
+
+# Copyright (c) 2025 Kenshi Muto, Masayoshi Takahashi
+#
+# This program is free software.
+# You can distribute or modify this program under the terms of
+# the GNU LGPL, Lesser General Public License version 2.1.
+
+require 'optparse'
+require 'tmpdir'
+require 'fileutils'
+require 'json'
+require 'erb'
+
+require 'review/i18n'
+require 'review/book'
+require 'review/configure'
+require 'review/version'
+require 'review/makerhelper'
+require 'review/loggable'
+require 'review/call_hook'
+require 'review/template'
+
+require 'review/ast'
+require 'review/ast/book_indexer'
+require 'review/renderer/html_renderer'
+
+module ReVIEW
+  module AST
+    module Command
+      # VivliostyleMaker - PDF generator using Vivliostyle CLI with AST Renderer
+      class VivliostyleMaker
+        include ERB::Util
+        include MakerHelper
+        include Loggable
+        include ReVIEW::CallHook
+
+        attr_accessor :config, :basedir
+
+        def initialize
+          @basedir = nil
+          @logger = ReVIEW.logger
+          @compile_errors = nil
+          @entry_files = []
+          @stylesheets = []
+          @javascripts = []
+        end
+
+        def self.execute(*args)
+          self.new.execute(*args)
+        end
+
+        def parse_opts(args)
+          cmd_config = {}
+          opts = OptionParser.new
+          @buildonly = nil
+
+          opts.banner = 'Usage: review-ast-vivliostylemaker [options] configfile'
+          opts.version = ReVIEW::VERSION
+          opts.on('--help', 'Prints this message and quit.') do
+            puts opts.help
+            exit 0
+          end
+          opts.on('--[no-]debug', 'Keep temporary files.') { |debug| cmd_config['debug'] = debug }
+          opts.on('--ignore-errors', 'Ignore compile errors.') { cmd_config['ignore-errors'] = true }
+          opts.on('-y', '--only file1,file2,...', 'Build only specified files.') do |v|
+            @buildonly = v.split(/\s*,\s*/).map { |m| m.strip.sub(/\.re\Z/, '') }
+          end
+
+          opts.parse!(args)
+          if args.size != 1
+            puts opts.help
+            exit 0
+          end
+
+          [cmd_config, args[0]]
+        end
+
+        def execute(*args)
+          cmd_config, yamlfile = parse_opts(args)
+          error! "#{yamlfile} not found." unless File.exist?(yamlfile)
+
+          begin
+            @config = ReVIEW::Configure.create(
+              maker: 'vivliostylemaker',
+              yamlfile: yamlfile,
+              config: cmd_config
+            )
+          rescue ReVIEW::ConfigError => e
+            error! e.message
+          end
+
+          update_log_level
+          I18n.setup(@config['language'])
+
+          begin
+            generate_pdf(yamlfile)
+          rescue ApplicationError => e
+            raise if @config['debug']
+
+            error! e.message
+          end
+        end
+
+        def update_log_level
+          if @config['debug']
+            if @logger.ttylogger?
+              ReVIEW.logger = nil
+              @logger = ReVIEW.logger(level: 'debug')
+            else
+              @logger.level = Logger::DEBUG
+            end
+          elsif !@logger.ttylogger?
+            @logger.level = Logger::INFO
+          end
+        end
+
+        def build_path
+          if @config['debug']
+            path = File.expand_path("#{@config['bookname']}-vivliostyle", Dir.pwd)
+            FileUtils.rm_rf(path, secure: true)
+            Dir.mkdir(path)
+            path
+          else
+            Dir.mktmpdir("#{@config['bookname']}-vivliostyle-")
+          end
+        end
+
+        def generate_pdf(yamlfile)
+          @basedir = File.absolute_path(File.dirname(yamlfile))
+          bookname = @config['bookname']
+
+          begin
+            @config.check_version(ReVIEW::VERSION, exception: true)
+          rescue ReVIEW::ConfigError => e
+            warn e.message
+          end
+
+          debug("#{bookname}.pdf will be created with Vivliostyle.")
+
+          # Remove old PDF
+          FileUtils.rm_f("#{bookname}.pdf")
+
+          @path = build_path
+          begin
+            debug("Created temporary directory as #{@path}.")
+
+            call_hook('hook_beforeprocess', @path, base_dir: @basedir)
+
+            # Initialize book and build indexes
+            @book = ReVIEW::Book::Base.new(@basedir, config: @config)
+            ReVIEW::AST::BookIndexer.build(@book)
+
+            # Setup stylesheets and javascripts
+            setup_stylesheet
+            setup_javascripts
+
+            # Build HTML files
+            build_frontmatter
+            build_body
+            call_hook('hook_afterbody', @path, base_dir: @basedir)
+            build_backmatter
+
+            # Copy images
+            copy_images(@config['imagedir'], File.join(@path, @config['imagedir']))
+            call_hook('hook_aftercopyimage', @path, base_dir: @basedir)
+
+            # Generate vivliostyle.config.json
+            generate_vivliostyle_config
+
+            # Run Vivliostyle CLI
+            call_hook('hook_beforevivliostyle', @path, base_dir: @basedir)
+            run_vivliostyle(bookname)
+            call_hook('hook_aftervivliostyle', @path, base_dir: @basedir)
+
+            # Copy output PDF
+            finalize_output(bookname)
+
+            @logger.success("built #{bookname}.pdf")
+          ensure
+            FileUtils.remove_entry_secure(@path) unless @config['debug']
+          end
+        end
+
+        private
+
+        def setup_stylesheet
+          theme = @config['vivliostylemaker']['theme']
+
+          if theme
+            # Use npm theme (will be resolved by Vivliostyle CLI)
+            debug("Using Vivliostyle theme: #{theme}")
+            @stylesheets = []
+          else
+            # Use bundled theme-review.css
+            css_src = find_template_path('vivliostyle/theme-review.css')
+            if css_src && File.exist?(css_src)
+              FileUtils.cp(css_src, @path)
+              @stylesheets = ['theme-review.css']
+              debug('Using bundled theme-review.css')
+            else
+              warn 'theme-review.css not found, no default stylesheet applied'
+              @stylesheets = []
+            end
+          end
+
+          # Copy additional CSS files
+          additional_css = @config['vivliostylemaker']['css'] || []
+          additional_css.each do |css_file|
+            src = File.join(@basedir, css_file)
+            if File.exist?(src)
+              FileUtils.cp(src, @path)
+              @stylesheets << File.basename(css_file)
+            else
+              warn "CSS file not found: #{css_file}"
+            end
+          end
+
+          # Copy user stylesheets from config (exclude style.css)
+          (@config['stylesheet'] || []).each do |css_file|
+            basename = File.basename(css_file)
+            next if basename == 'style.css' # Ignore legacy style.css
+
+            src = File.join(@basedir, css_file)
+            if File.exist?(src)
+              FileUtils.cp(src, @path)
+              @stylesheets << basename
+            end
+          end
+        end
+
+        def setup_javascripts
+          # Always include MathJax for Vivliostyle (default math rendering, no LaTeX required)
+          @javascripts.push(%Q(<script>MathJax = { tex: { inlineMath: [['\\\\(', '\\\\)']] }, svg: { fontCache: 'global' } };</script>))
+          @javascripts.push(%Q(<script type="text/javascript" id="MathJax-script" async="true" src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js"></script>))
+        end
+
+        def find_template_path(relative_path)
+          # Check user's layouts directory first
+          if @basedir
+            user_path = File.join(@basedir, 'layouts', relative_path)
+            return user_path if File.exist?(user_path)
+          end
+
+          # Check system templates
+          system_path = File.join(ReVIEW::Template::TEMPLATE_DIR, relative_path)
+          return system_path if File.exist?(system_path)
+
+          nil
+        end
+
+        def build_frontmatter
+          # Cover page
+          if @config['coverfile'] || @config['coverimage']
+            build_cover
+          end
+
+          # Title page
+          if @config['titlepage']
+            build_titlepage
+          end
+
+          # Table of contents
+          if @config['toc']
+            build_toc
+          end
+        end
+
+        def build_cover
+          coverfile = @config['coverfile']
+          coverimage = @config['coverimage']
+
+          if coverfile
+            build_cover_from_file(coverfile)
+          elsif coverimage
+            build_cover_from_image(coverimage)
+          end
+        end
+
+        def build_cover_from_file(coverfile)
+          src_path = File.join(@basedir, coverfile)
+
+          unless File.exist?(src_path)
+            warn "Cover file not found: #{coverfile}"
+            return
+          end
+
+          ext = File.extname(coverfile).downcase
+
+          if %w[.png .jpg .jpeg .gif .svg].include?(ext)
+            # Image cover - create HTML wrapper
+            build_image_cover(src_path, File.basename(coverfile))
+          elsif %w[.html .htm .xhtml].include?(ext)
+            # HTML cover - copy directly
+            build_html_cover(src_path, coverfile)
+          elsif %w[.re .md].include?(ext)
+            # Re:VIEW/Markdown cover - compile
+            build_review_cover(coverfile)
+          else
+            warn "Unsupported cover file format: #{ext}"
+          end
+        end
+
+        def build_cover_from_image(coverimage)
+          # coverimage is relative to imagedir
+          src_path = File.join(@basedir, @config['imagedir'], coverimage)
+
+          unless File.exist?(src_path)
+            warn "Cover image not found: #{coverimage}"
+            return
+          end
+
+          build_image_cover(src_path, coverimage)
+        end
+
+        def build_image_cover(src_path, filename)
+          # Copy cover image to build directory
+          dest_filename = "cover#{File.extname(filename)}"
+          FileUtils.cp(src_path, File.join(@path, dest_filename))
+
+          # Generate cover HTML
+          @title = @config.name_of('booktitle')
+          @body = <<~HTML
+            <div class="cover">
+              <img src="#{h(dest_filename)}" alt="#{h(@title)}" class="cover-image" />
+            </div>
+          HTML
+          html = wrap_with_layout(@body, @title)
+          write_html_file('cover.html', html)
+          @entry_files << 'cover.html'
+          debug("Generated cover page from image: #{filename}")
+        end
+
+        def build_html_cover(src_path, coverfile)
+          # Copy HTML cover file
+          dest_filename = 'cover.html'
+          content = File.read(src_path)
+
+          # If it's a fragment (no DOCTYPE), wrap with layout
+          if content.include?('<!DOCTYPE') || content.include?('<html')
+            # Full HTML document - copy as-is but ensure stylesheets are linked
+            write_html_file(dest_filename, content)
+          else
+            # HTML fragment - wrap with layout
+            @title = @config.name_of('booktitle')
+            @body = content
+            html = wrap_with_layout(@body, @title)
+            write_html_file(dest_filename, html)
+          end
+
+          @entry_files << dest_filename
+          debug("Copied cover page: #{coverfile}")
+        end
+
+        def build_review_cover(coverfile)
+          # Find the cover chapter
+          cover_path = File.join(@basedir, coverfile)
+
+          begin
+            # Create a temporary chapter for the cover
+            cover_chapter = ReVIEW::Book::Chapter.new(
+              @book, nil, '-', cover_path, nil
+            )
+
+            # Compile to AST
+            compiler = ReVIEW::AST::Compiler.for_chapter(cover_chapter)
+            ast_root = compiler.compile_to_ast(cover_chapter)
+
+            # Render to HTML
+            renderer = ReVIEW::Renderer::HtmlRenderer.new(cover_chapter)
+            html_body = renderer.visit(ast_root)
+
+            # Wrap with layout
+            @title = @config.name_of('booktitle')
+            @body = %(<div class="cover">#{html_body}</div>)
+            html = wrap_with_layout(@body, @title)
+
+            write_html_file('cover.html', html)
+            @entry_files << 'cover.html'
+            debug("Compiled cover page: #{coverfile}")
+          rescue StandardError => e
+            warn "Failed to compile cover file: #{e.message}"
+          end
+        end
+
+        def build_titlepage
+          @title = @config.name_of('booktitle')
+          @body = generate_titlepage_body
+          html = wrap_with_layout(@body, @title)
+          write_html_file('titlepage.html', html)
+          @entry_files << 'titlepage.html'
+        end
+
+        def generate_titlepage_body
+          template_path = find_template_path('vivliostyle/_titlepage.html.erb')
+          if template_path && File.exist?(template_path)
+            ReVIEW::Template.generate(path: template_path, binding: binding)
+          else
+            # Fallback simple titlepage
+            author_names = join_with_separator(@config.names_of('aut'), I18n.t('names_splitter'))
+            <<~HTML
+              <div class="titlepage">
+                <h1 class="booktitle">#{h(@config.name_of('booktitle'))}</h1>
+                <p class="author">#{h(author_names)}</p>
+              </div>
+            HTML
+          end
+        end
+
+        def build_toc
+          @title = I18n.t('toctitle')
+          @body = generate_toc_body
+          html = wrap_with_layout(@body, @title)
+          write_html_file('toc.html', html)
+          @entry_files << 'toc.html'
+        end
+
+        def generate_toc_body
+          toc_items = []
+          @book.parts.each do |part|
+            if part.name.present? && !part.file?
+              toc_items << %Q(<li class="part">#{h(part.name)}</li>)
+            end
+            part.chapters.each do |chap|
+              toc_items << %Q(<li><a href="#{chap.name}.html">#{h(chap.title)}</a></li>)
+            end
+          end
+
+          <<~HTML
+            <nav class="toc">
+              <h1>#{h(I18n.t('toctitle'))}</h1>
+              <ol>
+                #{toc_items.join("\n")}
+              </ol>
+            </nav>
+          HTML
+        end
+
+        def build_body
+          @compile_errors = nil
+
+          @book.parts.each do |part|
+            if part.name.present? && !part.file?
+              build_part_html(part)
+            end
+
+            part.chapters.each do |chap|
+              build_chapter_html(chap)
+            end
+          end
+
+          check_compile_status
+        end
+
+        def build_part_html(part)
+          @title = "#{I18n.t('part', part.number)} #{part.name}"
+          @body = <<~HTML
+            <div class="part">
+              <h1 class="part-number">#{h(I18n.t('part', part.number))}</h1>
+              <h2 class="part-title">#{h(part.name)}</h2>
+            </div>
+          HTML
+          html = wrap_with_layout(@body, @title)
+          filename = "part_#{part.number}.html"
+          write_html_file(filename, html)
+          @entry_files << filename
+        end
+
+        def build_chapter_html(chapter)
+          id = File.basename(chapter.path, '.*')
+
+          if @buildonly && !@buildonly.include?(id)
+            warn "skip #{id}.re"
+            return
+          end
+
+          begin
+            # Compile chapter to AST
+            compiler = ReVIEW::AST::Compiler.for_chapter(chapter)
+            ast_root = compiler.compile_to_ast(chapter)
+
+            # Render to HTML (body only, without layout wrapper)
+            renderer = ReVIEW::Renderer::HtmlRenderer.new(chapter)
+            html_body = renderer.visit(ast_root)
+
+            # Wrap with layout
+            @title = chapter.title
+            @body = html_body
+            html = wrap_with_layout(@body, @title)
+
+            filename = "#{chapter.name}.html"
+            write_html_file(filename, html)
+            @entry_files << filename
+
+            debug("Compiled #{chapter.path} -> #{filename}")
+          rescue StandardError => e
+            @compile_errors = true
+            error "compile error in #{chapter.path} (#{e.class})"
+            error e.message
+            if @config['debug']
+              puts e.backtrace.first(10).join("\n")
+            end
+          end
+        end
+
+        def build_backmatter
+          if @config['colophon']
+            build_colophon
+          end
+        end
+
+        def build_colophon
+          @title = I18n.t('colophontitle')
+          @body = generate_colophon_body
+          html = wrap_with_layout(@body, @title)
+          write_html_file('colophon.html', html)
+          @entry_files << 'colophon.html'
+        end
+
+        def generate_colophon_body
+          template_path = find_template_path('vivliostyle/_colophon.html.erb')
+          if template_path && File.exist?(template_path)
+            ReVIEW::Template.generate(path: template_path, binding: binding)
+          else
+            # Fallback simple colophon
+            items = []
+            (@config['colophon_order'] || []).each do |key|
+              value = @config.name_of(key)
+              next unless value
+
+              label = I18n.t("colophon_#{key}", nil) || key
+              items << "<dt>#{h(label)}</dt><dd>#{h(value)}</dd>"
+            end
+
+            <<~HTML
+              <div class="colophon">
+                <h1>#{h(@config.name_of('booktitle'))}</h1>
+                <dl>
+                  #{items.join("\n")}
+                </dl>
+                <p class="date">#{h(@config['date'].to_s)}</p>
+              </div>
+            HTML
+          end
+        end
+
+        def wrap_with_layout(body, title)
+          @body = body
+          @title = title
+          @language = @config['language']
+
+          template_path = find_template_path('vivliostyle/layout.html.erb')
+          if template_path && File.exist?(template_path)
+            ReVIEW::Template.generate(path: template_path, binding: binding)
+          else
+            # Fallback layout
+            javascript_tags = @javascripts.map { |js| "  #{js}" }.join("\n")
+            stylesheet_links = @stylesheets.map do |css|
+              %Q(  <link rel="stylesheet" href="#{h(css)}">)
+            end.join("\n")
+
+            <<~HTML
+              <!DOCTYPE html>
+              <html lang="#{h(@language)}">
+              <head>
+                <meta charset="UTF-8">
+              #{javascript_tags}
+              #{stylesheet_links}
+                <title>#{h(@title)}</title>
+              </head>
+              <body>
+              #{@body}
+              </body>
+              </html>
+            HTML
+          end
+        end
+
+        def write_html_file(filename, content)
+          File.write(File.join(@path, filename), content)
+        end
+
+        def copy_images(from_dir, to_dir)
+          return unless File.exist?(File.join(@basedir, from_dir))
+
+          src_dir = File.join(@basedir, from_dir)
+          FileUtils.mkdir_p(to_dir)
+
+          exts = @config['image_ext'] || %w[png gif jpg jpeg svg]
+          copy_images_recursive(src_dir, to_dir, exts)
+        end
+
+        def copy_images_recursive(src_dir, dest_dir, exts)
+          Dir.foreach(src_dir) do |entry|
+            next if entry.start_with?('.')
+
+            src_path = File.join(src_dir, entry)
+            dest_path = File.join(dest_dir, entry)
+
+            if File.directory?(src_path)
+              FileUtils.mkdir_p(dest_path)
+              copy_images_recursive(src_path, dest_path, exts)
+            elsif exts.any? { |ext| entry.downcase.end_with?(".#{ext}") }
+              FileUtils.cp(src_path, dest_path)
+            end
+          end
+        end
+
+        def generate_vivliostyle_config
+          author_names = join_with_separator(@config.names_of('aut'), I18n.t('names_splitter'))
+          config_data = {
+            'title' => @config.name_of('booktitle'),
+            'author' => author_names,
+            'language' => @config['language'],
+            'size' => @config['vivliostylemaker']['size'] || 'JIS-B5',
+            'entry' => @entry_files,
+            'output' => "#{@config['bookname']}.pdf",
+            'workspaceDir' => '.vivliostyle'
+          }
+
+          # Add theme if specified
+          theme = @config['vivliostylemaker']['theme']
+          if theme
+            config_data['theme'] = theme
+          end
+
+          config_path = File.join(@path, 'vivliostyle.config.json')
+          File.write(config_path, JSON.pretty_generate(config_data))
+          debug('Generated vivliostyle.config.json')
+        end
+
+        def run_vivliostyle(_bookname)
+          cmd = build_vivliostyle_command
+
+          debug("Running: #{cmd.join(' ')}")
+
+          # Execute vivliostyle
+          Dir.chdir(@path) do
+            result = system(*cmd)
+            unless result
+              error! 'Vivliostyle build failed. Check the output above for details.'
+            end
+          end
+        end
+
+        def build_vivliostyle_command
+          cmd = if @config['vivliostylemaker']['use_npx']
+                  # Use npx (ignores vivliostyle_path)
+                  ['npx', '@vivliostyle/cli', 'build', '-c', 'vivliostyle.config.json']
+                else
+                  # Use vivliostyle_path
+                  vivliostyle_path = resolve_vivliostyle_path
+                  [vivliostyle_path, 'build', '-c', 'vivliostyle.config.json']
+                end
+
+          # Add press-ready option if specified
+          if @config['vivliostylemaker']['press_ready']
+            cmd << '--press-ready'
+          end
+
+          cmd
+        end
+
+        def resolve_vivliostyle_path
+          vivliostyle_path = @config['vivliostylemaker']['vivliostyle_path'] || 'vivliostyle'
+
+          # Check if vivliostyle exists
+          if system("which #{vivliostyle_path} > /dev/null 2>&1") ||
+             File.exist?(File.join(@basedir, vivliostyle_path))
+            return vivliostyle_path
+          end
+
+          # Try to find in node_modules
+          node_path = File.join(@basedir, 'node_modules', '.bin', 'vivliostyle')
+          if File.exist?(node_path)
+            return node_path
+          end
+
+          error! 'Vivliostyle CLI not found. Please install with: npm install @vivliostyle/cli'
+        end
+
+        def finalize_output(bookname)
+          src_pdf = File.join(@path, "#{bookname}.pdf")
+          dest_pdf = File.join(@basedir, "#{bookname}.pdf")
+
+          if File.exist?(src_pdf)
+            FileUtils.cp(src_pdf, dest_pdf)
+            debug("Output: #{dest_pdf}")
+          else
+            error! "PDF file was not generated: #{src_pdf}"
+          end
+        end
+
+        def check_compile_status
+          if @compile_errors
+            if @config['ignore-errors']
+              warn 'compile error exists, but ignored due to --ignore-errors option'
+            else
+              error! 'compile error, PDF file not generated.'
+            end
+          end
+        end
+
+        def join_with_separator(value, sep)
+          if value.is_a?(Array)
+            value.join(sep)
+          else
+            value.to_s
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -153,6 +153,23 @@ module ReVIEW
         },
         'textmaker' => {
           'th_bold' => nil
+        },
+        # for VivliostyleMaker
+        'vivliostylemaker' => {
+          'use_npx' => true,
+          'vivliostyle_path' => './node_modules/.bin/vivliostyle',
+          'timeout' => 600,
+          'math_format' => 'mathjax',
+          'size' => 'JIS-B5',
+          'theme' => nil,
+          'css' => [],
+          'press_ready' => false,
+          'book' => true,
+          'hook_beforeprocess' => nil,
+          'hook_afterbody' => nil,
+          'hook_aftercopyimage' => nil,
+          'hook_beforevivliostyle' => nil,
+          'hook_aftervivliostyle' => nil
         }
       ]
       conf.maker = nil

--- a/lib/review/configure.rb
+++ b/lib/review/configure.rb
@@ -163,6 +163,7 @@ module ReVIEW
           'size' => 'JIS-B5',
           'theme' => nil,
           'css' => [],
+          'colophon' => true, # Use colophon
           'press_ready' => false,
           'book' => true,
           'hook_beforeprocess' => nil,

--- a/lib/review/renderer/html_renderer.rb
+++ b/lib/review/renderer/html_renderer.rb
@@ -446,7 +446,7 @@ module ReVIEW
         when 'imgmath'
           render_imgmath_format(content)
         else
-          # Unknown format: fallback to preformatted text
+          # Fallback: render as preformatted text
           %Q(<pre>#{escape(content)}\n</pre>\n)
         end
       end

--- a/lib/review/renderer/html_renderer.rb
+++ b/lib/review/renderer/html_renderer.rb
@@ -446,7 +446,7 @@ module ReVIEW
         when 'imgmath'
           render_imgmath_format(content)
         else
-          # Fallback: render as preformatted text
+          # Unknown format: fallback to preformatted text
           %Q(<pre>#{escape(content)}\n</pre>\n)
         end
       end

--- a/templates/vivliostyle/_colophon.html.erb
+++ b/templates/vivliostyle/_colophon.html.erb
@@ -1,0 +1,25 @@
+<div class="colophon">
+<div class="colophon-inner">
+<% if config['subtitle'].nil? %>
+  <p class="title"><%= h(config.name_of('booktitle')) %></p>
+<% else %>
+  <p class="title"><%= h(config.name_of('booktitle')) %><br /><span class="subtitle"><%= h(config.name_of('subtitle')) %></span></p>
+<% end %>
+<% if config['date'] || config['history'] %>
+<%= colophon_history %>
+<% end %>
+  <table class="colophon-table">
+<% (config['colophon_order'] || %w[aut csl trl dsr ill cov edt pbl contact prt]).each do |role| %>
+<%   if config[role] %>
+    <tr><th><%= h(ReVIEW::I18n.t(role)) %></th><td><%= h(join_with_separator(config.names_of(role), ReVIEW::I18n.t('names_splitter'))) %></td></tr>
+<%   end %>
+<% end %>
+<% if isbn_hyphen %>
+    <tr><th>ISBN</th><td><%= isbn_hyphen %></td></tr>
+<% end %>
+  </table>
+<% if config['rights'] && !config['rights'].empty? %>
+  <p class="copyright"><%= join_with_separator(config.names_of('rights').map { |m| h(m) }, '<br />') %></p>
+<% end %>
+</div>
+</div>

--- a/templates/vivliostyle/_colophon_history.html.erb
+++ b/templates/vivliostyle/_colophon_history.html.erb
@@ -1,0 +1,9 @@
+  <div class="pubhistory">
+<% if config['history'] %>
+<%   col_history.each do |item| %>
+    <p><%= item %></p>
+<%   end %>
+<% else %>
+    <p><%= ReVIEW::I18n.t('published_by2', date_to_s(config['date'])) %></p>
+<% end %>
+  </div>

--- a/templates/vivliostyle/layout.html.erb
+++ b/templates/vivliostyle/layout.html.erb
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="<%= @language %>">
+<head>
+  <meta charset="UTF-8">
+  <meta name="generator" content="Re:VIEW">
+<% if @javascripts.present? %>
+<%   @javascripts.each do |js| %>
+  <%= js %>
+<%   end %>
+<% end %>
+<% if @stylesheets.present? %>
+<%   @stylesheets.each do |style| %>
+  <link rel="stylesheet" type="text/css" href="<%= style %>">
+<%   end %>
+<% end %>
+  <title><%= h(@title) %></title>
+</head>
+<body>
+<%= @body %>
+</body>
+</html>

--- a/templates/vivliostyle/theme-review.css
+++ b/templates/vivliostyle/theme-review.css
@@ -4,6 +4,9 @@
  * License: CC0-1.0
  */
 
+/* Import Syntax Highlighting theme (Rouge - GitHub) */
+@import url("theme-rouge-github.css");
+
 /* ========================================
  * CSS Custom Properties (Vivliostyle standard)
  * ======================================== */
@@ -20,15 +23,35 @@
   --vs-color-heading: #2d3748;
   --vs-color-border: #cbd5e0;
 
+  /* Syntax Highlighting - GitHub Light Theme */
+  --vs-hl-bg: #f8f8f8;
+  --vs-hl-text: #24292f;
+  --vs-hl-comment: #6e7781;
+  --vs-hl-keyword: #cf222e;
+  --vs-hl-string: #0a3069;
+  --vs-hl-number: #0550ae;
+  --vs-hl-function: #8250df;
+  --vs-hl-class: #953800;
+  --vs-hl-tag: #116329;
+  --vs-hl-attribute: #116329;
+  --vs-hl-variable: #0550ae;
+  --vs-hl-operator: #0550ae;
+  --vs-hl-diff-add: #116329;
+  --vs-hl-diff-add-bg: #dafbe1;
+  --vs-hl-diff-del: #82071e;
+  --vs-hl-diff-del-bg: #ffebe9;
+  --vs-hl-error-bg: #82071e;
+  --vs-hl-error-text: #f6f8fa;
+
   /* Typography */
-  --vs-font-family: "Neue Frutiger World", "Verdana", "Hiragino Sans", sans-serif;
-  --vs-font-family-mono: "Source Code Pro", "Consolas", monospace;
+  --vs-font-family: "Hiragino Mincho ProN", "Hiragino Mincho Pro", "Yu Mincho", "YuMincho", "Noto Serif CJK JP", "Noto Serif JP", serif;
+  --vs-font-family-mono: "Menlo", "Consolas", "Courier New", "Courier", "Hiragino Kaku Gothic ProN", "MS Gothic", "Yu Gothic", monospace;
   --vs-font-size: 10pt;
   --vs-line-height: 1.7;
 
   /* Headings */
-  --vs-heading-font-family: var(--vs-font-family);
-  --vs-heading-font-weight: bold;
+  --vs-heading-font-family: "Hiragino Sans", "Hiragino Kaku Gothic ProN", "Yu Gothic", "YuGothic", "Noto Sans CJK JP", "Noto Sans JP", sans-serif;
+  --vs-heading-font-weight: 600;
   --vs-h1-font-size: 24pt;
   --vs-h2-font-size: 16pt;
   --vs-h3-font-size: 14pt;
@@ -123,6 +146,8 @@ body {
   background-color: var(--vs-color-bg);
   text-align: justify;
   text-justify: inter-character;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 /* ========================================
@@ -130,9 +155,14 @@ body {
  * ======================================== */
 h1, h2, h3, h4, h5, h6 {
   font-family: var(--vs-heading-font-family);
-  font-weight: var(--vs-heading-font-weight);
   line-height: 1.4;
   color: var(--vs-color-heading);
+  text-align: left;
+  text-justify: auto;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  font-weight: var(--vs-heading-font-weight);
 }
 
 h1 {
@@ -141,15 +171,17 @@ h1 {
   margin-bottom: 1em;
   padding-top: 1em;
   padding-bottom: 0.5em;
-  border-top: 4pt solid var(--vs-color-primary);
 }
 
 h2 {
   font-size: var(--vs-h2-font-size);
   margin-top: 2em;
   margin-bottom: 0.8em;
-  padding-left: 0.8em;
-  border-left: 4pt solid var(--vs-color-primary);
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+  padding-left: 0.5em;
+  border-radius: 3pt;
+  background-color: var(--vs-color-border);
 }
 
 h3 {
@@ -197,6 +229,7 @@ hr + p, .noindent {
 a {
   color: var(--vs-color-anchor);
   text-decoration: none;
+  word-break: break-all;
 }
 
 /* ========================================
@@ -225,6 +258,7 @@ pre {
   word-wrap: break-word;
   font-size: 9pt;
   line-height: 1.4;
+  text-align: left;
 }
 
 pre code {
@@ -244,6 +278,7 @@ ul, ol {
 
 li {
   margin: 0.3em 0;
+  text-align: left;
 }
 
 dl {
@@ -281,17 +316,25 @@ table {
   border-collapse: collapse;
   margin: 1em 0;
   width: 100%;
+  max-width: 100%;
+  table-layout: fixed;
 }
 
 th, td {
-  border: 1pt solid #333;
+  border: 0.3pt solid var(--vs-color-border);
   padding: 0.5em;
   text-align: left;
+  word-break: break-all;
 }
 
 th {
-  background-color: #f0f0f0;
+  background-color: var(--vs-color-inline-code-bg);
   font-weight: bold;
+}
+
+/* Zebra striping for table rows */
+tbody tr:nth-child(even) {
+  background-color: var(--vs-color-blockquote-bg);
 }
 
 /* ========================================
@@ -347,12 +390,8 @@ img {
 
 /* Lead paragraph */
 .lead {
-  font-size: 1.1em;
   margin-bottom: 1.5em;
-}
-
-.lead p {
-  text-indent: 0;
+  margin-left: 3em;
 }
 
 /* Column */
@@ -363,6 +402,7 @@ img {
   border-radius: 4pt;
   background-color: var(--vs-color-blockquote-bg);
   break-inside: avoid;
+  word-break: break-all;
 }
 
 .column h1, .column h2, .column h3,
@@ -379,6 +419,7 @@ img {
   border: 2pt solid var(--vs-color-primary);
   border-radius: 4pt;
   break-inside: avoid;
+  word-break: break-all;
 }
 
 /* Minicolumns */
@@ -438,8 +479,7 @@ img {
 
 pre.list, pre.emlist, pre.source {
   background-color: var(--vs-color-inline-code-bg);
-  border: 1pt solid var(--vs-color-inline-code-border);
-  border-radius: 4pt;
+  border: none;
   padding: 0.8em 1em;
   margin: 0;
   font-size: 9pt;
@@ -601,6 +641,81 @@ a.noteref {
   @top-left { content: none; }
   @top-right { content: none; }
   @bottom-center { content: none; }
+}
+
+/* Colophon (imprint) page */
+.colophon {
+  page: colophon;
+  break-inside: avoid;
+  min-height: 100vh; /* ページ全体の高さと同等にする */
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  padding-bottom: 2rem;
+}
+
+@page colophon {
+  @top-left { content: none; }
+  @top-right { content: none; }
+  @bottom-center { content: none; }
+}
+
+.colophon .colophon-inner {
+  margin-top: auto;
+}
+
+.colophon .title {
+  font-family: var(--vs-heading-font-family);
+  font-size: var(--vs-h2-font-size);
+  font-weight: var(--vs-heading-font-weight);
+  margin-bottom: 1em;
+  text-align: center;
+}
+
+.colophon .subtitle {
+  font-size: 0.8em;
+  font-weight: normal;
+}
+
+.colophon .pubhistory {
+  margin: 1.5em 0;
+  text-align: center;
+}
+
+.colophon .pubhistory p {
+  margin: 0.3em 0;
+  text-indent: 0;
+}
+
+.colophon table.colophon-table {
+  width: auto;
+  margin: 1.5em auto;
+  border-collapse: collapse;
+}
+
+.colophon table.colophon-table tr {
+  background-color: transparent;
+}
+
+.colophon table.colophon-table th,
+.colophon table.colophon-table td {
+  border: none;
+  padding: 0.3em 1em;
+  text-align: left;
+  vertical-align: top;
+}
+
+.colophon table.colophon-table th {
+  background: none;
+  font-weight: normal;
+  white-space: nowrap;
+}
+
+.colophon .copyright {
+  margin-top: 2em;
+  text-align: center;
+  font-size: 0.9em;
+  text-indent: 0;
 }
 
 /* ========================================

--- a/templates/vivliostyle/theme-review.css
+++ b/templates/vivliostyle/theme-review.css
@@ -1,0 +1,628 @@
+/*
+ * Re:VIEW Vivliostyle Theme
+ * Based on @vivliostyle/theme-techbook structure
+ * License: CC0-1.0
+ */
+
+/* ========================================
+ * CSS Custom Properties (Vivliostyle standard)
+ * ======================================== */
+:root {
+  /* Colors - Dark Gray theme */
+  --vs-color-primary: #2d3748;
+  --vs-color-body: #1a202c;
+  --vs-color-bg: transparent;
+  --vs-color-anchor: #4a5568;
+  --vs-color-blockquote-border: #a0aec0;
+  --vs-color-blockquote-bg: #f7fafc;
+  --vs-color-inline-code-bg: #edf2f7;
+  --vs-color-inline-code-border: #e2e8f0;
+  --vs-color-heading: #2d3748;
+  --vs-color-border: #cbd5e0;
+
+  /* Typography */
+  --vs-font-family: "Neue Frutiger World", "Verdana", "Hiragino Sans", sans-serif;
+  --vs-font-family-mono: "Source Code Pro", "Consolas", monospace;
+  --vs-font-size: 10pt;
+  --vs-line-height: 1.7;
+
+  /* Headings */
+  --vs-heading-font-family: var(--vs-font-family);
+  --vs-heading-font-weight: bold;
+  --vs-h1-font-size: 24pt;
+  --vs-h2-font-size: 16pt;
+  --vs-h3-font-size: 14pt;
+  --vs-h4-font-size: 12pt;
+  --vs-h5-font-size: 11pt;
+  --vs-h6-font-size: 10pt;
+
+  /* Page */
+  --vs-page-width: 182mm;
+  --vs-page-height: 257mm;
+  --vs-page-margin-top: 25mm;
+  --vs-page-margin-bottom: 25mm;
+  --vs-page-margin-inside: 22mm;
+  --vs-page-margin-outside: 22mm;
+}
+
+/* ========================================
+ * Reset
+ * ======================================== */
+*, *::before, *::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+/* ========================================
+ * Page Settings
+ * ======================================== */
+@page {
+  size: var(--vs-page-width) var(--vs-page-height);
+  margin-top: var(--vs-page-margin-top);
+  margin-bottom: var(--vs-page-margin-bottom);
+
+  @top-left {
+    content: env(pub-title);
+    font-size: 9pt;
+    color: #666;
+  }
+  @top-right {
+    content: env(doc-title);
+    font-size: 9pt;
+    color: #666;
+  }
+  @bottom-center {
+    content: counter(page);
+    font-size: 9pt;
+  }
+}
+
+@page :left {
+  margin-left: var(--vs-page-margin-outside);
+  margin-right: var(--vs-page-margin-inside);
+
+  @top-left {
+    content: env(pub-title);
+  }
+  @top-right {
+    content: none;
+  }
+}
+
+@page :right {
+  margin-left: var(--vs-page-margin-inside);
+  margin-right: var(--vs-page-margin-outside);
+
+  @top-left {
+    content: none;
+  }
+  @top-right {
+    content: env(doc-title);
+  }
+}
+
+@page :first {
+  @top-left { content: none; }
+  @top-right { content: none; }
+}
+
+/* ========================================
+ * Base Typography
+ * ======================================== */
+html {
+  orphans: 1;
+  widows: 1;
+}
+
+body {
+  font-family: var(--vs-font-family);
+  font-size: var(--vs-font-size);
+  line-height: var(--vs-line-height);
+  color: var(--vs-color-body);
+  background-color: var(--vs-color-bg);
+  text-align: justify;
+  text-justify: inter-character;
+}
+
+/* ========================================
+ * Headings
+ * ======================================== */
+h1, h2, h3, h4, h5, h6 {
+  font-family: var(--vs-heading-font-family);
+  font-weight: var(--vs-heading-font-weight);
+  line-height: 1.4;
+  color: var(--vs-color-heading);
+}
+
+h1 {
+  font-size: var(--vs-h1-font-size);
+  break-before: right;
+  margin-bottom: 1em;
+  padding-top: 1em;
+  padding-bottom: 0.5em;
+  border-top: 4pt solid var(--vs-color-primary);
+}
+
+h2 {
+  font-size: var(--vs-h2-font-size);
+  margin-top: 2em;
+  margin-bottom: 0.8em;
+  padding-left: 0.8em;
+  border-left: 4pt solid var(--vs-color-primary);
+}
+
+h3 {
+  font-size: var(--vs-h3-font-size);
+  margin-top: 1.5em;
+  margin-bottom: 0.6em;
+  padding-bottom: 0.3em;
+  border-bottom: 1pt solid var(--vs-color-border);
+}
+
+h4 {
+  font-size: var(--vs-h4-font-size);
+  margin-top: 1.2em;
+  margin-bottom: 0.5em;
+}
+
+h5 {
+  font-size: var(--vs-h5-font-size);
+  margin-top: 1em;
+  margin-bottom: 0.4em;
+}
+
+h6 {
+  font-size: var(--vs-h6-font-size);
+  margin-top: 1em;
+  margin-bottom: 0.3em;
+}
+
+/* ========================================
+ * Paragraphs
+ * ======================================== */
+p {
+  margin: 0;
+  text-indent: 1em;
+}
+
+h1 + p, h2 + p, h3 + p, h4 + p, h5 + p, h6 + p,
+hr + p, .noindent {
+  text-indent: 0;
+}
+
+/* ========================================
+ * Links
+ * ======================================== */
+a {
+  color: var(--vs-color-anchor);
+  text-decoration: none;
+}
+
+/* ========================================
+ * Code
+ * ======================================== */
+pre, code {
+  font-family: var(--vs-font-family-mono);
+}
+
+code {
+  background-color: var(--vs-color-inline-code-bg);
+  border: 1pt solid var(--vs-color-inline-code-border);
+  border-radius: 3pt;
+  padding: 0.1em 0.3em;
+  font-size: 0.9em;
+}
+
+pre {
+  background-color: #f8f8f8;
+  border: 1pt solid #ddd;
+  border-radius: 4pt;
+  padding: 1em;
+  margin: 1em 0;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  font-size: 9pt;
+  line-height: 1.4;
+}
+
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: inherit;
+}
+
+/* ========================================
+ * Lists
+ * ======================================== */
+ul, ol {
+  margin: 1em 0;
+  padding-left: 2em;
+}
+
+li {
+  margin: 0.3em 0;
+}
+
+dl {
+  margin: 1em 0;
+}
+
+dt {
+  font-weight: bold;
+  margin-top: 0.5em;
+}
+
+dd {
+  margin-left: 2em;
+  margin-top: 0.3em;
+}
+
+/* ========================================
+ * Blockquote
+ * ======================================== */
+blockquote {
+  margin: 1em 0;
+  padding: 0.5em 1em;
+  border-left: 4pt solid var(--vs-color-blockquote-border);
+  background-color: var(--vs-color-blockquote-bg);
+}
+
+blockquote p {
+  text-indent: 0;
+}
+
+/* ========================================
+ * Tables
+ * ======================================== */
+table {
+  border-collapse: collapse;
+  margin: 1em 0;
+  width: 100%;
+}
+
+th, td {
+  border: 1pt solid #333;
+  padding: 0.5em;
+  text-align: left;
+}
+
+th {
+  background-color: #f0f0f0;
+  font-weight: bold;
+}
+
+/* ========================================
+ * Images and Figures
+ * ======================================== */
+figure {
+  margin: 1em 0;
+  text-align: center;
+}
+
+figure img {
+  max-width: 100%;
+  height: auto;
+}
+
+figcaption {
+  font-size: 0.9em;
+  margin-top: 0.5em;
+}
+
+img {
+  max-width: 100%;
+  height: auto;
+}
+
+/* ========================================
+ * Footnotes
+ * ======================================== */
+.footnote {
+  float: footnote;
+  font-size: 8pt;
+}
+
+::footnote-marker {
+  font-size: 8pt;
+}
+
+::footnote-call {
+  font-size: 8pt;
+  vertical-align: super;
+  line-height: 0;
+}
+
+/* ========================================
+ * Re:VIEW Specific Classes
+ * ======================================== */
+
+/* Section number */
+.secno {
+  color: var(--vs-color-primary);
+  margin-right: 0.3em;
+}
+
+/* Lead paragraph */
+.lead {
+  font-size: 1.1em;
+  margin-bottom: 1.5em;
+}
+
+.lead p {
+  text-indent: 0;
+}
+
+/* Column */
+.column {
+  margin: 1.5em 0;
+  padding: 1em 1.2em;
+  border: 1pt solid var(--vs-color-border);
+  border-radius: 4pt;
+  background-color: var(--vs-color-blockquote-bg);
+  break-inside: avoid;
+}
+
+.column h1, .column h2, .column h3,
+.column h4, .column h5, .column h6 {
+  break-before: auto;
+  margin-top: 0;
+  border: none;
+  padding: 0;
+}
+
+.xcolumn {
+  margin: 1.5em 0;
+  padding: 1em 1.2em;
+  border: 2pt solid var(--vs-color-primary);
+  border-radius: 4pt;
+  break-inside: avoid;
+}
+
+/* Minicolumns */
+.reference, .supplement, .syntax {
+  margin: 1em 0;
+  padding: 0.8em 1em;
+  background-color: var(--vs-color-blockquote-bg);
+  border-left: 3pt solid var(--vs-color-border);
+  break-inside: avoid;
+}
+
+/* Callout blocks (note, memo, tip, etc.) */
+.note, .memo, .tip, .info,
+.warning, .important, .caution, .notice {
+  margin: 1em 0;
+  padding: 0.8em 1em;
+  border-left: 4pt solid;
+  background-color: var(--vs-color-blockquote-bg);
+  break-inside: avoid;
+}
+
+.note { border-color: #4a5568; }
+.memo { border-color: #718096; }
+.tip { border-color: #48bb78; }
+.info { border-color: #4299e1; }
+.warning { border-color: #ecc94b; }
+.important { border-color: #f56565; }
+.caution { border-color: #ed8936; }
+.notice { border-color: #a0aec0; }
+
+.note-header, .memo-header, .tip-header, .info-header,
+.warning-header, .important-header, .caution-header, .notice-header {
+  font-weight: bold;
+  margin-bottom: 0.5em;
+  color: var(--vs-color-heading);
+}
+
+.note p, .memo p, .tip p, .info p,
+.warning p, .important p, .caution p, .notice p {
+  text-indent: 0;
+}
+
+/* Code listings */
+.caption-code, .emlist-code, .emlistnum-code,
+.source-code, .cmd-code, .code {
+  margin: 1em 0;
+}
+
+.caption-code .caption,
+.emlist-code .caption,
+.source-code .caption {
+  font-size: 0.9em;
+  font-weight: bold;
+  margin-bottom: 0.3em;
+  color: var(--vs-color-heading);
+}
+
+pre.list, pre.emlist, pre.source {
+  background-color: var(--vs-color-inline-code-bg);
+  border: 1pt solid var(--vs-color-inline-code-border);
+  border-radius: 4pt;
+  padding: 0.8em 1em;
+  margin: 0;
+  font-size: 9pt;
+  line-height: 1.5;
+  overflow-x: auto;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+pre.cmd {
+  background-color: #1a202c;
+  color: #e2e8f0;
+  border: none;
+  border-radius: 4pt;
+  padding: 0.8em 1em;
+  margin: 0;
+  font-size: 9pt;
+  line-height: 1.5;
+}
+
+/* Dummy image placeholder */
+pre.dummyimage {
+  background-color: #e2e8f0;
+  border: 2pt dashed var(--vs-color-border);
+  padding: 2em;
+  text-align: center;
+  color: #718096;
+}
+
+/* Image container */
+.image {
+  margin: 1.5em 0;
+  text-align: center;
+}
+
+.image img {
+  max-width: 100%;
+  height: auto;
+}
+
+.image .caption {
+  font-size: 0.9em;
+  margin-top: 0.5em;
+  color: var(--vs-color-heading);
+}
+
+/* Image table */
+.imgtable {
+  margin: 1.5em 0;
+  text-align: center;
+}
+
+/* Table container */
+.table {
+  margin: 1.5em 0;
+}
+
+.table .caption {
+  font-size: 0.9em;
+  font-weight: bold;
+  margin-bottom: 0.5em;
+  color: var(--vs-color-heading);
+}
+
+/* Equation */
+.equation, .caption-equation {
+  margin: 1em 0;
+  text-align: center;
+}
+
+.caption-equation .caption {
+  font-size: 0.9em;
+  margin-top: 0.5em;
+}
+
+/* Bibliography */
+.bibpaper {
+  margin: 0.5em 0;
+  padding-left: 2em;
+  text-indent: -2em;
+}
+
+.bibref {
+  font-style: italic;
+}
+
+/* References */
+.listref, .tableref, .imgref, .eqref {
+  /* inherit default link styles */
+}
+
+/* Paragraph alignment */
+.noindent {
+  text-indent: 0;
+}
+
+.flushright {
+  text-align: right;
+  text-indent: 0;
+}
+
+.center {
+  text-align: center;
+  text-indent: 0;
+}
+
+/* Page break */
+.pagebreak {
+  break-before: page;
+}
+
+/* Draft comment */
+.draft-comment {
+  background-color: #fef3c7;
+  border: 1pt solid #f59e0b;
+  padding: 0.5em;
+  margin: 0.5em 0;
+  font-size: 0.9em;
+}
+
+/* Endnotes */
+.endnotes {
+  margin-top: 2em;
+  border-top: 1pt solid var(--vs-color-border);
+  padding-top: 1em;
+}
+
+.endnote {
+  font-size: 0.9em;
+  margin: 0.3em 0;
+}
+
+/* Footnote reference link */
+a.noteref {
+  font-size: 0.8em;
+  vertical-align: super;
+  line-height: 0;
+}
+
+/* Cover page */
+.cover {
+  page: cover;
+  text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+}
+
+.cover-image {
+  max-width: 100%;
+  max-height: 100%;
+  object-fit: contain;
+}
+
+@page cover {
+  margin: 0;
+  padding: 0;
+  @top-left { content: none; }
+  @top-right { content: none; }
+  @bottom-center { content: none; }
+}
+
+/* ========================================
+ * Screen Media
+ * ======================================== */
+@media screen {
+  body {
+    max-width: 50rem;
+    margin: 2rem auto;
+    padding: 0 1rem;
+  }
+
+  h1 {
+    break-before: auto;
+  }
+
+  .footnote {
+    float: none;
+    display: block;
+    font-size: 0.85em;
+    border-top: 1pt solid #ccc;
+    padding-top: 0.5em;
+    margin-top: 1em;
+  }
+}

--- a/templates/vivliostyle/theme-rouge-github.css
+++ b/templates/vivliostyle/theme-rouge-github.css
@@ -1,0 +1,258 @@
+/*
+ * Syntax Highlighting (Rouge - GitHub theme)
+ * For use with Re:VIEW Vivliostyle output
+ * Uses CSS custom properties defined in theme-review.css
+ * License: CC0-1.0
+ */
+
+/* ========================================
+ * Rouge Table Structure (Line Numbers)
+ * ======================================== */
+
+/* Remove all borders from Rouge tables */
+.highlight table,
+.highlight table tbody,
+.highlight table tr,
+.highlight table td,
+.highlight table th,
+.highlight .rouge-table,
+.highlight .rouge-table tbody,
+.highlight .rouge-table tr,
+.highlight .rouge-table td,
+.rouge-table,
+.rouge-table tbody,
+.rouge-table tr,
+.rouge-table td,
+pre .rouge-table,
+pre .rouge-table tbody,
+pre .rouge-table tr,
+pre .rouge-table td,
+pre table.highlight,
+pre table.highlight tbody,
+pre table.highlight tr,
+pre table.highlight td {
+  border: none !important;
+  border-collapse: collapse;
+  background: transparent;
+}
+
+.highlight table td,
+.highlight .rouge-table td,
+.rouge-table td,
+pre .rouge-table td,
+pre table.highlight td {
+  padding: 0;
+  vertical-align: top;
+}
+
+.highlight table pre,
+.highlight .rouge-table pre,
+.rouge-table pre,
+pre .rouge-table pre,
+pre table.highlight pre {
+  margin: 0;
+  padding: 0;
+  background: transparent;
+  border: none !important;
+  border-radius: 0;
+}
+
+/* Line number gutter */
+.highlight .rouge-gutter,
+.highlight .gl,
+.rouge-gutter,
+.lineno {
+  width: 2em;
+  min-width: 2em;
+  max-width: 3em;
+  padding-right: 0.8em;
+  text-align: right;
+  color: var(--vs-hl-comment);
+  user-select: none;
+  border-right: none !important;
+  background: transparent;
+}
+
+.highlight .rouge-gutter pre,
+.highlight .gl pre,
+.rouge-gutter pre,
+pre.lineno {
+  padding: 0;
+  margin: 0;
+  background: transparent;
+  border: none !important;
+  border-radius: 0;
+}
+
+/* Code content area */
+.highlight .rouge-code,
+.highlight .rouge-code pre,
+.rouge-code,
+.rouge-code pre {
+  width: 100%;
+  padding-left: 0.5em;
+  background: transparent;
+}
+
+/* ========================================
+ * Syntax Highlighting Colors
+ * ======================================== */
+
+/* Base */
+.highlight,
+.highlight .w {
+  color: var(--vs-hl-text);
+  background-color: var(--vs-hl-bg);
+}
+
+/* Keywords */
+.highlight .k,
+.highlight .kd,
+.highlight .kn,
+.highlight .kp,
+.highlight .kr,
+.highlight .kt,
+.highlight .kv,
+.highlight .kc {
+  color: var(--vs-hl-keyword);
+}
+
+/* Strings */
+.highlight .s,
+.highlight .sa,
+.highlight .sc,
+.highlight .dl,
+.highlight .sd,
+.highlight .s2,
+.highlight .se,
+.highlight .sh,
+.highlight .sx,
+.highlight .s1,
+.highlight .ss {
+  color: var(--vs-hl-string);
+}
+
+/* Numbers and Literals */
+.highlight .l,
+.highlight .ld,
+.highlight .m,
+.highlight .mb,
+.highlight .mf,
+.highlight .mh,
+.highlight .mi,
+.highlight .il,
+.highlight .mo,
+.highlight .mx {
+  color: var(--vs-hl-number);
+}
+
+/* Functions and Methods */
+.highlight .nf,
+.highlight .fm,
+.highlight .nd {
+  color: var(--vs-hl-function);
+}
+
+/* Classes, Modules, Constants */
+.highlight .nc,
+.highlight .nn,
+.highlight .no,
+.highlight .nb {
+  color: var(--vs-hl-class);
+}
+
+/* Tags and Attributes (HTML/XML) */
+.highlight .nt,
+.highlight .na,
+.highlight .sr {
+  color: var(--vs-hl-tag);
+}
+
+/* Variables */
+.highlight .nv,
+.highlight .vc,
+.highlight .vg,
+.highlight .vi,
+.highlight .vm {
+  color: var(--vs-hl-variable);
+}
+
+/* Operators */
+.highlight .o,
+.highlight .ow {
+  color: var(--vs-hl-operator);
+}
+
+/* Comments */
+.highlight .c,
+.highlight .ch,
+.highlight .cd,
+.highlight .cm,
+.highlight .cp,
+.highlight .cpf,
+.highlight .c1,
+.highlight .cs {
+  color: var(--vs-hl-comment);
+}
+
+/* Misc */
+.highlight .sb,
+.highlight .bp,
+.highlight .ne,
+.highlight .nl,
+.highlight .py {
+  color: var(--vs-hl-number);
+}
+
+.highlight .gh,
+.highlight .gu {
+  color: var(--vs-hl-number);
+  font-weight: bold;
+}
+
+.highlight .gl,
+.highlight .gt {
+  color: var(--vs-hl-comment);
+}
+
+.highlight .ni,
+.highlight .si {
+  color: var(--vs-hl-text);
+}
+
+/* Text styles */
+.highlight .ge {
+  color: var(--vs-hl-text);
+  font-style: italic;
+}
+
+.highlight .gs {
+  color: var(--vs-hl-text);
+  font-weight: bold;
+}
+
+.highlight .ges {
+  font-weight: bold;
+  font-style: italic;
+}
+
+/* Diff */
+.highlight .gi {
+  color: var(--vs-hl-diff-add);
+  background-color: var(--vs-hl-diff-add-bg);
+}
+
+.highlight .gd {
+  color: var(--vs-hl-diff-del);
+  background-color: var(--vs-hl-diff-del-bg);
+}
+
+.highlight .gr {
+  color: var(--vs-hl-error-text);
+}
+
+/* Error */
+.highlight .err {
+  color: var(--vs-hl-error-text);
+  background-color: var(--vs-hl-error-bg);
+}

--- a/test/ast/test_vivliostyle_maker.rb
+++ b/test/ast/test_vivliostyle_maker.rb
@@ -206,7 +206,7 @@ class VivliostyleEntryTest < Test::Unit::TestCase
   end
 end
 
-class VivliostyleRunnerTest < Test::Unit::TestCase # rubocop:disable Naming/ClassAndModuleCamelCase
+class VivliostyleRunnerTest < Test::Unit::TestCase
   def setup
     @tmpdir = Dir.mktmpdir
     @log_io = StringIO.new

--- a/test/ast/test_vivliostyle_maker.rb
+++ b/test/ast/test_vivliostyle_maker.rb
@@ -1,0 +1,189 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'json'
+require 'review/ast/command/vivliostyle_maker'
+
+class ASTVivliostyleMakerTest < Test::Unit::TestCase
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @old_pwd = Dir.pwd
+    @log_io = StringIO.new
+    ReVIEW.logger = ReVIEW::Logger.new(@log_io)
+  end
+
+  def teardown
+    Dir.chdir(@old_pwd)
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_parse_opts_help
+    maker = ReVIEW::AST::Command::VivliostyleMaker.new
+    assert_raise(SystemExit) do
+      capture_output do
+        maker.parse_opts(['--help'])
+      end
+    end
+  end
+
+  def test_parse_opts_with_debug
+    maker = ReVIEW::AST::Command::VivliostyleMaker.new
+    cmd_config, yamlfile = maker.parse_opts(['--debug', 'config.yml'])
+    assert_equal true, cmd_config['debug']
+    assert_equal 'config.yml', yamlfile
+  end
+
+  def test_parse_opts_with_only
+    maker = ReVIEW::AST::Command::VivliostyleMaker.new
+    cmd_config, yamlfile = maker.parse_opts(['-y', 'ch01,ch02', 'config.yml'])
+    assert_equal 'config.yml', yamlfile
+  end
+
+  def test_configure_has_vivliostylemaker_settings
+    config = ReVIEW::Configure.values
+    assert config.key?('vivliostylemaker')
+    assert_equal './node_modules/.bin/vivliostyle', config['vivliostylemaker']['vivliostyle_path']
+    assert_equal 600, config['vivliostylemaker']['timeout']
+    assert_equal 'JIS-B5', config['vivliostylemaker']['size']
+    assert_nil config['vivliostylemaker']['theme']
+    assert_equal [], config['vivliostylemaker']['css']
+  end
+
+  def test_generates_html_files_with_renderer
+    # Skip if sample-book doesn't exist
+    samplebook_dir = File.expand_path('../../samples/sample-book/src', __dir__)
+    unless File.exist?(samplebook_dir)
+      omit('sample-book not found')
+    end
+
+    prepare_samplebook(@tmpdir, 'sample-book/src', nil, 'config.yml')
+
+    Dir.chdir(@tmpdir) do
+      maker = ReVIEW::AST::Command::VivliostyleMaker.new
+
+      # Mock run_vivliostyle to avoid requiring actual vivliostyle CLI
+      def maker.run_vivliostyle(bookname)
+        # Create a dummy PDF for testing
+        File.write(File.join(@path, "#{bookname}.pdf"), 'dummy pdf')
+      end
+
+      begin
+        maker.execute('--debug', 'config.yml')
+      rescue SystemExit
+        # Ignore exit
+      end
+
+      # Check if HTML files were generated
+      output_dir = Dir.glob('*-vivliostyle').first
+      if output_dir
+        assert File.exist?(File.join(output_dir, 'vivliostyle.config.json')),
+               'vivliostyle.config.json should be generated'
+
+        # Verify config.json structure
+        config_content = File.read(File.join(output_dir, 'vivliostyle.config.json'))
+        config_data = JSON.parse(config_content)
+        assert config_data.key?('title')
+        assert config_data.key?('entry')
+        assert config_data['entry'].is_a?(Array)
+      end
+    end
+  end
+
+  def test_vivliostyle_config_json_generation
+    # Create minimal test project
+    FileUtils.mkdir_p(File.join(@tmpdir, 'images'))
+    File.write(File.join(@tmpdir, 'catalog.yml'), <<~YAML)
+      CHAPS:
+        - ch01.re
+    YAML
+    File.write(File.join(@tmpdir, 'ch01.re'), <<~RE)
+      = Test Chapter
+
+      Hello, Vivliostyle!
+    RE
+    File.write(File.join(@tmpdir, 'config.yml'), <<~YAML)
+      review_version: 5.0
+      bookname: testbook
+      booktitle: Test Book
+      aut: Test Author
+      language: ja
+      toc: true
+      colophon: true
+      vivliostylemaker:
+        size: A5
+    YAML
+
+    Dir.chdir(@tmpdir) do
+      maker = ReVIEW::AST::Command::VivliostyleMaker.new
+
+      # Mock run_vivliostyle
+      def maker.run_vivliostyle(bookname)
+        File.write(File.join(@path, "#{bookname}.pdf"), 'dummy pdf')
+      end
+
+      begin
+        maker.execute('--debug', 'config.yml')
+      rescue SystemExit
+        # Ignore exit
+      end
+
+      output_dir = 'testbook-vivliostyle'
+      assert File.directory?(output_dir), 'Output directory should exist'
+
+      config_path = File.join(output_dir, 'vivliostyle.config.json')
+      assert File.exist?(config_path), 'vivliostyle.config.json should exist'
+
+      config_data = JSON.parse(File.read(config_path))
+      assert_equal 'Test Book', config_data['title']
+      assert_equal 'Test Author', config_data['aut'] || config_data['author']
+      assert_equal 'ja', config_data['language']
+      assert_equal 'A5', config_data['size']
+      assert_includes config_data['entry'], 'ch01.html'
+    end
+  end
+
+  def test_theme_setting_in_config
+    FileUtils.mkdir_p(File.join(@tmpdir, 'images'))
+    File.write(File.join(@tmpdir, 'catalog.yml'), <<~YAML)
+      CHAPS:
+        - ch01.re
+    YAML
+    File.write(File.join(@tmpdir, 'ch01.re'), <<~RE)
+      = Test Chapter
+
+      Hello!
+    RE
+    File.write(File.join(@tmpdir, 'config.yml'), <<~YAML)
+      review_version: 5.0
+      bookname: testbook
+      booktitle: Test Book
+      language: ja
+      vivliostylemaker:
+        theme: '@vivliostyle/theme-techbook'
+    YAML
+
+    Dir.chdir(@tmpdir) do
+      maker = ReVIEW::AST::Command::VivliostyleMaker.new
+
+      def maker.run_vivliostyle(bookname)
+        File.write(File.join(@path, "#{bookname}.pdf"), 'dummy pdf')
+      end
+
+      begin
+        maker.execute('--debug', 'config.yml')
+      rescue SystemExit
+        # Ignore
+      end
+
+      output_dir = 'testbook-vivliostyle'
+      config_path = File.join(output_dir, 'vivliostyle.config.json')
+
+      if File.exist?(config_path)
+        config_data = JSON.parse(File.read(config_path))
+        assert_equal '@vivliostyle/theme-techbook', config_data['theme']
+      end
+    end
+  end
+end

--- a/test/ast/test_vivliostyle_maker.rb
+++ b/test/ast/test_vivliostyle_maker.rb
@@ -6,184 +6,263 @@ require 'fileutils'
 require 'json'
 require 'review/ast/command/vivliostyle_maker'
 
-class ASTVivliostyleMakerTest < Test::Unit::TestCase
-  def setup
-    @tmpdir = Dir.mktmpdir
-    @old_pwd = Dir.pwd
-    @log_io = StringIO.new
-    ReVIEW.logger = ReVIEW::Logger.new(@log_io)
-  end
-
-  def teardown
-    Dir.chdir(@old_pwd)
-    FileUtils.rm_rf(@tmpdir)
-  end
-
-  def test_parse_opts_help
-    maker = ReVIEW::AST::Command::VivliostyleMaker.new
+class VivliostyleCLIParserTest < Test::Unit::TestCase
+  def test_parse_help
     assert_raise(SystemExit) do
       capture_output do
-        maker.parse_opts(['--help'])
+        ReVIEW::AST::Command::Vivliostyle::CLI::Parser.parse(['--help'])
       end
     end
   end
 
-  def test_parse_opts_with_debug
-    maker = ReVIEW::AST::Command::VivliostyleMaker.new
-    cmd_config, yamlfile = maker.parse_opts(['--debug', 'config.yml'])
-    assert_equal true, cmd_config['debug']
-    assert_equal 'config.yml', yamlfile
+  def test_parse_debug_option
+    options = ReVIEW::AST::Command::Vivliostyle::CLI::Parser.parse(['--debug', 'config.yml'])
+    assert_equal true, options.cmd_config['debug']
+    assert_equal 'config.yml', options.yamlfile
+    assert_nil(options.buildonly)
   end
 
-  def test_parse_opts_with_only
-    maker = ReVIEW::AST::Command::VivliostyleMaker.new
-    cmd_config, yamlfile = maker.parse_opts(['-y', 'ch01,ch02', 'config.yml'])
-    assert_equal 'config.yml', yamlfile
+  def test_parse_only_option
+    options = ReVIEW::AST::Command::Vivliostyle::CLI::Parser.parse(['-y', 'ch01,ch02', 'config.yml'])
+    assert_equal 'config.yml', options.yamlfile
+    assert_equal %w[ch01 ch02], options.buildonly
   end
 
+  def test_parse_ignore_errors_option
+    options = ReVIEW::AST::Command::Vivliostyle::CLI::Parser.parse(['--ignore-errors', 'config.yml'])
+    assert_equal true, options.cmd_config['ignore-errors']
+  end
+end
+
+class VivliostyleBuildContextTest < Test::Unit::TestCase
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @config = ReVIEW::Configure.values.merge(
+      'bookname' => 'testbook',
+      'language' => 'ja'
+    )
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+  end
+
+  def test_setup_build_directory_debug_mode
+    context = ReVIEW::AST::Command::Vivliostyle::BuildContext.new(
+      config: @config,
+      basedir: @tmpdir,
+      debug: true
+    )
+    context.setup_build_directory
+
+    assert context.build_path.end_with?('testbook-vivliostyle')
+    assert File.directory?(context.build_path)
+
+    FileUtils.rm_rf(context.build_path)
+  end
+
+  def test_entry_files_management
+    context = ReVIEW::AST::Command::Vivliostyle::BuildContext.new(
+      config: @config,
+      basedir: @tmpdir
+    )
+
+    context.add_entry_file('ch01.html')
+    context.add_entry_file('ch02.html')
+
+    assert_equal %w[ch01.html ch02.html], context.entry_files
+  end
+
+  def test_stylesheet_management
+    context = ReVIEW::AST::Command::Vivliostyle::BuildContext.new(
+      config: @config,
+      basedir: @tmpdir
+    )
+
+    context.add_stylesheet('style.css')
+    assert_equal ['style.css'], context.stylesheets
+  end
+
+  def test_source_path
+    context = ReVIEW::AST::Command::Vivliostyle::BuildContext.new(
+      config: @config,
+      basedir: @tmpdir
+    )
+
+    assert_equal File.join(@tmpdir, 'images', 'foo.png'), context.source_path('images/foo.png')
+  end
+end
+
+class VivliostyleLayoutWrapperTest < Test::Unit::TestCase
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @config = ReVIEW::Configure.values.merge(
+      'bookname' => 'testbook',
+      'language' => 'ja'
+    )
+    @context = ReVIEW::AST::Command::Vivliostyle::BuildContext.new(
+      config: @config,
+      basedir: @tmpdir,
+      debug: true
+    )
+    @context.setup_build_directory
+    @context.add_stylesheet('theme.css')
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+    FileUtils.rm_rf(@context.build_path) if @context.build_path
+  end
+
+  def test_wrap_generates_html
+    wrapper = ReVIEW::AST::Command::Vivliostyle::LayoutWrapper.new(context: @context)
+
+    html = wrapper.wrap('<p>Hello</p>', title: 'Test')
+
+    assert_match(/<html lang="ja">/, html)
+    assert_match(%r{<title>Test</title>}, html)
+    assert_match(%r{<p>Hello</p>}, html)
+    assert_match(/theme\.css/, html)
+  end
+
+  def test_write_html
+    wrapper = ReVIEW::AST::Command::Vivliostyle::LayoutWrapper.new(context: @context)
+
+    wrapper.write_html('test.html', '<html></html>')
+
+    assert File.exist?(@context.output_path('test.html'))
+  end
+end
+
+class VivliostyleEntryTest < Test::Unit::TestCase
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @log_io = StringIO.new
+    ReVIEW.logger = ReVIEW::Logger.new(@log_io)
+
+    @config = ReVIEW::Configure.values.merge(
+      'bookname' => 'testbook',
+      'booktitle' => 'Test Book',
+      'language' => 'ja',
+      'aut' => 'Test Author'
+    )
+    ReVIEW::I18n.setup(@config['language'])
+
+    @context = ReVIEW::AST::Command::Vivliostyle::BuildContext.new(
+      config: @config,
+      basedir: @tmpdir,
+      debug: true
+    )
+    @context.setup_build_directory
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+    FileUtils.rm_rf(@context.build_path) if @context.build_path
+  end
+
+  def test_titlepage_entry
+    entry = ReVIEW::AST::Command::Vivliostyle::Entries::TitlepageEntry.new(context: @context)
+
+    assert_equal 'titlepage.html', entry.filename
+    assert_equal 'Test Book', entry.title
+
+    entry.generate
+
+    assert File.exist?(@context.output_path('titlepage.html'))
+    assert_includes(@context.entry_files, 'titlepage.html')
+
+    content = File.read(@context.output_path('titlepage.html'))
+    assert_match(/Test Book/, content)
+  end
+
+  def test_toc_entry
+    # Setup book with chapters
+    FileUtils.mkdir_p(File.join(@tmpdir, 'images'))
+    File.write(File.join(@tmpdir, 'catalog.yml'), "CHAPS:\n  - ch01.re\n")
+    File.write(File.join(@tmpdir, 'ch01.re'), "= Chapter 1\n\nContent")
+
+    book = ReVIEW::Book::Base.new(@tmpdir, config: @config)
+    @context.book = book
+
+    entry = ReVIEW::AST::Command::Vivliostyle::Entries::TocEntry.new(context: @context)
+
+    entry.generate
+
+    assert File.exist?(@context.output_path('toc.html'))
+    content = File.read(@context.output_path('toc.html'))
+    assert_match(/ch01\.html/, content)
+  end
+
+  def test_colophon_entry
+    entry = ReVIEW::AST::Command::Vivliostyle::Entries::ColophonEntry.new(context: @context)
+
+    assert_equal 'colophon.html', entry.filename
+
+    entry.generate
+
+    assert File.exist?(@context.output_path('colophon.html'))
+    assert_includes(@context.entry_files, 'colophon.html')
+  end
+end
+
+class VivliostyleRunnerTest < Test::Unit::TestCase # rubocop:disable Naming/ClassAndModuleCamelCase
+  def setup
+    @tmpdir = Dir.mktmpdir
+    @log_io = StringIO.new
+    ReVIEW.logger = ReVIEW::Logger.new(@log_io)
+
+    @config = ReVIEW::Configure.values.merge(
+      'bookname' => 'testbook',
+      'booktitle' => 'Test Book',
+      'language' => 'ja',
+      'aut' => 'Test Author',
+      'vivliostylemaker' => {
+        'size' => 'A5',
+        'theme' => '@vivliostyle/theme-techbook'
+      }
+    )
+    @context = ReVIEW::AST::Command::Vivliostyle::BuildContext.new(
+      config: @config,
+      basedir: @tmpdir,
+      debug: true
+    )
+    @context.setup_build_directory
+    @context.add_entry_file('ch01.html')
+    @context.add_entry_file('ch02.html')
+  end
+
+  def teardown
+    FileUtils.rm_rf(@tmpdir)
+    FileUtils.rm_rf(@context.build_path) if @context.build_path
+  end
+
+  def test_generate_config
+    runner = ReVIEW::AST::Command::Vivliostyle::Runner.new(context: @context)
+    runner.generate_config
+
+    config_path = @context.output_path('vivliostyle.config.json')
+    assert File.exist?(config_path)
+
+    config_data = JSON.parse(File.read(config_path))
+    assert_equal 'Test Book', config_data['title']
+    assert_equal 'Test Author', config_data['author']
+    assert_equal 'ja', config_data['language']
+    assert_equal 'A5', config_data['size']
+    assert_equal '@vivliostyle/theme-techbook', config_data['theme']
+    assert_equal %w[ch01.html ch02.html], config_data['entry']
+    assert_equal 'testbook.pdf', config_data['output']
+  end
+end
+
+class VivliostyleMakerConfigTest < Test::Unit::TestCase
   def test_configure_has_vivliostylemaker_settings
     config = ReVIEW::Configure.values
     assert config.key?('vivliostylemaker')
     assert_equal './node_modules/.bin/vivliostyle', config['vivliostylemaker']['vivliostyle_path']
     assert_equal 600, config['vivliostylemaker']['timeout']
     assert_equal 'JIS-B5', config['vivliostylemaker']['size']
-    assert_nil config['vivliostylemaker']['theme']
+    assert_nil(config['vivliostylemaker']['theme'])
     assert_equal [], config['vivliostylemaker']['css']
-  end
-
-  def test_generates_html_files_with_renderer
-    # Skip if sample-book doesn't exist
-    samplebook_dir = File.expand_path('../../samples/sample-book/src', __dir__)
-    unless File.exist?(samplebook_dir)
-      omit('sample-book not found')
-    end
-
-    prepare_samplebook(@tmpdir, 'sample-book/src', nil, 'config.yml')
-
-    Dir.chdir(@tmpdir) do
-      maker = ReVIEW::AST::Command::VivliostyleMaker.new
-
-      # Mock run_vivliostyle to avoid requiring actual vivliostyle CLI
-      def maker.run_vivliostyle(bookname)
-        # Create a dummy PDF for testing
-        File.write(File.join(@path, "#{bookname}.pdf"), 'dummy pdf')
-      end
-
-      begin
-        maker.execute('--debug', 'config.yml')
-      rescue SystemExit
-        # Ignore exit
-      end
-
-      # Check if HTML files were generated
-      output_dir = Dir.glob('*-vivliostyle').first
-      if output_dir
-        assert File.exist?(File.join(output_dir, 'vivliostyle.config.json')),
-               'vivliostyle.config.json should be generated'
-
-        # Verify config.json structure
-        config_content = File.read(File.join(output_dir, 'vivliostyle.config.json'))
-        config_data = JSON.parse(config_content)
-        assert config_data.key?('title')
-        assert config_data.key?('entry')
-        assert config_data['entry'].is_a?(Array)
-      end
-    end
-  end
-
-  def test_vivliostyle_config_json_generation
-    # Create minimal test project
-    FileUtils.mkdir_p(File.join(@tmpdir, 'images'))
-    File.write(File.join(@tmpdir, 'catalog.yml'), <<~YAML)
-      CHAPS:
-        - ch01.re
-    YAML
-    File.write(File.join(@tmpdir, 'ch01.re'), <<~RE)
-      = Test Chapter
-
-      Hello, Vivliostyle!
-    RE
-    File.write(File.join(@tmpdir, 'config.yml'), <<~YAML)
-      review_version: 5.0
-      bookname: testbook
-      booktitle: Test Book
-      aut: Test Author
-      language: ja
-      toc: true
-      colophon: true
-      vivliostylemaker:
-        size: A5
-    YAML
-
-    Dir.chdir(@tmpdir) do
-      maker = ReVIEW::AST::Command::VivliostyleMaker.new
-
-      # Mock run_vivliostyle
-      def maker.run_vivliostyle(bookname)
-        File.write(File.join(@path, "#{bookname}.pdf"), 'dummy pdf')
-      end
-
-      begin
-        maker.execute('--debug', 'config.yml')
-      rescue SystemExit
-        # Ignore exit
-      end
-
-      output_dir = 'testbook-vivliostyle'
-      assert File.directory?(output_dir), 'Output directory should exist'
-
-      config_path = File.join(output_dir, 'vivliostyle.config.json')
-      assert File.exist?(config_path), 'vivliostyle.config.json should exist'
-
-      config_data = JSON.parse(File.read(config_path))
-      assert_equal 'Test Book', config_data['title']
-      assert_equal 'Test Author', config_data['aut'] || config_data['author']
-      assert_equal 'ja', config_data['language']
-      assert_equal 'A5', config_data['size']
-      assert_includes config_data['entry'], 'ch01.html'
-    end
-  end
-
-  def test_theme_setting_in_config
-    FileUtils.mkdir_p(File.join(@tmpdir, 'images'))
-    File.write(File.join(@tmpdir, 'catalog.yml'), <<~YAML)
-      CHAPS:
-        - ch01.re
-    YAML
-    File.write(File.join(@tmpdir, 'ch01.re'), <<~RE)
-      = Test Chapter
-
-      Hello!
-    RE
-    File.write(File.join(@tmpdir, 'config.yml'), <<~YAML)
-      review_version: 5.0
-      bookname: testbook
-      booktitle: Test Book
-      language: ja
-      vivliostylemaker:
-        theme: '@vivliostyle/theme-techbook'
-    YAML
-
-    Dir.chdir(@tmpdir) do
-      maker = ReVIEW::AST::Command::VivliostyleMaker.new
-
-      def maker.run_vivliostyle(bookname)
-        File.write(File.join(@path, "#{bookname}.pdf"), 'dummy pdf')
-      end
-
-      begin
-        maker.execute('--debug', 'config.yml')
-      rescue SystemExit
-        # Ignore
-      end
-
-      output_dir = 'testbook-vivliostyle'
-      config_path = File.join(output_dir, 'vivliostyle.config.json')
-
-      if File.exist?(config_path)
-        config_data = JSON.parse(File.read(config_path))
-        assert_equal '@vivliostyle/theme-techbook', config_data['theme']
-      end
-    end
   end
 end


### PR DESCRIPTION
LaTeXの代わりにVivliostyleを使ってPDFを生成する、review-ast-vivliostylemakerコマンドを追加します。
#1956 を前提としたものなので、ast-rendererブランチへの差分としています。

関連:
- #1956