### PR TITLE
tableのセル処理の修正

### DIFF
--- a/lib/review/builder.rb
+++ b/lib/review/builder.rb
@@ -244,7 +244,7 @@ module ReVIEW
           sepidx ||= idx
           next
         end
-        rows.push(line.strip.split(table_row_separator_regexp).map { |s| s.sub(/\A\./, '') })
+        rows.push(line.rstrip.split(table_row_separator_regexp).map { |s| s.sub(/\A\./, '') })
       end
       rows = adjust_n_cols(rows)
       app_error 'no rows in the table' if rows.empty?

--- a/lib/review/idgxmlbuilder.rb
+++ b/lib/review/idgxmlbuilder.rb
@@ -542,8 +542,19 @@ module ReVIEW
         @col = col2 if col2 > @col
       end
       app_error 'no rows in the table' if rows.empty?
+
+      rows.map! { |row| pad_table_row(row) } if @tablewidth
+
       [sepidx, rows]
     end
+
+    def pad_table_row(row)
+      missing = @col - row.split(table_row_separator_regexp).length
+      return row if missing <= 0
+
+      row + ("\tDUMMYCELLSPLITTER" * missing)
+    end
+    private :pad_table_row
 
     def table_rows(sepidx, rows)
       cellwidth = []

--- a/test/test_htmlbuilder.rb
+++ b/test/test_htmlbuilder.rb
@@ -2472,6 +2472,19 @@ EOS
     assert_equal '「1.2 bar」', hd
   end
 
+  def test_table_with_cell_empty_for_this_builder
+    actual = compile_block("//table{\n@<raw>{|latex|\\quad}\tbbb\n------------\nccc\tddd\n//}\n")
+    expected = <<-EOS
+<div class="table">
+<table>
+<tr><th></th><th>bbb</th></tr>
+<tr><td>ccc</td><td>ddd</td></tr>
+</table>
+</div>
+EOS
+    assert_equal expected, actual
+  end
+
   def test_table
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     expected = <<-EOS

--- a/test/test_idgxmlbuilder.rb
+++ b/test/test_idgxmlbuilder.rb
@@ -119,6 +119,16 @@ class IDGXMLBuidlerTest < Test::Unit::TestCase
     assert_equal %Q(<table><tbody><tr><b>1</b>\t<i>2</i></tr><tr type="lastline"><b>3</b>\t<i>4</i>&lt;&gt;&amp;</tr></tbody></table>), actual
   end
 
+  def test_table_with_short_row
+    # A row with fewer cells than the widest one is padded out, so the number
+    # of <td> matches the aid:tcols this table declares to InDesign.
+    actual = compile_block("//table{\naaa\tbbb\n------------\nccc\n//}\n")
+    expected = <<-EOS.chomp
+<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="2"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">aaa</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">bbb</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172">ccc</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="14.172"></td></tbody></table>
+EOS
+    assert_equal expected, actual
+  end
+
   def test_table
     actual = compile_block("//table{\naaa\tbbb\n------------\nccc\tddd<>&\n//}\n")
     expected = <<-EOS.chomp
@@ -193,7 +203,7 @@ EOS
   def test_table_row_separator
     src = "//table{\n1\t2\t\t3  4| 5\n------------\na b\tc  d   |e\n//}\n"
     expected = <<-EOS.chomp
-<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="3"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">3  4| 5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">a b</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">c  d   |e</td></tbody></table>
+<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="3"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">3  4| 5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">a b</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448">c  d   |e</td><td xyh="3,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="9.448"></td></tbody></table>
 EOS
     actual = compile_block(src)
     assert_equal expected, actual
@@ -201,7 +211,7 @@ EOS
     @config['table_row_separator'] = 'singletab'
     actual = compile_block(src)
     expected = <<-EOS.chomp
-<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="4"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086"></td><td xyh="4,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">3  4| 5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">a b</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">c  d   |e</td></tbody></table>
+<table><tbody xmlns:aid5="http://ns.adobe.com/AdobeInDesign/5.0/" aid:table="table" aid:trows="2" aid:tcols="4"><td xyh="1,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">1</td><td xyh="2,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">2</td><td xyh="3,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086"></td><td xyh="4,1,1" aid:table="cell" aid:theader="1" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">3  4| 5</td><td xyh="1,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">a b</td><td xyh="2,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086">c  d   |e</td><td xyh="3,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086"></td><td xyh="4,2,1" aid:table="cell" aid:crows="1" aid:ccols="1" aid:ccolwidth="7.086"></td></tbody></table>
 EOS
     assert_equal expected, actual
 


### PR DESCRIPTION
tableの組版でセルが正しく処理されない不具合をclaude codeが2件ほど見つけたので、その修正です。
（とはいえ正常ケースで失敗するのではなく、書き方に問題がある場合におかしくなる、というものなのであまり影響はないです。）

## 再現方法

`config.yml` に `tableopt: "10"` を設定し、次の章をコンパイルします。

```review
= 表のバグ

//table[t1][列がずれる]{
@<raw>{|latex|\quad}  数値
------------
A     B
//}

//table[t2][セルが消える]{
A     B
------------
C
//}
```

※ `tableopt: "10"`が関係するのはt2のみで、t1はあってもなくても再現します。

### 問題1: HTML で列がずれる(t1)

```
$ review-compile --target=html ch01.re
<tr><th>数値</th><th></th></tr>     ← 「数値」が 1 列目に繰り上がっている
```

期待する出力は `<tr><th></th><th>数値</th></tr>` です。
1列目は LaTeX 専用の `@<raw>` なので HTML では空になりますが、列の位置は保たれるべきです。

LaTeXなどの他のビルダーでも同じ条件で起こります(IDGXML は後述のとおり別実装のため影響しません)。

### 問題2: IDGXML でセルが消える(t2)

```
$ review-compile --target=idgxml ch01.re
<tbody ... aid:tcols="2"> ... <td xyh="1,2,1" ...>C</td></tbody>
```

`aid:tcols="2"` と宣言しているのに、2 行目の `<td>` が 1 つしかありません。InDesign には行と列数が食い違った表が渡ります。

## 原因と修正

### 問題1: `Builder#parse_table_rows` の `strip`

ブロックの各行は、ビルダーに渡る前に `Compiler#read_block` でインライン記法が展開済みです。そのため `@<raw>{|latex|…}` だけのセルは HTML では空文字になり、行は区切り文字から始まる`"\t数値"` という文字列になります。

ここに `String#strip` がかかると、行頭の空白と一緒に区切り文字まで削除されます。結果として 1 列目が消え、`adjust_n_cols` が行末を埋めるため、以降のセルが 1 列ずつ左にずれます。

そのため `strip` を `rstrip` に変更しました。

### 問題2: IDGXML が持つ独自の行解析

他のビルダーは `Builder#parse_table_rows` を通り、最後の `adjust_n_cols` で全行が最大列数に揃えられます。

`IDGXMLBuilder` は自前の `parse_table_rows` を持っています。これは行を配列ではなく文字列のまま保持する必要があるためで、`.` と書かれた空セルを `DUMMYCELLSPLITTER` に置き換えることで `/\t+/` による分割から保護しています。この独自実装に、列数を揃える処理だけが入っていませんでした。

そこで同じ `DUMMYCELLSPLITTER` を使って不足分のセルを補うように修正しています。
