### PR TITLE
ci: add tests for newer TeX Live(s)

### DIFF
--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -93,5 +93,17 @@ atbegshi
 iftex
 ifptex
 
-# math image generation (test_img_math)
+# math image generation (lib/review/img_math.rb)
 dvipng
+anyfontsize
+pdfcrop
+
+# for hyperref
+infwarerr
+epstopdf-pkg
+kvoptions
+
+# for XeLaTeX / LuaLaTeX
+fontspec
+zxjatype
+bxcjkjatype

--- a/.github/tl_packages
+++ b/.github/tl_packages
@@ -1,0 +1,97 @@
+# engines (uplatex -> dvipdfmx, lualatex)
+latex
+latex-bin
+latexconfig
+l3kernel
+l3packages
+ptex
+uptex
+platex
+uplatex
+platex-tools
+ptex-base
+uptex-base
+ptex-fonts
+uptex-fonts
+dvipdfmx
+dvips
+luatex
+
+# Japanese typesetting
+japanese-otf
+pxbase
+pxpgfmark
+pxjahyper
+pxrubrica
+plautopatch
+endnotesj
+jsclasses
+
+# review-jlreq / jlreq and its undeclared dependencies
+jlreq
+luatexja
+everyhook
+svn-prov
+filehook
+
+# CJK fonts and CMaps
+haranoaji
+haranoaji-extra
+ptex-fontmaps
+adobemapping
+lm
+cm-super
+ec
+type1cm
+
+# Base 35 PostScript fonts (review-base.sty uses T1/phv)
+psnfss
+helvetic
+times
+courier
+
+# packages required by review-base.sty / review-style.sty
+hyperref
+caption
+needspace
+bigfoot
+graphics
+graphics-def
+graphics-cfg
+xcolor
+colortbl
+framed
+wrapfig
+ascmac
+float
+amsmath
+amsfonts
+amscls
+tools
+makeindex
+listings
+fancyhdr
+multirow
+ulem
+
+# packages required by review-tcbox.sty / techbooster styles
+tcolorbox
+pgf
+varwidth
+environ
+trimspaces
+tikzfill
+pdfcol
+fancyvrb
+upquote
+
+# support packages for the vendored styles
+etoolbox
+xkeyval
+everypage
+atbegshi
+iftex
+ifptex
+
+# math image generation (test_img_math)
+dvipng

--- a/.github/workflows/ruby-tex.yml
+++ b/.github/workflows/ruby-tex.yml
@@ -19,28 +19,71 @@ jobs:
         texlive: ['2023', '2025', 'latest']
         include:
           - texlive: '2023'
-            texlive_version: '2023'
-            repository: https://texlive.info/historic/systems/texlive/2023/tlnet-final/
+            repository: https://texlive.info/historic/systems/texlive/2023/tlnet-final
           - texlive: '2025'
-            texlive_version: '2025'
-            repository: https://texlive.info/historic/systems/texlive/2025/tlnet-final/
+            repository: https://texlive.info/historic/systems/texlive/2025/tlnet-final
           - texlive: 'latest'
-            texlive_version: 'latest'
             experimental: true
     steps:
     - uses: actions/checkout@v7
     - name: Install non-TeX tools in ubuntu
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq poppler-utils libfuse2
-    - name: Install TeXLive ${{ matrix.texlive }}
-      uses: zauguin/install-texlive@v4
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq ghostscript poppler-utils libfuse2
+    - name: Cache TeXLive ${{ matrix.texlive }}
+      id: texlive-cache
+      uses: actions/cache@v4
       with:
