### PR TITLE
fix: resolve a part's .re against the book, not the working directory

### DIFF
--- a/lib/review/book/part.rb
+++ b/lib/review/book/part.rb
@@ -43,8 +43,8 @@ module ReVIEW
         @path = name
         if io
           @content = io.read
-        elsif @path.present? && File.exist?(File.join(@book.config['contentdir'], @path))
-          @content = File.read(File.join(@book.config['contentdir'], @path), mode: 'rt:BOM|utf-8')
+        elsif @path.present? && File.exist?(File.join(@book.contentdir, @path))
+          @content = File.read(File.join(@book.contentdir, @path), mode: 'rt:BOM|utf-8')
           @name = File.basename(name, '.re')
         else
           @content = ''
@@ -80,7 +80,7 @@ module ReVIEW
 
       def volume
         if @number && file?
-          Volume.count_file(File.join(@book.config['contentdir'], @path))
+          Volume.count_file(File.join(@book.contentdir, @path))
         else
           Volume.new(0, 0, 0)
         end

--- a/test/test_book_part.rb
+++ b/test/test_book_part.rb
@@ -17,6 +17,58 @@ class PartTest < Test::Unit::TestCase
     assert_equal 'name', part.name
   end
 
+  # A part's .re is resolved against the book's directory, not the process's working directory.
+  def test_content_is_read_relative_to_the_book_not_the_working_directory
+    Dir.mktmpdir do |bookdir|
+      File.write(File.join(bookdir, 'part1.re'), "= Part Title\n\nThe part body.\n")
+
+      Dir.mktmpdir do |elsewhere|
+        Dir.chdir(elsewhere) do
+          book = Book::Base.new(bookdir)
+          part = Book::Part.new(book, 1, [], 'part1.re')
+
+          assert_equal "= Part Title\n\nThe part body.\n", part.content
+          assert_equal 'part1', part.name
+        end
+      end
+    end
+  end
+
+  # The same path is used to measure the part, so it moves with the content.
+  def test_volume_is_measured_relative_to_the_book
+    Dir.mktmpdir do |bookdir|
+      File.write(File.join(bookdir, 'part1.re'), "= Part Title\n")
+
+      Dir.mktmpdir do |elsewhere|
+        Dir.chdir(elsewhere) do
+          book = Book::Base.new(bookdir)
+          part = Book::Part.new(book, 1, [], 'part1.re')
+
+          assert_operator(part.volume.bytes, :>, 0)
+        end
+      end
+    end
+  end
+
+  # With contentdir set, the .re lives under it, still inside the book.
+  def test_content_honours_contentdir
+    Dir.mktmpdir do |bookdir|
+      FileUtils.mkdir_p(File.join(bookdir, 'contents'))
+      File.write(File.join(bookdir, 'contents', 'part1.re'), "= In contentdir\n")
+
+      Dir.mktmpdir do |elsewhere|
+        Dir.chdir(elsewhere) do
+          config = ReVIEW::Configure.values
+          config['contentdir'] = 'contents'
+          book = Book::Base.new(bookdir, config: config)
+          part = Book::Part.new(book, 1, [], 'part1.re')
+
+          assert_equal "= In contentdir\n", part.content
+        end
+      end
+    end
+  end
+
   def test_each_chapter
     part = Book::Part.new(nil, nil, [1, 2, 3])
 


### PR DESCRIPTION
`Book::Part` が部の `.re` ファイルをカレントディレクトリ基準で読んでいるため、本のディレクトリ以外からビルドしようとpartの本文が空になるようでした（エラーにはなりません）。

basedir を結合したパスを返すために`Book::Base#contentdir`が用意されており、Book::Chapterはこれを使っています。
Partは生の`config['contentdir']` を参照していたので、Chapterに合わせてPartも修正します。合わせてテストも追加します。