### PR TITLE
chore: update rouge to 5.0 or later

### DIFF
--- a/review.gemspec
+++ b/review.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('logger')
   gem.add_dependency('nkf')
   gem.add_dependency('rexml')
-  gem.add_dependency('rouge')
+  gem.add_dependency('rouge', '>= 5.0')
   gem.add_dependency('rubyzip')
   gem.add_dependency('tty-logger')
   gem.add_development_dependency('chunky_png')

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -1435,7 +1435,7 @@ EOS
     expected = <<-EOS
 <div id="samplelist" class="code">
 <p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>
-<table class="highlight rouge-table"><tbody><tr><td class="rouge-gutter gl"><pre class="lineno">1
+<table class="highlight rouge-table"><tbody><tr><td class="rouge-gutter gl" aria-hidden="true"><pre class="lineno">1
 2
 3
 4
@@ -1469,7 +1469,7 @@ EOS
     expected = <<-EOB
 <div id="samplelist" class="code">
 <p class="caption">リスト1.1: this is <b>test</b>&lt;&amp;&gt;_</p>
-<table class="highlight rouge-table"><tbody><tr><td class="rouge-gutter gl"><pre class="lineno">100
+<table class="highlight rouge-table"><tbody><tr><td class="rouge-gutter gl" aria-hidden="true"><pre class="lineno">100
 101
 102
 103


### PR DESCRIPTION
rouge 5.0.0で`aria-hidden`がつくようになったので、これをデフォルトにしてみます。
その際出力結果が変わるので、それに合わせてテストも修正します。

おそらくこれで https://github.com/kmuto/review/pull/1967 のテストも通るようになると思います。