-        texlive_version: ${{ matrix.texlive_version }}
-        repository: ${{ matrix.repository }}
-        package_file: .github/tl_packages
-    - name: Set up Japanese font maps
-      run: kanji-config-updmap-sys haranoaji
+        path: ~/texlive
+        key: texlive-${{ runner.os }}-${{ matrix.texlive }}-${{ hashFiles('.github/tl_packages') }}
+    - name: Install TeXLive ${{ matrix.texlive }}
+      if: steps.texlive-cache.outputs.cache-hit != 'true'
+      env:
+        TL_REPOSITORY: ${{ matrix.repository || 'https://mirror.ctan.org/systems/texlive/tlnet' }}
+      run: |
+        set -euxo pipefail
+        mkdir -p "${RUNNER_TEMP}/install-tl"
+        curl -fsSL "${TL_REPOSITORY}/install-tl-unx.tar.gz" |
+          tar xz -C "${RUNNER_TEMP}/install-tl" --strip-components=1
+        # minimum profile, added some packages
+        cat > "${RUNNER_TEMP}/texlive.profile" <<EOF
+        selected_scheme scheme-infraonly
+        TEXDIR ${HOME}/texlive
+        TEXMFLOCAL ${HOME}/texlive/texmf-local
+        TEXMFSYSVAR ${HOME}/texlive/texmf-var
+        TEXMFSYSCONFIG ${HOME}/texlive/texmf-config
+        TEXMFVAR ${HOME}/texlive/texmf-var
+        TEXMFCONFIG ${HOME}/texlive/texmf-config
+        TEXMFHOME ${HOME}/texlive/texmf-home
+        instopt_portable 1
+        instopt_adjustpath 0
+        tlpdbopt_install_docfiles 0
+        tlpdbopt_install_srcfiles 0
+        tlpdbopt_autobackup 0
+        tlpdbopt_create_formats 1
+        EOF
+        perl "${RUNNER_TEMP}/install-tl/install-tl" \
+          --profile "${RUNNER_TEMP}/texlive.profile" \
+          --repository "${TL_REPOSITORY}"
+        export PATH="${HOME}/texlive/bin/x86_64-linux:${PATH}"
+        tlmgr install $(sed -e 's/#.*//' -e '/^\s*$/d' .github/tl_packages)
+        kanji-config-updmap-sys haranoaji
+    - name: Add TeXLive to PATH
+      run: echo "${HOME}/texlive/bin/x86_64-linux" >> "${GITHUB_PATH}"
+    # check commands
+    - name: Verify TeXLive commands
+      run: |
+        set -u
+        missing=0
+        for cmd in uplatex platex lualatex dvipdfmx dvipng pdfcrop mendex extractbb kpsewhich gs pdftocairo; do
+          if version=$("$cmd" --version 2>&1 | head -1); then
+            printf '  ok      %-10s %s\n' "$cmd" "$version"
+          else
+            printf '  MISSING %s\n' "$cmd"
+            missing=1
+          fi
+        done
+        exit $missing
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -65,4 +108,4 @@ jobs:
         export PATH=${GITHUB_WORKSPACE}/vendor/imagemagick:${PATH}
         gem install bundler --no-document
         bundle install --retry 3
-        bundle exec rake
+        bundle exec ruby test/run_test.rb --verbose

--- a/.github/workflows/ruby-tex.yml
+++ b/.github/workflows/ruby-tex.yml
@@ -10,17 +10,38 @@ jobs:
   build:
 
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
       fail-fast: false
       matrix:
         ruby: ['3.2']
-        os: [ubuntu-22.04]
+        os: [ubuntu-latest]
+        texlive: ['2023', '2025']
+        include:
+          - ruby: '3.2'
+            os: ubuntu-latest
+            texlive: 'latest'
+            experimental: true
     steps:
-    - uses: actions/checkout@v2
-    - name: Install TeXLive 2021 in ubuntu
+    - uses: actions/checkout@v7
+    - name: Install non-TeX tools in ubuntu
       if: runner.os == 'Linux'
       run: |
