### PR TITLE
feat: support `@<em>{}` in TOPBuilder

### DIFF
--- a/lib/review/topbuilder.rb
+++ b/lib/review/topbuilder.rb
@@ -413,6 +413,8 @@ module ReVIEW
       "▲#{str}☆"
     end
 
+    alias_method :inline_em, :inline_i
+
     def inline_b(str)
       "★#{str}☆"
     end

--- a/test/test_topbuilder.rb
+++ b/test/test_topbuilder.rb
@@ -101,6 +101,11 @@ class TOPBuidlerTest < Test::Unit::TestCase
     assert_equal 'test ▲inline<&;\\ test☆ test2', actual
   end
 
+  def test_inline_em
+    actual = compile_inline('test @<em>{inline test} test2')
+    assert_equal 'test ▲inline test☆ test2', actual
+  end
+
   def test_inline_b
     actual = compile_inline('test @<b>{inline test} test2')
     assert_equal 'test ★inline test☆ test2', actual


### PR DESCRIPTION
TOPBuilderに`@<em>{}` がなかったので追加します。