### PR TITLE
fix: support jlreq-trimmarks in TeX Live 2025

### DIFF
--- a/templates/latex/review-jlreq/review-jlreq.cls
+++ b/templates/latex/review-jlreq/review-jlreq.cls
@@ -138,7 +138,8 @@
 
 % トンボ設定
 \if@pdftombo
-  \RequirePackage[trimmarks_paper=\recls@tombopaper,bleed_margin=\recls@tombobleed]{jlreq-trimmarks}
+  \edef\recls@trimmarksopt{trimmarks_paper=\recls@tombopaper,bleed_margin=\recls@tombobleed}%
+  \expandafter\RequirePackage\expandafter[\recls@trimmarksopt]{jlreq-trimmarks}
   % https://github.com/abenori/jlreq/blob/master/jlreq-trimmarks-ja.md を参照
   \jlreqtrimmarkssetup{banner={}}
   % 隠しノンブル


### PR DESCRIPTION
( #1969 をベースに修正したものなので、`ci/setup-texlive-action`ブランチ向けになっています)

#1969 で失敗しているTeX Live 2025, 2026に対応するための修正です。jlreq-trimmarksに与えるパラメタの渡し方を変更します。