-        sudo apt-get update -y -qq && sudo apt-get install -y -qq texlive-lang-japanese texlive-fonts-recommended texlive-fonts-extra texlive-luatex texlive-extra-utils texlive-latex-extra dvipng poppler-utils libfuse2
+        sudo apt-get update -y -qq && sudo apt-get install -y -qq poppler-utils libfuse2
+    - name: Install TeXLive ${{ matrix.texlive }}
+      uses: TeX-Live/setup-texlive-action@v4
+      with:
+        version: ${{ matrix.texlive }}
+        packages: |
+          scheme-small
+          collection-langjapanese
+          collection-latexextra
+          collection-fontsrecommended
+          collection-luatex
+          collection-binextra
+          dvipng
+    - name: Set up Japanese font maps
+      run: kanji-config-updmap-sys haranoaji
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -37,9 +58,9 @@ jobs:
       if: runner.os == 'Linux'
       run: sudo sed -i 's/none/read|write/g' /etc/ImageMagick-6/policy.xml
     - name: use Node.js 18.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v7
       with:
-        node-version: 18
+        node-version: 24
     - name: Build and test with Rake
       run: |
         export PATH=${GITHUB_WORKSPACE}/vendor/imagemagick:${PATH}

--- a/.github/workflows/ruby-tex.yml
+++ b/.github/workflows/ruby-tex.yml
@@ -32,7 +32,7 @@ jobs:
         sudo apt-get update -y -qq && sudo apt-get install -y -qq ghostscript poppler-utils
     - name: Cache TeXLive ${{ matrix.texlive }}
       id: texlive-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/texlive
         key: texlive-${{ runner.os }}-${{ matrix.texlive }}-${{ hashFiles('.github/tl_packages') }}

--- a/.github/workflows/ruby-tex.yml
+++ b/.github/workflows/ruby-tex.yml
@@ -16,11 +16,16 @@ jobs:
       matrix:
         ruby: ['3.2']
         os: [ubuntu-latest]
-        texlive: ['2023', '2025']
+        texlive: ['2023', '2025', 'latest']
         include:
-          - ruby: '3.2'
-            os: ubuntu-latest
-            texlive: 'latest'
+          - texlive: '2023'
+            texlive_version: '2023'
+            repository: https://texlive.info/historic/systems/texlive/2023/tlnet-final/
+          - texlive: '2025'
+            texlive_version: '2025'
+            repository: https://texlive.info/historic/systems/texlive/2025/tlnet-final/
+          - texlive: 'latest'
+            texlive_version: 'latest'
             experimental: true
     steps:
     - uses: actions/checkout@v7
@@ -29,17 +34,11 @@ jobs:
       run: |
         sudo apt-get update -y -qq && sudo apt-get install -y -qq poppler-utils libfuse2
     - name: Install TeXLive ${{ matrix.texlive }}
-      uses: TeX-Live/setup-texlive-action@v4
+      uses: zauguin/install-texlive@v4
       with:
-        version: ${{ matrix.texlive }}
-        packages: |
-          scheme-small
-          collection-langjapanese
-          collection-latexextra
-          collection-fontsrecommended
-          collection-luatex
-          collection-binextra
-          dvipng
+        texlive_version: ${{ matrix.texlive_version }}
+        repository: ${{ matrix.repository }}
+        package_file: .github/tl_packages
     - name: Set up Japanese font maps
       run: kanji-config-updmap-sys haranoaji
     - name: Set up Ruby

--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -138,7 +138,8 @@
 
 % トンボ設定
 \if@pdftombo
-  \RequirePackage[trimmarks_paper=\recls@tombopaper,bleed_margin=\recls@tombobleed]{jlreq-trimmarks}
+  \edef\recls@trimmarksopt{trimmarks_paper=\recls@tombopaper,bleed_margin=\recls@tombobleed}%
+  \expandafter\RequirePackage\expandafter[\recls@trimmarksopt]{jlreq-trimmarks}
   % https://github.com/abenori/jlreq/blob/master/jlreq-trimmarks-ja.md を参照
   \jlreqtrimmarkssetup{banner={}}
   % 隠しノンブル


### PR DESCRIPTION
TeX-Live/setup-texlive-actionを使って、最近のTeX Liveでも動かしてみます。
（TeX Live 2025以降だとreview-jlreqが動かないんでは？　とClaude Codeが言っているのでその検証を兼ねています）